### PR TITLE
Solving empty matrix in time_subet for ['MAM', 'JJA', 'SON', 'AMJJAS'…

### DIFF
--- a/icclim/time_subset.py
+++ b/icclim/time_subset.py
@@ -292,6 +292,8 @@ def get_dict_temporal_slices(dt_arr, values_arr, fill_value, calend='gregorian',
         for y in years:                         
     
             indices_dt_arr_non_masked_year = get_indices_temp_aggregation(dt_arr, month=map_info_slice[str(temporal_subset_mode)]['months'], year=y, f=1)
+            if indices_dt_arr_non_masked_year.size==0:
+                continue
             dt_arr_subset_i = dt_arr[indices_dt_arr_non_masked_year]
 
             arr_subset_i = values_arr[indices_dt_arr_non_masked_year, :, :]


### PR DESCRIPTION
…] slice mode

Fixing the problem from issue #31 
The problem came from the last year in dataset and ends at (1711,1,1,0,0,0,0,5,1). It did return an empty matrix when looking for a season after DJB so it wasn't working for 'MAM', 'JJA', 'SON', 'AMJJAS'