### PR TITLE
Add utility function to access data structure from config_indice.json

### DIFF
--- a/icclim/config_indice.json
+++ b/icclim/config_indice.json
@@ -346,7 +346,7 @@
             }
         },
 
-        "slice_mode":["None","year","month","ONDJFM",
+        "slice_mode":["year","month","ONDJFM",
             "AMJJAS","DJF","MAM","JJA","SON"],
 
         "operation":
@@ -364,9 +364,22 @@
     },
 
     "dispel4py":
-    {
-        "configFileName":"input_C4I.json",
-        "def":["PE","Worfklow"]        
+    { 
+        "List_PE":
+        {
+            "NetCDFProcessing()":
+            {
+                "indice_name":null,
+                "user_indice":null,
+                "slice_mode":null,
+                "in_files":null,
+                "out_file":null
+            },
+            "ReadNetCDF()":{},
+            "StandardDeviation()":{},
+            "AverageData()":{},
+            "CombineDataAndPlot()":{}
+        }        
     },
 
     "C4I":
@@ -374,19 +387,11 @@
         "dispel4py_wps":
         {
             "configFileName":"input_C4I.json",
-            "def":["PE","Worfklow"]
+            "jsonStructure":
+            {
+                "PE":{},
+                "Workflow":{}
+            }
         }
-    },
-
-    "List_PE":
-    {
-        "NetCDFProcessing()":
-        {
-
-        },
-        "ReadNetCDF()":[],
-        "StandardDeviation()":[],
-        "AverageData()":[],
-        "CombineDataAndPlot()":[]
     }
 }

--- a/icclim/util/read.py
+++ b/icclim/util/read.py
@@ -7,3 +7,17 @@ def read_config_file(config_file=config_file):
     with open(config_file) as json_data:
             data = json.load(json_data)
     return data
+
+def get_icclim_indice_config(config_structure=config_structure):
+        #Loading config from icclim for the dispel4py wps workflow
+        return config_structure["icclim"]["indice"].keys()
+
+def get_icclim_slice_mode(config_structure=config_structure):
+        #Loading config from icclim for the dispel4py wps workflow
+        return config_structure["icclim"]["slice_mode"] 
+
+def get_disp4py_config(config_structure=config_structure):
+        #Loading config from icclim for the dispel4py wps workflow
+        conf_filename = config_structure["C4I"]["dispel4py_wps"]["configFileName"]
+        json_structure = config_structure["C4I"]["dispel4py_wps"]["jsonStructure"]
+        return conf_filename, json_structure


### PR DESCRIPTION
Add utility function to access data structure from config_indice.json to syncrhonize the wps on C4I and icclim configuration.
The new function on read.py allow to access directly the indice or slice_mode available on icclim. If an indice is added to icclim, he should be directly added on the wps - if C4I has the new version of icclim.