### PR TITLE
Incremented version in __init__ to 4.1.1

### DIFF
--- a/icclim/__init__.py
+++ b/icclim/__init__.py
@@ -1,3 +1,3 @@
 from icclim import *
 
-__version__ = "4.1.0" # print icclim.__version__
+__version__ = "4.1.1" # print icclim.__version__


### PR DESCRIPTION
I noticed the version was not updated in ``icclim/__init__.py``. This PR updates the version number.