### PR TITLE
Add slice_mode in the config file and create a read.py script

### DIFF
--- a/icclim/config_indice.json
+++ b/icclim/config_indice.json
@@ -5,297 +5,349 @@
             "TG":
             {
                 "var_name":"tasmean",
-                "indice_type":"simple"
+                "indice_type":"simple",
+                "out_unit":"days"
             },
 
             "GD4":
             {
                 "var_name":"tasmean",
-                "indice_type":"simple"
+                "indice_type":"simple",
+                "out_unit":"days"
             },
 
             "HD17":
             {
                 "var_name":"tasmean",
-                "indice_type":"simple"
+                "indice_type":"simple",
+                "out_unit":"days"
             },
 
             "TG10p":
             {
                 "var_name":"tasmean",
-                "indice_type":"percentile_based"
+                "indice_type":"percentile_based",
+                "out_unit":"days"
             },
 
             "TG90p":
             {
                 "var_name":"tasmean",
-                "indice_type":"percentile_based"
+                "indice_type":"percentile_based",
+                "out_unit":"days"
             },
 
             "TN":
             {
                 "var_name":"tasmin",
-                "indice_type":"simple"
+                "indice_type":"simple",
+                "out_unit":"days"
             },
 
             "TNx":
             {
                 "var_name":"tasmin",
-                "indice_type":"simple"
+                "indice_type":"simple",
+                "out_unit":"days"
             },
 
             "TNn":
             {
                 "var_name":"tasmin",
-                "indice_type":"simple"
+                "indice_type":"simple",
+                "out_unit":"days"
             },
 
             "TR":
             {
                 "var_name":"tasmin",
-                "indice_type":"simple"
+                "indice_type":"simple",
+                "out_unit":"days"
             },
 
             "FD":
             {
                 "var_name":"tasmin",
-                "indice_type":"simple"
+                "indice_type":"simple",
+                "out_unit":"days"
             },
 
             "CFD":
             {
                 "var_name":"tasmin",
-                "indice_type":"simple"
+                "indice_type":"simple",
+                "out_unit":"days"
             },
 
             "TN10p":
             {
                 "var_name":"tasmin",
-                "indice_type":"percentile_based"
+                "indice_type":"percentile_based",
+                "out_unit":"days"
             },
 
             "TN90p":
             {
                 "var_name":"tasmin",
-                "indice_type":"percentile_based"
+                "indice_type":"percentile_based",
+                "out_unit":"days"
             },
 
             "CDSI":
             {
                 "var_name":"tasmin",
-                "indice_type":"percentile_based"
+                "indice_type":"percentile_based",
+                "out_unit":"days"
             },
 
             "TX":
             {
                 "var_name":"tasmax",
-                "indice_type":"simple"
+                "indice_type":"simple",
+                "out_unit":"days"
             },
 
             "TXx":
             {
                 "var_name":"tasmax",
-                "indice_type":"simple"
+                "indice_type":"simple",
+                "out_unit":"days"
             },
 
             "TXn":
             {
                 "var_name":"tasmax",
-                "indice_type":"simple"
+                "indice_type":"simple",
+                "out_unit":"days"
             },
 
             "SU":
             {
                 "var_name":"tasmax",
-                "indice_type":"simple"
+                "indice_type":"simple",
+                "out_unit":"days"
             },
 
             "CSU":
             {
                 "var_name":"tasmax",
-                "indice_type":"simple"
+                "indice_type":"simple",
+                "out_unit":"days"
             },
 
             "ID":
             {
                 "var_name":"tasmax",
-                "indice_type":"simple"
+                "indice_type":"simple",
+                "out_unit":"days"
             },
 
             "TX10p":
             {
                 "var_name":"tasmax",
-                "indice_type":"percentile_based"
+                "indice_type":"percentile_based",
+                "out_unit":"days"
             },
 
             "TX90p":
             {
                 "var_name":"tasmax",
-                "indice_type":"percentile_based"
+                "indice_type":"percentile_based",
+                "out_unit":"days"
             },
 
             "WSDI":
             {
                 "var_name":"tasmax",
-                "indice_type":"percentile_based"
+                "indice_type":"percentile_based",
+                "out_unit":"days"
             },
 
             "DTR":
             {
                 "var_name":["tasmin", "tasmax"],
-                "indice_type":"multivariable"
+                "indice_type":"multivariable",
+                "out_unit":"days"
             },
 
             "ETR":
             {
                 "var_name":["tasmin", "tasmax"],
-                "indice_type":"multivariable"
+                "indice_type":"multivariable",
+                "out_unit":"days"
             },
 
             "vDTR":
             {
                 "var_name":["tasmin", "tasmax"],
-                "indice_type":"multivariable"
+                "indice_type":"multivariable",
+                "out_unit":"days"
             },
 
             "PRCPTOT":
             {
                 "var_name":"pr",
-                "indice_type":"simple"
+                "indice_type":"simple",
+                "out_unit":"days"
             },
 
             "RR1":
             {
                 "var_name":"pr",
-                "indice_type":"simple"
+                "indice_type":"simple",
+                "out_unit":"days"
             },
 
             "SDII":
             {
                 "var_name":"pr",
-                "indice_type":"simple"
+                "indice_type":"simple",
+                "out_unit":"days"
             },
 
             "CWD":
             {
                 "var_name":"pr",
-                "indice_type":"simple"
+                "indice_type":"simple",
+                "out_unit":"days"
             },
 
             "CDD":
             {
                 "var_name":"pr",
-                "indice_type":"simple"
+                "indice_type":"simple",
+                "out_unit":"days"
             },
 
             "R10mm":
             {
                 "var_name":"pr",
-                "indice_type":"simple"
+                "indice_type":"simple",
+                "out_unit":"days"
             },
 
             "RR20mm":
             {
                 "var_name":"pr",
-                "indice_type":"simple"
+                "indice_type":"simple",
+                "out_unit":"days"
             },
             
             "RX1day":
             {
                 "var_name":"pr",
-                "indice_type":"simple"
+                "indice_type":"simple",
+                "out_unit":"days"
             },
 
             "RX5day":
             {
                 "var_name":"pr",
-                "indice_type":"simple"
+                "indice_type":"simple",
+                "out_unit":"days"
             },
             
             "R75p":
             {
                 "var_name":"pr",
-                "indice_type":"percentile_based"
+                "indice_type":"percentile_based",
+                "out_unit":"days"
             },
 
             "R75pTOT":
             {
                 "var_name":"pr",
-                "indice_type":"percentile_based"
+                "indice_type":"percentile_based",
+                "out_unit":"days"
             },
 
             "R95p":
             {
                 "var_name":"pr",
-                "indice_type":"percentile_based"
+                "indice_type":"percentile_based",
+                "out_unit":"days"
             },
 
             "R95pTOT":
             {
                 "var_name":"pr",
-                "indice_type":"percentile_based"
+                "indice_type":"percentile_based",
+                "out_unit":"days"
             },
 
             "R99p":
             {
                 "var_name":"pr",
-                "indice_type":"percentile_based"
+                "indice_type":"percentile_based",
+                "out_unit":"days"
             },
 
             "R99pTOT":
             {
                 "var_name":"pr",
-                "indice_type":"percentile_based"
+                "indice_type":"percentile_based",
+                "out_unit":"days"
             },
 
             "SD":
             {
                 "var_name":"SNOWFALL TO COMPLETE",
-                "indice_type":"simple"
+                "indice_type":"simple",
+                "out_unit":"days"
             },
 
             "SD1":
             {
                 "var_name":"SNOWFALL TO COMPLETE",
-                "indice_type":"simple"
+                "indice_type":"simple",
+                "out_unit":"days"
             },
 
             "SD5cm":
             {
                 "var_name":"SNOWFALL TO COMPLETE",
-                "indice_type":"simple"
+                "indice_type":"simple",
+                "out_unit":"days"
             },
 
             "SD50cm":
             {
                 "var_name":"SNOWFALL TO COMPLETE",
-                "indice_type":"simple"
+                "indice_type":"simple",
+                "out_unit":"days"
             },
 
             "CD":
             {
                 "var_name":["tasmean", "pr"],
-                "indice_type":"multivariable"
+                "indice_type":"multivariable",
+                "out_unit":"days"
             },
 
             "CW":
             {
                 "var_name":["tasmean", "pr"],
-                "indice_type":"multivariable"
+                "indice_type":"multivariable",
+                "out_unit":"days"
             },
 
             "WD":
             {
                 "var_name":["tasmean", "pr"],
-                "indice_type":"multivariable"
+                "indice_type":"multivariable",
+                "out_unit":"days"
             },
 
             "WW":
             {
                 "var_name":["tasmean", "pr"],
-                "indice_type":"multivariable"
+                "indice_type":"multivariable",
+                "out_unit":"days"
             }
         },
+
+        "slice_mode":["None","year","month","ONDJFM",
+            "AMJJAS","DJF","MAM","JJA","SON"],
 
         "operation":
         {

--- a/icclim/icclim.py
+++ b/icclim/icclim.py
@@ -205,7 +205,6 @@ def indice(in_files,
     if os.path.isdir(out_path) == False:
         raise IOError('Output directory does not exists.')
         
-    data = read.read_config_file()
     onc = util_nc.create_output_netcdf(netcdf_version, out_file)
     ind_type = check.icclim_output_file_defaults('variable_type_str')
     

--- a/icclim/icclim.py
+++ b/icclim/icclim.py
@@ -1,5 +1,4 @@
 # -*- coding: latin-1 -*-
-
 #  Copyright CERFACS (http://cerfacs.fr/)
 #  Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
 #
@@ -31,6 +30,7 @@ if sys.version_info[0] < 3:
     import calc_ind
 
     import util.logging_info as logging_info
+    import util.read as read
     import util.calc as calc
     import util.check as check
     import util.callback as callback
@@ -52,6 +52,7 @@ else:
     from . import calc_ind
 
     from icclim.util import callback
+    from icclim.util import read
     from icclim.util import util_dt
     from icclim.util import util_nc
     from icclim.util import arr_size
@@ -204,7 +205,7 @@ def indice(in_files,
     if os.path.isdir(out_path) == False:
         raise IOError('Output directory does not exists.')
         
-
+    data = read.read_config_file()
     onc = util_nc.create_output_netcdf(netcdf_version, out_file)
     ind_type = check.icclim_output_file_defaults('variable_type_str')
     

--- a/icclim/util/read.py
+++ b/icclim/util/read.py
@@ -1,0 +1,9 @@
+import json
+import os
+
+config_file = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))+"/config_indice.json"
+
+def read_config_file(config_file=config_file):
+    with open(config_file) as json_data:
+            data = json.load(json_data)
+    return data


### PR DESCRIPTION
Add slice_mode in the config file, create a read.py script to read the config file from outside of the icclim module.
Currently the read.py has no utility within the icclim module but will be the main program to read netcdf and config file. It is already used in the WPS currently in development for the DARE project.