### PR TITLE
Fix typo in config_indice.json

### DIFF
--- a/icclim/config_indice.json
+++ b/icclim/config_indice.json
@@ -93,7 +93,7 @@
                 "out_unit":"days"
             },
 
-            "CDSI":
+            "CSDI":
             {
                 "var_name":"tasmin",
                 "indice_type":"percentile_based",


### PR DESCRIPTION
I found another typo in the config_indice.json. CSDI was mispelled CDSI.