### PR TITLE
Fix: improper lint on doc conf

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -13,9 +13,8 @@
 import os
 import sys
 
-import icclim
-
 sys.path.insert(0, os.path.abspath("../.."))
+import icclim
 
 # -- Project information -----------------------------------------------------
 project = "Icclim"

--- a/doc/source/explanation/index.rst
+++ b/doc/source/explanation/index.rst
@@ -1,5 +1,3 @@
-.. _explanation:
-
 Explanation
 ===========
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,7 @@ exclude =
 	docs,
 	build,
 	.eggs,
+	conf.py,
 ignore =
     W503 # W503 line break before binary operator, black mess with it
 	E203 # whitespace before ':' - doesn't work well with black
@@ -29,3 +30,4 @@ testpaths = icclim/tests/unit_tests
 [isort]
 profile = black
 known_first_party = icclim
+skip = conf.py


### PR DESCRIPTION
The pre-commit linting was breaking the sphynx build.
The cause is the `import icclim` which must be done after updating the sys.path.