### PR TITLE
Feature/c3s extract funs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,9 +9,5 @@ build:
     python: "3.8"
 
 python:
-  version: 3.8
-  install:
-    - method: pip
-      path: .
-      extra_requirements:
-        - dev
+   install:
+   - requirements: requirements.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,17 @@
+version: 2
+
+sphinx:
+  configuration: doc/source/conf.py
+
+build:
+  os: "ubuntu-20.04"
+  tools:
+    python: "3.8"
+
+python:
+  version: 3.8
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - dev

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,4 +10,4 @@ build:
 
 python:
    install:
-   - requirements: requirements.txt
+   - requirements: requirements_dev.txt

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -33,7 +33,6 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.napoleon",
     "sphinx.ext.autosectionlabel",
-    "nbsphinx",  # notebooks
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/doc/source/explanation/climate_indices.rst
+++ b/doc/source/explanation/climate_indices.rst
@@ -36,10 +36,113 @@ air temperature and precipitation variables can be computed with icclim:
     - 4 compound indices (CD, CW, WD, WW)
 
 Detailed description of each indice is available at https://www.ecad.eu/documents/atbd.pdf.
-
+See table below for a short description of each indices.
+The description is extracted from clix-meta.
 Initially icclim was designed for online computing of climate indices through the `climate4impact portal <https://climate4impact.eu>`_.
 In spite of existence of other packages able to compute climate indices (`CDO <https://code.mpimet.mpg.de/projects/cdo>`_, `R package <https://etccdi.pacificclimate.org/resources/software-library>`_ ),
 it was decided to develop a new software in Python.
 Python language was first of all chosen to interface with `PyWPS <https://pywps.org/>`_: Python implementation of Web Processing Service
 (WPS) Standard.
 Another reason was to interface eventually with the `OpenClimateGIS <https://github.com/NCPP/ocgis/>`_.
+
++-----------------+------------------------------------------------------------+
+| short name      |   Description                                              |
++=================+============================================================+
+| TG              |   Mean of daily mean temperature                           |
++-----------------+------------------------------------------------------------+
+| TN              |   Mean of daily minimum temperature                        |
++-----------------+------------------------------------------------------------+
+| TX              |   Mean of daily maximum temperature                        |
++-----------------+------------------------------------------------------------+
+| DTR             |   Mean Diurnal Temperature Range                           |
++-----------------+------------------------------------------------------------+
+| ETR             |   Intra-period extreme temperature range                   |
++-----------------+------------------------------------------------------------+
+| vDTR            |   Mean day-to-day variation in Diurnal Temperature Range   |
++-----------------+------------------------------------------------------------+
+| SU              |   Number of Summer Days (Tmax > 25C)                       |
++-----------------+------------------------------------------------------------+
+| TR              |   Number of Tropical Nights (Tmin > 20C)                   |
++-----------------+------------------------------------------------------------+
+| WSDI            |                                                            |
++-----------------+------------------------------------------------------------+
+| TG90p           |   Percentage of days when Tmean > 90th percentile          |
++-----------------+------------------------------------------------------------+
+| TN90p           |   Percentage of days when Tmin > 90th percentile           |
++-----------------+------------------------------------------------------------+
+| TX90p           |   Percentage of days when Tmax > 90th percentile           |
++-----------------+------------------------------------------------------------+
+| TXx             |   Maximum daily maximum temperature                        |
++-----------------+------------------------------------------------------------+
+| TNx             |   Maximum daily minimum temperature                        |
++-----------------+------------------------------------------------------------+
+| CSU             |   Maximum number of consecutive summer days (Tmax >25 C)   |
++-----------------+------------------------------------------------------------+
+| GD4             |   Growing degree days (sum of Tmean > 4 C)                 |
++-----------------+------------------------------------------------------------+
+| FD              |   Number of Frost Days (Tmin < 0C)                         |
++-----------------+------------------------------------------------------------+
+| CFD             |   Maximum number of consecutive frost days (Tmin < 0 C)    |
++-----------------+------------------------------------------------------------+
+| HD17            |   Heating degree days (sum of Tmean < 17 C)                |
++-----------------+------------------------------------------------------------+
+| ID              |   Number of sharp Ice Days (Tmax < 0C)                     |
++-----------------+------------------------------------------------------------+
+| TG10p           |   Percentage of days when Tmean < 10th percentile          |
++-----------------+------------------------------------------------------------+
+| TN10p           |   Percentage of days when Tmin < 10th percentile           |
++-----------------+------------------------------------------------------------+
+| TX10p           |   Percentage of days when Tmax < 10th percentile           |
++-----------------+------------------------------------------------------------+
+| TXn             |   Minimum daily maximum temperature                        |
++-----------------+------------------------------------------------------------+
+| TNn             |   Minimum daily minimum temperature                        |
++-----------------+------------------------------------------------------------+
+| CSDI            |                                                            |
++-----------------+------------------------------------------------------------+
+| CDD             |   Maximum consecutive dry days (Precip < 1mm)              |
++-----------------+------------------------------------------------------------+
+| PRCPTOT         |   Total precipitation during Wet Days                      |
++-----------------+------------------------------------------------------------+
+| RR1             |   Number of Wet Days (precip >= 1 mm)                      |
++-----------------+------------------------------------------------------------+
+| SDII            |   Average precipitation during Wet Days (SDII)             |
++-----------------+------------------------------------------------------------+
+| CWD             |   Maximum consecutive wet days (Precip >= 1mm)             |
++-----------------+------------------------------------------------------------+
+| R10mm           |   Number of heavy precipitation days (Precip >=10mm)       |
++-----------------+------------------------------------------------------------+
+| R20mm           |   Number of very heavy precipitation days (Precip >= 20mm) |
++-----------------+------------------------------------------------------------+
+| RX1day          |   Maximum 1-day precipitation                              |
++-----------------+------------------------------------------------------------+
+| RX5day          |   Maximum 5-day precipitation                              |
++-----------------+------------------------------------------------------------+
+| R75p            |                                                            |
++-----------------+------------------------------------------------------------+
+| R75pTOT         |                                                            |
++-----------------+------------------------------------------------------------+
+| R95p            |                                                            |
++-----------------+------------------------------------------------------------+
+| R95pTOT         |                                                            |
++-----------------+------------------------------------------------------------+
+| R99p            |                                                            |
++-----------------+------------------------------------------------------------+
+| R99pTOT         |                                                            |
++-----------------+------------------------------------------------------------+
+| SD              |   Mean of daily snow depth                                 |
++-----------------+------------------------------------------------------------+
+| SD1             |   Snow days (SD >= 1 cm)                                   |
++-----------------+------------------------------------------------------------+
+| SD5cm           |   Number of days with snow depth >= 5 cm                   |
++-----------------+------------------------------------------------------------+
+| SD50cm          |   Number of days with snow depth >= 50 cm                  |
++-----------------+------------------------------------------------------------+
+| CD              |                                                            |
++-----------------+------------------------------------------------------------+
+| CW              |                                                            |
++-----------------+------------------------------------------------------------+
+| WD              |                                                            |
++-----------------+------------------------------------------------------------+
+| WW              |                                                            |
++-----------------+------------------------------------------------------------+

--- a/doc/source/how_to/dask.rst
+++ b/doc/source/how_to/dask.rst
@@ -21,7 +21,7 @@ icclim uses xarray to manipulate data and xarray provides multiple backends to h
 By default, xarray uses numpy, this is overwritten in icclim to use dask whenever a path to a file is provided as input.
 Numpy is fast and reliable for small dataset but may exhaust the memory on large dataset.
 The other backend possibility of xarray is dask. dask can divide data into small chunk to minimize the memory footprint
-of computations. This chunking also enable parallel computation by running the calculus on each chunk concurrently.
+of computations. This chunking also enable parallel computation by running the calculation on each chunk concurrently.
 This parallelization can speed up the computation but because each parallel thread will need multiple chunks to be
 in-memory at once, it can bring back memory issues that chunking was meant to avoid.
 
@@ -313,12 +313,12 @@ Internal re-chunking
 ~~~~~~~~~~~~~~~~~~~~
 The warning would be: ``PerformanceWarning: Increasing number of chunks by factor of xx``.
 This warning is usually raised when computing percentiles.
-In percentiles calculus step, the data used to compute the percentile grow significantly in-memory.
+In percentiles calculation step, the intermediary data generated to compute percentiles is much larger than the initial data.
 First, because of the rolling window used to retrieve all values of each day, the analysed data is multiplied by
 window size (usually by 5).
 Then, on temperatures indices such as Tx90p, we compute percentiles for each day of year (doy).
 This means we must read almost all chunks of time dimension.
-To avoid consuming all RAM at once with this, icclim/xclim internally re-chunk data that's why dask warns
+To avoid consuming all RAM at once with these, icclim/xclim internally re-chunk data that's why dask warns
 that many chunks are being created.
 In that case this warning can be ignored.
 

--- a/doc/source/how_to/dask.rst
+++ b/doc/source/how_to/dask.rst
@@ -1,0 +1,379 @@
+Larger than memory computation
+==============================
+
+TL;DR
+-----
+icclim make use of dask to chunk and parallelize computations.
+You can configure dask to limit the memory footprint of these calculus by instantiating a distributed Client
+and by tuning dask.config options.
+A configuration working well for small to medium dataset and simple climate indices is :
+
+>>>import dask
+>>>from distributed import Client
+>>>client = Client(memory_limit='10GB', n_workers=1, threads_per_worker=8)
+>>>dask.config.set({"array.slicing.split_large_chunks": False})
+>>>dask.config.set({"array.chunk-size": "50 MB"})
+>>>icclim.index(in_files="data.nc", indice_name='SU', out_file="output.nc")
+
+------------------------------------------------------------------------------------------------
+
+icclim uses xarray to manipulate data and xarray provides multiple backends to handle in-memory data.
+By default, xarray uses numpy, this is overwritten in icclim to use dask whenever a path to a file is provided as input.
+Numpy is fast and reliable for small dataset but may exhaust the memory on large dataset.
+The other backend possibility is dask. dask can divide data into small chunk to minimize the memory footprint of the
+computation. This chunking also enable parallel computation. This parallelization can speed up the computation but
+because each parallel thread need multiple chunks to be in-memory at once, it can bring back memory issues.
+
+In this document we first explain some concepts around dask, parallelization and performances, then we propose multiple
+dask configurations to be used with icclim.
+Each configuration aims to answer a specific scenario. For you own data, you will likely need to customize these
+configuration to your needs.
+
+The art of chunking
+-------------------
+Dask proposes a way to divide large dataset into multiple smaller chunks that fit in memory.
+This process is known as chunking and with icclim there are 2 ways to control it.
+First, you can open your dataset with xarray and do your own chunking:
+
+>>>import xarray
+>>>import icclim
+>>>ds = xarray.open_dataset("data.nc")
+>>>ds = ds.chunk({"time": 10, "lat": 20, "lon": 20})
+
+And then use this `ds` dataset as input for icclim.
+
+>>>icclim.index(in_files=ds, indice_name='SU', out_file="output.nc")
+
+In that case, icclim will not rechunk your data, it is left to you to find the proper chunking.
+For more information on how to properly chunk see:
+- xarray guide //TODO
+- xarray tips //TODO
+- dask guide //TODO
+Another option is to leave icclim and dask find the best chunking for each dimension.
+This is the recommended way, the chunking behavior can be controlled by limiting the size of each individual chunk.
+
+>>>import dask
+>>>dask.config.set({"array.chunk-size": "50 MB"})
+>>>icclim.index(in_files="data.nc", ...)
+
+By default, the dask chunk-size is around 100MB.
+You can also use ``with`` python keyword if you don't want this configuration to spread globally.
+Internally, icclim will ask xarray and dask to chunk using ``"auto"`` configuration.
+This usually results in a pretty good chunking. It chunks by respecting as much as possible how the data
+is stored and will make chunks as large as approximately the configured chunk-size.
+Moreover, some operations in icclim/xclim need to re-chunk intermediary results. We usually try to keep the chunk sizes
+to their initial value but re-chunking is costly and we sometimes prefer to generate larger chunks to improve performances.
+If you wish to avoid this large chunking behavior, you can use the following dask configuration:
+
+>>>dask.config.set({"array.slicing.split_large_chunks": True})
+
+On performances
+---------------
+Computation of ECA&D indices can largely be done in parallel on spatial dimensions.
+Indeed, each of these indices are relying on a time series for each pixel. Thus, in a ideal world we could compute
+each pixel independently but, this would usually result in a lot of chunks.
+This is not optimal because the smaller each chunk is, the greater the overhead is.
+By overhead, we mean here the necessary python code running to move around and handle each independent chunk.
+Plus, unless running on a cloud or HPC, we are limited by the number of threads (or processes) available.
+Another important aspect of dask to consider for performances is the task graph. Dask creates a graph of all the actions
+(tasks) it must accomplish to compute the calculation. This graph created before the computation, shows for each chunk
+the route to follow in order to compute the climat index.
+This allow some nice optimizations, for example if some spatial or time selection is done, it will only read and load in
+memory the selected data.
+However, each task also add some overhead and, a small graph with a few tasks will likely compute faster.
+Plus, each chunk has it's own route in the graph, and the more there are chunks the more routes are created.
+In extreme cases, when there are a lot of chunks, the graph may take eons to create and the computation may never start.
+This means that creating small chunks leads to numerous chunks and thus to a potentially large graph.
+
+Beside, when starting dask on a limited system (e.g a laptop) it's quite easy to exhaust all available memory.
+In that case, dask has multiple safety mechanism and can even kill the computing process (a.k.a the worker) once it
+reaches a memory limit (default to 95% of memory).
+Even before this limit, the performances can deteriorate when dask measures a high memory use of a worker.
+When a worker use around 60% of it's memory, dask will ask it to write to disk the intermediary results it has computed.
+These i/o operation are much slower than in RAM manipulation, even on a recent SSD disk.
+
+
+Hence, there are multiple things to consider to maximize performances:
+First, if your data (and the intermediary computation) fits in memory, it might be better to use Numpy backend directly.
+To do so, simply provide the opened dataset to icclim:
+
+>>>ds = xarray.open_dataset("data.nc")
+>>>icclim.index(in_files=ds, indice_name='SU', out_file="output.nc")
+
+There will be no parallelization but, on small dataset it's unnecessary, numpy is really fast.
+
+On the other hand when using dask we must:
+- Minimize the number of task to speed things up, thus divide data into large enough chunks.
+- Minimize the workload of each worker to avoid i/o operation, thus divide data into small enough chunks.
+In the following we present a few possible configuration for dask.
+
+
+Small to medium dataset (a few MB) - No configuration
+-----------------------------------------------------
+
+The first approach is to use default values.
+By default icclim rely on "auto" chunking of dask.
+Dask will be started with the threading scheduler which, in the same python process will spawn multiple thread
+to concurrently compute the indices.
+// TODO: add link to default scheduler doc
+This can work on most cases for small to medium datasets and may yield the best performances.
+However some percentiles based indices (T_90p and T_10p families) may use a lot of memory even on medium
+indices. This memory footprint is caused by the bootstrapping of percentiles, an algorithm used to correct
+statistical biais. This algorithm rely on a Monte Carlo simulation which inherently use a lot of ressources.
+The longer the bootstrap period is, the more ressources are used. The bootstrap period is the overlapping years
+between the period where percentile are computed (a.k.a "in base") and the period where the climate index is computed
+(a.k.a "out of base").
+
+.. Notes::
+
+    To control the "in base" period, ``icclim.index`` provides the ``base_period_time_range`` parameter.
+    To control the "out of base", ``icclim.index`` provides the ``time_range`` parameter.
+
+For these percentile based indices, we recommend to use one of the following configuration.
+
+Medium to large dataset (~200MB) - dask LocalCluster
+----------------------------------------------------
+
+By default, dask will run on a default threaded scheduler.
+This behavior can be overwritten by creating you own "cluster" running locally on your machine.
+This LocalCluster is distributed in a separate dask package called "distributed" and is not a mandatory
+dependency of icclim.
+To install it run:
+
+>>> conda install dask distributed -c conda-forge
+
+See the documentation for more details: http://distributed.dask.org/en/stable/
+Once installed, you can delegate the LocalCluster instantiation using `distributed.Client` class.
+This class both create a cluster and run a web application to investigate how your computation is going.
+This web dashboard is very useful to understand what is going right or wrong.
+By default it runs on ``localhost:8787``, you can print the client object to see on which port it runs.
+
+>>> from distributed import Client
+>>> client = Client()
+By default dask // TODO fill defaults values for Client
+
+The cluster can be configured directly through Client arguments.
+
+>>> client = Client(memory_limit='16GB', n_workers=1, threads_per_worker=8)
+
+A few notes:
+- The CLient must be started in the same python interpreter as the computation. This is how dask know to use
+the cluster instead of the default scheduler.
+- If needed, the localCluster can be started independently and the Client connected to a running LocalCluster.
+See dask documentation for how to: // TODO add link
+- Each worker is an independent python process and memory_limit is set for each of these process.
+If you have 16GB of RAM don't set ``memory_limit='16GB'`` unless you run a single worker.
+- Memory sharing is much more efficient between threads than between processes.
+- Threads number is usually optimal when it's a multiple of your CPU cores (usually *2).
+- All threads of the same worker are waiting whenever one of the thread is reading or writing on disk.
+- It's useless to spawn too many threads, there are hardware limits on how many of them can run concurrently
+and if they are numerous, the OS will waste time orchestrating them.
+- A dask worker may write to disk some of their data even if it is far form reaching the memory limit.
+This seems to be a normal behavior when dask knows some intermediary results will not be used soon.
+This can significantly slow down the computation due to i/o.
+- Percentiles based indices may use up to ``nb_thread * chunk_size * 30`` memory which is unusually high for a
+dask application. We are trying to reduce this memory footprint but it means some costly rechunking in the middle of
+computation have to be made.
+
+Knowing these we can consider multiple scenarios.
+
+Low memory footprint
+~~~~~~~~~~~~~~~~~~~~
+
+Let's suppose you want to compute indices on your laptop while continue to work on other subjects.
+You should configure your local cluster to use not too many threads and processes and to limit the amount of memory
+each process (worker) has.
+On my 4 cores, 16GB of RAM laptop I would consider:
+
+>>> client = Client(memory_limit='10GB', n_workers=1, threads_per_worker=4)
+
+Eventually, to reduce the amount of i/o we can also increase dask memory thresholds:
+
+>>> dask.config.set({"distributed.worker.memory.target": "0.8"})
+>>> dask.config.set({"distributed.worker.memory.spill": "0.9"})
+>>> dask.config.set({"distributed.worker.memory.pause": "0.95"})
+>>> dask.config.set({"distributed.worker.memory.terminate": "0.98"})
+
+These thresholds are fractions of memory_limit used by dask to take a decision.
+Here, at 80% of memory the worker will write to disk its unmanaged memory.
+At 90%, the worker will write all its memory to disk.
+At 95%, the worker pause computation to focus on writing.
+At 98%, the worker is killed to avoid reaching memory limit.
+Increasing these threshold has a risk, because they could be filled quicker than expected resulting in a killed worker
+and thus loosing all work done by this worker.
+If a single worker is running, the whole computation will be restarted (and will likely reach the same memory limit).
+
+High ressource use
+~~~~~~~~~~~~~~~~~~
+If you want to have the result as quickly as possible without risking
+On my 4 cores, 16GB of RAM laptop I would consider:
+
+>>>client = Client(memory_limit='16GB', n_workers=1, threads_per_worker=8)
+
+On this kind of configuration, it can be useful to add 1 or 2 workers in case a lot of i/o is necessary.
+It can also be necessary to reduce chunk size, dask default value is around 100 MB which on some indices
+may fill all the memory.
+
+It's over 9000!
+~~~~~~~~~~~~~~~
+
+This configuration may put your computer to its knees, use it at your own risk.
+The idea is to bypass all memory safety implemented by dask.
+This may yield very good performances because there will be no i/o on disk by dask itself.
+However, when your OS run out of RAM, it will use your disk swap which is very similar to dask spilling mechanism but probably slower.
+And if you run out of swap, your computer will likely crash.
+To roll the dices use the following configuration
+>>>client = Client(memory_limit='0')
+Dask will spawn multiple processes without memory limits and each process will spawn multiple threads.
+
+Large to huge dataset (1GB and above)
+------------------------------------
+
+If you which to compute climate indices on a large dataset a personal computer is probably be inappropriate.
+In that case you can deploy a "real" dask cluster opposed to the LocalCluster.
+You can find more information on how to deploy dask cluster here: //TODO add link to cloud dask
+
+If you must run your computation on limited ressources, you can try to:
+- Use only one or two threads on a single worker
+This will drastically slow down the computation but very few chunks will be in memory at once letting you use quite large chunks.
+- Use small chunk size, but beware the smaller they are the more complex dask graph become.
+- Split you data into smaller netcdf inputs and run the computation multiple time.
+This is the most frustrating option because chunking is supposed to do exactly that. But, sometimes
+it can be easier to chunk "by hand" than to find the exact configuration that fit for the input dataset.
+
+Real example
+------------
+
+On CMIP6 data, when computing the percentile based indices Tx90p for 20 years, bootstrapped on 19 years we used:
+>>>client = Client(memory_limit='16GB', n_workers=1, threads_per_worker=2)
+>>>dask.config.set({"array.slicing.split_large_chunks": False})
+>>>dask.config.set({"array.chunk-size": "100 MB"})
+>>>dask.config.set({"distributed.worker.memory.target": "0.8"})
+>>>dask.config.set({"distributed.worker.memory.spill": "0.9"})
+>>>dask.config.set({"distributed.worker.memory.pause": "0.95"})
+>>>dask.config.set({"distributed.worker.memory.terminate": "0.98"})
+
+
+Troubleshooting and dashboard analysis
+--------------------------------------
+
+This section describe common warnings and errors that dask can raise.
+There are also some silent issues that dask dashboard can expose.
+A dashboard is started when running the distributed ``Client(...)``.
+
+
+Memory overload
+~~~~~~~~~~~~~~~
+The warning may be "distributed.nanny - WARNING - Restarting worker" or the error "KilledWorker".
+This means the computation uses more memory than what is available.
+Keep in mind that:
+- memory_limit parameter is the limit of each individual workers
+- Some indices, such as percentile based indices (R__p, T_90p, T_10p families) may use large amount of memory.
+- You can reduce memory footprint by using smaller chunk
+- Each thread may load multiple chunks in memory at once.
+To solve this issue, you must either provide additional available memory or reduce the quantity of memory used.
+You can increase memory_limit up to your physical memory available (RAM) with ``Client(memory_limit="16GB")``,
+this may speed up computation by reducing writes and reads on disk.
+You can reduce the number of concurrently running threads (and workers) in the distributed Client configuration with
+``Client(n_workers=1, threads_per_worker=1)``. This may slow down computation.
+You can reduce the size of each chunk with ``dask.config.set({"array.chunk-size": "50 MB"})``, default is around 100MB.
+This may slow down computation as well.
+Or you can combine all three solutions above.
+
+
+Garbage collection "wasting" CPU time
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The warning would be: ``distributed.utils_perf - WARNING - full garbage collections took xx% CPU time recently (threshold: 10%)``
+This is usually accompanied by: ``distributed.worker - WARNING - gc.collect() took 1.259s. This is usually a sign that some tasks handle too many Python objects at the same time. Rechunking the work into smaller tasks might help.``
+Python runs on a virtual machine (VM) which handles the memory allocation of objects for us.
+This means the VM sometimes needs to cleanup garbage objects that aren't referenced anymore.
+This operation takes some CPU ressource but free the RAM for other uses.
+In our dask context, the warning may be raised when icclim/xclim has created large chunks which takes longer to be garbage collected.
+
+Internal re-chunking
+~~~~~~~~~~~~~~~~~~~~
+The warning would be: ``PerformanceWarning: Increasing number of chunks by factor of xx``.
+This warning is usually raised when computing percentiles.
+In this step, the input in base data used to compute the percentile grow significantly.
+First, because of the rolling window the input data size is multiplied by window size.
+Then, on temperatures indices such as Tx90p, we compute values for each day of year(doy).
+This means we need for each to read all years of in_base thus usually all chunks of time dimension.
+To avoid consuming all RAM at once we rechunk the doy values to the initial chunking size but
+dask warns us that it creates quite a few new chunks.
+This warning should not be a serious issue and can be ignored.
+
+Computation never start
+~~~~~~~~~~~~~~~~~~~~~~~
+The error raised can be ``CancelledError``.
+We can also acknowledge this by looking at dask dashboard and not seeing any task being schedule.
+This usually means dask graph is too big and the scheduler has trouble creating it.
+If your memory allows it, you can try to increase the chunk-size with ``dask.config.set({"array.chunk-size": "200 MB"})``.
+This will reduce the amount of task created by dask thus reducing graph size.
+To compensate, you may need to reduce the number of running threads with ``Client(n_workers=1, threads_per_worker=2)``.
+This should help limit the memory footprint of the computation.
+
+.. Note::
+
+    Beware, if the computation is fast or if the client is not started in the same python process as icclim,
+    the dashboard may also look empty.
+
+Disk read and write analysis - Dashboard
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+When poorly configured, the computation can spend most of it's CPU time reading and writing chunks on disk.
+You can visualize if it is the case for you by opening dask dashboard (it should be on ``localhost:8787``).
+In the status page, you can see in the right panel each task dynamically being added.
+In these the colourful boxes, each color represent a specific task.
+I/O on disk is displayed as orange transparent boxes. You should also see all other thread of the same worker
+stopping when on thread is reading or writing on disk.
+If there are a lot of i/o you may need to reconfigure dask for futur runs.
+The solution to this are similar to the memory overload described above.
+You can increase total available memory with ``Client(memory_limit="16GB")``.
+You can decrease memory pressure by reducing chunk size with ``dask.config.set({"array.chunk-size": "50 MB"})`` or
+by reducing number of threads with ``Client(n_workers=1, threads_per_worker=2)``.
+Beside, you can also benefit from using multiple worker in this case.
+Each worker is a separate non blocking process thus they are not locking each other when one of them need to write or
+read on disk. They are however slower than thread to share memory, this can result in the "chatterbox" issue presented
+below.
+
+.. Note::
+
+    - Don't instantiate multiple client with different configurations, put everything in the same Client constructor call.
+    - Beware, as of icclim 5.0.0, the bootstrapping of percentiles is known to produce **a lot** of i/o.
+
+Worker chatterbox syndrome - Dashboard
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+In all this document, we mainly recommend to use a single worker with multiple threads.
+Most of the code icclim runs is relying on dask and numpy, and both release the python GLI (More details on GIL here: https://realpython.com/python-gil/).
+This means we can benefit from multi threading and that's why we usually recommend to use a single process (worker) with
+multiple threads.
+However, some configuration can benefit from spawning multiple workers.
+In dask dashboard, you will see red transparent boxes representing the worker communication.
+If you see a lot of these and especially if they do not overlap with other task, it means the workers are
+spending most of their CPU times exchanging data.
+This can be caused by either:
+    1. there are too many workers for the amount of work
+    2. the load balancing has a lot to do.
+In the first case, the solution is simply to reduce the number of workers and eventually to increase the number of
+threads per worker.
+// TODO verify these claims and find a source
+For the second case, when a worker has been given too many task to do, the load balancer is charged of
+redistributing these task to other worker. It can happen when some task take significant time to be processed.
+In icclim/xclim this is for example the case of the ``cal_perc`` function used to compute percentiles.
+There is no easy solution for this case, letting the load balancer do its job seems necessary.
+
+Idle threads
+~~~~~~~~~~~~
+When looking at dask dashboard, the task timelines should be full of colors.
+If you see a lot of emptiness between colored boxes, it means your thread are doing nothing.
+It could be because a blocking operation is in progress (e.g i/o on disk).
+To fix this, you may report to `Disk read and write analysis - Dashboard`_ above.
+It could also be because you have too many available threads and the work cannot be properly divided
+between each thread.
+In that case, you can simply reduce the number of thread in Clint configuration with ``Client(n_workers=1, threads_per_worker=4)``.
+
+Conclusion
+----------
+
+We can't provide a single configuration which fits all possible datasets.
+In this document we tried to summarize the few configurations we found useful while developing icclim.
+You will need to tailor these to your own needs.

--- a/doc/source/how_to/dask.rst
+++ b/doc/source/how_to/dask.rst
@@ -4,15 +4,15 @@ Larger than memory computation
 TL;DR
 -----
 icclim make use of dask to chunk and parallelize computations.
-You can configure dask to limit the memory footprint of these calculus by instantiating a distributed Client
-and by tuning dask.config options.
+You can configure dask to limit its memory footprint and CPu usage by instantiating a distributed Client and by tuning
+dask.config options.
 A configuration working well for small to medium dataset and simple climate indices is :
 
 >>>import dask
 >>>from distributed import Client
 >>>client = Client(memory_limit='10GB', n_workers=1, threads_per_worker=8)
 >>>dask.config.set({"array.slicing.split_large_chunks": False})
->>>dask.config.set({"array.chunk-size": "50 MB"})
+>>>dask.config.set({"array.chunk-size": "100 MB"})
 >>>icclim.index(in_files="data.nc", indice_name='SU', out_file="output.nc")
 
 ------------------------------------------------------------------------------------------------
@@ -20,14 +20,17 @@ A configuration working well for small to medium dataset and simple climate indi
 icclim uses xarray to manipulate data and xarray provides multiple backends to handle in-memory data.
 By default, xarray uses numpy, this is overwritten in icclim to use dask whenever a path to a file is provided as input.
 Numpy is fast and reliable for small dataset but may exhaust the memory on large dataset.
-The other backend possibility is dask. dask can divide data into small chunk to minimize the memory footprint of the
-computation. This chunking also enable parallel computation. This parallelization can speed up the computation but
-because each parallel thread need multiple chunks to be in-memory at once, it can bring back memory issues.
+The other backend possibility of xarray is dask. dask can divide data into small chunk to minimize the memory footprint
+of computations. This chunking also enable parallel computation by running the calculus on each chunk concurrently.
+This parallelization can speed up the computation but because each parallel thread will need multiple chunks to be
+in-memory at once, it can bring back memory issues that chunking was meant to avoid.
 
 In this document we first explain some concepts around dask, parallelization and performances, then we propose multiple
 dask configurations to be used with icclim.
+At the bottom, you can also find a few dask pitfall dodging instructions which might help understanding why your
+computation doesn't run.
 Each configuration aims to answer a specific scenario. For you own data, you will likely need to customize these
-configuration to your needs.
+configurations to your needs.
 
 The art of chunking
 -------------------
@@ -40,17 +43,17 @@ First, you can open your dataset with xarray and do your own chunking:
 >>>ds = xarray.open_dataset("data.nc")
 >>>ds = ds.chunk({"time": 10, "lat": 20, "lon": 20})
 
-And then use this `ds` dataset as input for icclim.
+And then use ``ds`` dataset object as input for icclim.
 
 >>>icclim.index(in_files=ds, indice_name='SU', out_file="output.nc")
 
-In that case, icclim will not rechunk your data, it is left to you to find the proper chunking.
+In that case, icclim will not re-chunk ``ds`` data. It is left to you to find the proper chunking.
 For more information on how to properly chunk see:
-- xarray guide //TODO
-- xarray tips //TODO
-- dask guide //TODO
-Another option is to leave icclim and dask find the best chunking for each dimension.
-This is the recommended way, the chunking behavior can be controlled by limiting the size of each individual chunk.
+- xarray guide: https://xarray.pydata.org/en/stable/user-guide/dask.html#chunking-and-performance
+- dask best practices: https://docs.dask.org/en/stable/array-best-practices.html
+Another option is to leave dask find the best chunking for each dimension.
+This is the recommended way and the default behavior of icclim when using file path inputs.
+In this case, chunking can still be controlled by limiting the size of each individual chunk:
 
 >>>import dask
 >>>dask.config.set({"array.chunk-size": "50 MB"})
@@ -62,8 +65,9 @@ Internally, icclim will ask xarray and dask to chunk using ``"auto"`` configurat
 This usually results in a pretty good chunking. It chunks by respecting as much as possible how the data
 is stored and will make chunks as large as approximately the configured chunk-size.
 Moreover, some operations in icclim/xclim need to re-chunk intermediary results. We usually try to keep the chunk sizes
-to their initial value but re-chunking is costly and we sometimes prefer to generate larger chunks to improve performances.
-If you wish to avoid this large chunking behavior, you can use the following dask configuration:
+to their initial value but re-chunking is costly and we sometimes prefer to generate larger chunks to try improving
+performances.
+If you wish to avoid this large chunking behavior, you can try the following dask configuration:
 
 >>>dask.config.set({"array.slicing.split_large_chunks": True})
 
@@ -71,26 +75,32 @@ On performances
 ---------------
 Computation of ECA&D indices can largely be done in parallel on spatial dimensions.
 Indeed, each of these indices are relying on a time series for each pixel. Thus, in a ideal world we could compute
-each pixel independently but, this would usually result in a lot of chunks.
-This is not optimal because the smaller each chunk is, the greater the overhead is.
+each pixel independently. In reality this would usually result in a considerable amount of chunks.
+This is not optimal because the smaller each chunk is, the greater dask overhead is.
 By overhead, we mean here the necessary python code running to move around and handle each independent chunk.
-Plus, unless running on a cloud or HPC, we are limited by the number of threads (or processes) available.
+Plus, unless running on cloud or a HPC, we are limited by the number of cores available, so we physically can't
+parallelize everything.
 Another important aspect of dask to consider for performances is the task graph. Dask creates a graph of all the actions
-(tasks) it must accomplish to compute the calculation. This graph created before the computation, shows for each chunk
+(tasks) it must accomplish to compute the calculation. This graph, created before the computation, shows for each chunk
 the route to follow in order to compute the climat index.
-This allow some nice optimizations, for example if some spatial or time selection is done, it will only read and load in
-memory the selected data.
-However, each task also add some overhead and, a small graph with a few tasks will likely compute faster.
+This allows some nice optimizations, for example if some spatial or time selections are done within icclim/xclim, it
+will only read and load in-memory the necessary data.
+However, each task also add some overhead and, most of the time a small graph with a few tasks will compute faster.
 Plus, each chunk has it's own route in the graph, and the more there are chunks the more routes are created.
 In extreme cases, when there are a lot of chunks, the graph may take eons to create and the computation may never start.
-This means that creating small chunks leads to numerous chunks and thus to a potentially large graph.
+This means that configuring a small chunk size leads to numerous chunks being created and thus to a potentially large
+graph. The graph is also dependant on the actual computation. A climate index like "SU" (count of days above 25ºC)
+will obviously create a much simpler graph than WSDI (longest spell of at least 6 consecutive days where maximum daily
+temperature is above the 90th daily percentile).
+Finally the resampling may also play a role in the graph complexity. In icclim we control it with ``slice_mode`` parameter.
+A Yearly slice_mode likely be simpler than a monthly one.
 
 Beside, when starting dask on a limited system (e.g a laptop) it's quite easy to exhaust all available memory.
 In that case, dask has multiple safety mechanism and can even kill the computing process (a.k.a the worker) once it
-reaches a memory limit (default to 95% of memory).
+reaches a memory limit (default is 95% of memory).
 Even before this limit, the performances can deteriorate when dask measures a high memory use of a worker.
-When a worker use around 60% of it's memory, dask will ask it to write to disk the intermediary results it has computed.
-These i/o operation are much slower than in RAM manipulation, even on a recent SSD disk.
+When a worker uses around 60% of its memory, dask will ask it to write to disk the intermediary results it has computed.
+These i/o operations are much slower than in RAM manipulation, even on recent SSD disk.
 
 
 Hence, there are multiple things to consider to maximize performances:
@@ -100,40 +110,39 @@ To do so, simply provide the opened dataset to icclim:
 >>>ds = xarray.open_dataset("data.nc")
 >>>icclim.index(in_files=ds, indice_name='SU', out_file="output.nc")
 
-There will be no parallelization but, on small dataset it's unnecessary, numpy is really fast.
+There will be no parallelization but, on small dataset it's unnecessary. Numpy is natively really fast and dask overhead
+may slow it downs.
 
 On the other hand when using dask we must:
-- Minimize the number of task to speed things up, thus divide data into large enough chunks.
-- Minimize the workload of each worker to avoid i/o operation, thus divide data into small enough chunks.
+- Minimize the number of task to speed things up, thus divide data into **large enough chunks**.
+- Minimize the workload of each worker to avoid i/o operation, thus divide data into **small enough chunks**.
 In the following we present a few possible configuration for dask.
 
 
 Small to medium dataset (a few MB) - No configuration
 -----------------------------------------------------
-
 The first approach is to use default values.
-By default icclim rely on "auto" chunking of dask.
-Dask will be started with the threading scheduler which, in the same python process will spawn multiple thread
-to concurrently compute the indices.
-// TODO: add link to default scheduler doc
+By default icclim relies on dask's "auto" chunking and dask will be started with the threading scheduler.
+This scheduler runs everything in the existing python process and will spawn multiple threads
+to concurrently compute climate indices.
+You can find more information on the default scheduler here: https://docs.dask.org/en/stable/scheduling.html#local-threads
 This can work on most cases for small to medium datasets and may yield the best performances.
-However some percentiles based indices (T_90p and T_10p families) may use a lot of memory even on medium
-indices. This memory footprint is caused by the bootstrapping of percentiles, an algorithm used to correct
-statistical biais. This algorithm rely on a Monte Carlo simulation which inherently use a lot of ressources.
-The longer the bootstrap period is, the more ressources are used. The bootstrap period is the overlapping years
+However some percentiles based temperature indices (T_90p and T_10p families) may use a lot of memory even on medium datasets.
+This memory footprint is caused by the bootstrapping of percentiles, an algorithm used to correct statistical biais.
+This bootstrapping use a Monte Carlo simulation, which inherently use a lot of resources.
+The longer the bootstrap period is, the more resources are necessary. The bootstrap period is the overlapping years
 between the period where percentile are computed (a.k.a "in base") and the period where the climate index is computed
 (a.k.a "out of base").
 
 .. Notes::
 
     To control the "in base" period, ``icclim.index`` provides the ``base_period_time_range`` parameter.
-    To control the "out of base", ``icclim.index`` provides the ``time_range`` parameter.
+    To control the "out of base" period, ``icclim.index`` provides the ``time_range`` parameter.
 
 For these percentile based indices, we recommend to use one of the following configuration.
 
 Medium to large dataset (~200MB) - dask LocalCluster
 ----------------------------------------------------
-
 By default, dask will run on a default threaded scheduler.
 This behavior can be overwritten by creating you own "cluster" running locally on your machine.
 This LocalCluster is distributed in a separate dask package called "distributed" and is not a mandatory
@@ -143,51 +152,54 @@ To install it run:
 >>> conda install dask distributed -c conda-forge
 
 See the documentation for more details: http://distributed.dask.org/en/stable/
-Once installed, you can delegate the LocalCluster instantiation using `distributed.Client` class.
-This class both create a cluster and run a web application to investigate how your computation is going.
-This web dashboard is very useful to understand what is going right or wrong.
+Once installed, you can delegate the ``LocalCluster`` instantiation using `distributed.Client` class.
+This ``Client`` object creates both a ``LocalCluster`` and a web application to investigate how your computation is going.
+This web dashboard is very useful to understand where are the computation bottlenecks and to visualize how dask is working.
 By default it runs on ``localhost:8787``, you can print the client object to see on which port it runs.
 
 >>> from distributed import Client
 >>> client = Client()
-By default dask // TODO fill defaults values for Client
+By default dask creates a ``LocalCluster`` with 1 worker (process), CPU count threads and a memory limit up to
+the system available memory.
+You can see how cpu are counted here: https://github.com/dask/dask/blob/main/dask/system.py
+And how default memory is computed here: https://github.com/dask/distributed/blob/main/distributed/worker.py#L4237
+Note that depending on your running OS, these values are not exactly computed the same way.
 
 The cluster can be configured directly through Client arguments.
 
 >>> client = Client(memory_limit='16GB', n_workers=1, threads_per_worker=8)
 
 A few notes:
-- The CLient must be started in the same python interpreter as the computation. This is how dask know to use
-the cluster instead of the default scheduler.
+- The CLient must be started in the same python interpreter as the computation. This is how dask know which scheduler
+to use.
 - If needed, the localCluster can be started independently and the Client connected to a running LocalCluster.
-See dask documentation for how to: // TODO add link
-- Each worker is an independent python process and memory_limit is set for each of these process.
-If you have 16GB of RAM don't set ``memory_limit='16GB'`` unless you run a single worker.
-- Memory sharing is much more efficient between threads than between processes.
-- Threads number is usually optimal when it's a multiple of your CPU cores (usually *2).
-- All threads of the same worker are waiting whenever one of the thread is reading or writing on disk.
+See dask documentation for how to: http://distributed.dask.org/en/stable/client.html
+- Each worker is an independent python process and memory_limit is set for each of these processes.
+So, if you have 16GB of RAM don't set ``memory_limit='16GB'`` unless you run a single worker.
+- Memory sharing is much more efficient between threads than between processes (workers).
+- On a single worker a good threads number can be a multiple of your CPU cores (usually *2).
+- All threads of the same worker are idle whenever one of the thread is reading or writing on disk.
 - It's useless to spawn too many threads, there are hardware limits on how many of them can run concurrently
-and if they are numerous, the OS will waste time orchestrating them.
-- A dask worker may write to disk some of their data even if it is far form reaching the memory limit.
-This seems to be a normal behavior when dask knows some intermediary results will not be used soon.
-This can significantly slow down the computation due to i/o.
-- Percentiles based indices may use up to ``nb_thread * chunk_size * 30`` memory which is unusually high for a
-dask application. We are trying to reduce this memory footprint but it means some costly rechunking in the middle of
+and if they are too numerous, the OS will waste time orchestrating them.
+- A dask worker may write to disk some of its data even if the memory limit is not reached.
+This seems to be a normal behavior happening when dask knows some intermediary results will not be used soon.
+However, this can significantly slow down the computation due to i/o.
+- Percentiles based indices may need up to ``nb_thread * chunk_size * 30`` memory which is unusually high for a
+dask application. We are trying to reduce this memory footprint but it means some costly re-chunking in the middle of
 computation have to be made.
 
-Knowing these we can consider multiple scenarios.
+Knowing all these, we can consider a few scenarios.
 
 Low memory footprint
 ~~~~~~~~~~~~~~~~~~~~
-
 Let's suppose you want to compute indices on your laptop while continue to work on other subjects.
 You should configure your local cluster to use not too many threads and processes and to limit the amount of memory
-each process (worker) has.
+each process (worker) has available.
 On my 4 cores, 16GB of RAM laptop I would consider:
 
 >>> client = Client(memory_limit='10GB', n_workers=1, threads_per_worker=4)
 
-Eventually, to reduce the amount of i/o we can also increase dask memory thresholds:
+Eventually, to reduce the amount of i/o on disk we can also increase dask memory thresholds:
 
 >>> dask.config.set({"distributed.worker.memory.target": "0.8"})
 >>> dask.config.set({"distributed.worker.memory.spill": "0.9"})
@@ -197,54 +209,59 @@ Eventually, to reduce the amount of i/o we can also increase dask memory thresho
 These thresholds are fractions of memory_limit used by dask to take a decision.
 Here, at 80% of memory the worker will write to disk its unmanaged memory.
 At 90%, the worker will write all its memory to disk.
-At 95%, the worker pause computation to focus on writing.
+At 95%, the worker pause computation to focus on writing to disk.
 At 98%, the worker is killed to avoid reaching memory limit.
-Increasing these threshold has a risk, because they could be filled quicker than expected resulting in a killed worker
+Increasing these thresholds has a risk. The memory could be filled quicker than expected resulting in a killed worker
 and thus loosing all work done by this worker.
-If a single worker is running, the whole computation will be restarted (and will likely reach the same memory limit).
+If a single worker is running and it is killed, the whole computation will be restarted (and will likely reach the same
+memory limit).
 
-High ressource use
-~~~~~~~~~~~~~~~~~~
-If you want to have the result as quickly as possible without risking
+High resource use
+~~~~~~~~~~~~~~~~~
+If you want to have the result as quickly as possible it's a good idea to give dask the necessary resources.
+However this may render your computer "laggy".
 On my 4 cores, 16GB of RAM laptop I would consider:
 
 >>>client = Client(memory_limit='16GB', n_workers=1, threads_per_worker=8)
 
 On this kind of configuration, it can be useful to add 1 or 2 workers in case a lot of i/o is necessary.
-It can also be necessary to reduce chunk size, dask default value is around 100 MB which on some indices
-may fill all the memory.
+But memory_limit should be reduced if there are multiple workers on the same computer.
+It can also be necessary to reduce chunk size, dask default value is around 100 MB which on some complex indices
+may result in a large memory usage.
 
 It's over 9000!
 ~~~~~~~~~~~~~~~
-
 This configuration may put your computer to its knees, use it at your own risk.
 The idea is to bypass all memory safety implemented by dask.
 This may yield very good performances because there will be no i/o on disk by dask itself.
-However, when your OS run out of RAM, it will use your disk swap which is very similar to dask spilling mechanism but probably slower.
+However, when your OS run out of RAM, it will use your disk swap which is similar to dask spilling mechanism but
+probably much slower.
 And if you run out of swap, your computer will likely crash.
-To roll the dices use the following configuration
+To roll the dices use the following configuration ``memory_limit='0'`` in :
+
 >>>client = Client(memory_limit='0')
-Dask will spawn multiple processes without memory limits and each process will spawn multiple threads.
+
+Dask will spawn a worker with multiple threads without memory limits.
 
 Large to huge dataset (1GB and above)
 ------------------------------------
+If you which to compute climate indices of a large datasets, a personal computer is probably be inappropriate.
+In that case you can deploy a real dask cluster as opposed to the LocalCluster.
+You can find more information on how to deploy dask cluster here: https://docs.dask.org/en/stable/scheduling.html#dask-distributed-cluster
 
-If you which to compute climate indices on a large dataset a personal computer is probably be inappropriate.
-In that case you can deploy a "real" dask cluster opposed to the LocalCluster.
-You can find more information on how to deploy dask cluster here: //TODO add link to cloud dask
-
-If you must run your computation on limited ressources, you can try to:
-- Use only one or two threads on a single worker
+If you must run your computation on limited resources, you can try to:
+- Use only one or two threads on a single worker.
 This will drastically slow down the computation but very few chunks will be in memory at once letting you use quite large chunks.
-- Use small chunk size, but beware the smaller they are the more complex dask graph become.
+- Use small chunk size, but beware the smaller they are the more complex dask graph becomes.
 - Split you data into smaller netcdf inputs and run the computation multiple time.
 This is the most frustrating option because chunking is supposed to do exactly that. But, sometimes
 it can be easier to chunk "by hand" than to find the exact configuration that fit for the input dataset.
+You also want to consider the Pangeo rechunker library to ease this process: https://rechunker.readthedocs.io/en/latest/
 
 Real example
 ------------
 
-On CMIP6 data, when computing the percentile based indices Tx90p for 20 years, bootstrapped on 19 years we used:
+On CMIP6 data, when computing the percentile based indices Tx90p for 20 years and, bootstrapping on 19 years we use:
 >>>client = Client(memory_limit='16GB', n_workers=1, threads_per_worker=2)
 >>>dask.config.set({"array.slicing.split_large_chunks": False})
 >>>dask.config.set({"array.chunk-size": "100 MB"})
@@ -256,51 +273,54 @@ On CMIP6 data, when computing the percentile based indices Tx90p for 20 years, b
 
 Troubleshooting and dashboard analysis
 --------------------------------------
-
 This section describe common warnings and errors that dask can raise.
 There are also some silent issues that dask dashboard can expose.
-A dashboard is started when running the distributed ``Client(...)``.
-
+A dashboard is started when running the distributed ``Client(...)`` and is usually available on ``localhost:8787``.
 
 Memory overload
 ~~~~~~~~~~~~~~~
-The warning may be "distributed.nanny - WARNING - Restarting worker" or the error "KilledWorker".
-This means the computation uses more memory than what is available.
+The warning may be ``"distributed.nanny - WARNING - Restarting worker"`` or the error ``"KilledWorker"``.
+This means the computation uses more memory than what is available for the worker.
 Keep in mind that:
-- memory_limit parameter is the limit of each individual workers
-- Some indices, such as percentile based indices (R__p, T_90p, T_10p families) may use large amount of memory.
-- You can reduce memory footprint by using smaller chunk
+- ``memory_limit`` parameter is a limit set for each individual worker.
+- Some indices, such as percentile based indices (R__p, R__pTOT, T_90p, T_10p families) may use large amount of memory.
+This is especially true on temperature based indices where percentiles are bootstrapped.
+- You can reduce memory footprint by using smaller chunks.
 - Each thread may load multiple chunks in memory at once.
-To solve this issue, you must either provide additional available memory or reduce the quantity of memory used.
-You can increase memory_limit up to your physical memory available (RAM) with ``Client(memory_limit="16GB")``,
-this may speed up computation by reducing writes and reads on disk.
+To solve this issue, you must either increase available memory per worker or reduce the quantity of memory used by the computation.
+You can increase memory_limit up to your physical memory available (RAM) with ``Client(memory_limit="16GB")``.
+This increase can also speed up computation by reducing writes and reads on disk.
 You can reduce the number of concurrently running threads (and workers) in the distributed Client configuration with
 ``Client(n_workers=1, threads_per_worker=1)``. This may slow down computation.
 You can reduce the size of each chunk with ``dask.config.set({"array.chunk-size": "50 MB"})``, default is around 100MB.
 This may slow down computation as well.
-Or you can combine all three solutions above.
-
+Or you can combine the three solutions above.
+You can read more on this issue here: http://distributed.dask.org/en/stable/killed.html
 
 Garbage collection "wasting" CPU time
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The warning would be: ``distributed.utils_perf - WARNING - full garbage collections took xx% CPU time recently (threshold: 10%)``
 This is usually accompanied by: ``distributed.worker - WARNING - gc.collect() took 1.259s. This is usually a sign that some tasks handle too many Python objects at the same time. Rechunking the work into smaller tasks might help.``
-Python runs on a virtual machine (VM) which handles the memory allocation of objects for us.
+Python runs on a virtual machine (VM) which handles the memory allocations for us.
 This means the VM sometimes needs to cleanup garbage objects that aren't referenced anymore.
-This operation takes some CPU ressource but free the RAM for other uses.
-In our dask context, the warning may be raised when icclim/xclim has created large chunks which takes longer to be garbage collected.
+This operation takes some CPU resource but free the RAM for other uses.
+In our dask context, the warning may be raised when icclim/xclim has created large chunks which takes longer to be
+garbage collected.
+This warning means some CPU is wasted but the computation is still running.
+It might help to re-chunk into smaller chunk.
 
 Internal re-chunking
 ~~~~~~~~~~~~~~~~~~~~
 The warning would be: ``PerformanceWarning: Increasing number of chunks by factor of xx``.
 This warning is usually raised when computing percentiles.
-In this step, the input in base data used to compute the percentile grow significantly.
-First, because of the rolling window the input data size is multiplied by window size.
-Then, on temperatures indices such as Tx90p, we compute values for each day of year(doy).
-This means we need for each to read all years of in_base thus usually all chunks of time dimension.
-To avoid consuming all RAM at once we rechunk the doy values to the initial chunking size but
-dask warns us that it creates quite a few new chunks.
-This warning should not be a serious issue and can be ignored.
+In percentiles calculus step, the data used to compute the percentile grow significantly in-memory.
+First, because of the rolling window used to retrieve all values of each day, the analysed data is multiplied by
+window size (usually by 5).
+Then, on temperatures indices such as Tx90p, we compute percentiles for each day of year (doy).
+This means we must read almost all chunks of time dimension.
+To avoid consuming all RAM at once with this, icclim/xclim internally re-chunk data that's why dask warns
+that many chunks are being created.
+In that case this warning can be ignored.
 
 Computation never start
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -308,31 +328,31 @@ The error raised can be ``CancelledError``.
 We can also acknowledge this by looking at dask dashboard and not seeing any task being schedule.
 This usually means dask graph is too big and the scheduler has trouble creating it.
 If your memory allows it, you can try to increase the chunk-size with ``dask.config.set({"array.chunk-size": "200 MB"})``.
-This will reduce the amount of task created by dask thus reducing graph size.
+This will reduce the amount of task created on dask graph.
 To compensate, you may need to reduce the number of running threads with ``Client(n_workers=1, threads_per_worker=2)``.
 This should help limit the memory footprint of the computation.
 
 .. Note::
 
     Beware, if the computation is fast or if the client is not started in the same python process as icclim,
-    the dashboard may also look empty.
+    the dashboard may also look empty but the computation is actually running.
 
 Disk read and write analysis - Dashboard
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-When poorly configured, the computation can spend most of it's CPU time reading and writing chunks on disk.
-You can visualize if it is the case for you by opening dask dashboard (it should be on ``localhost:8787``).
+When poorly configured, the computation can spend most of its CPU time reading and writing chunks on disk.
+You can visualize this case by opening dask dashboard, usually on ``localhost:8787``.
 In the status page, you can see in the right panel each task dynamically being added.
 In these the colourful boxes, each color represent a specific task.
-I/O on disk is displayed as orange transparent boxes. You should also see all other thread of the same worker
-stopping when on thread is reading or writing on disk.
-If there are a lot of i/o you may need to reconfigure dask for futur runs.
+I/O on disk is displayed as orange transparent boxes. You should also see all other threads of the same worker
+stopping when one thread is reading or writing on disk.
+If there is a lot of i/o you may need to reconfigure dask.
 The solution to this are similar to the memory overload described above.
 You can increase total available memory with ``Client(memory_limit="16GB")``.
 You can decrease memory pressure by reducing chunk size with ``dask.config.set({"array.chunk-size": "50 MB"})`` or
 by reducing number of threads with ``Client(n_workers=1, threads_per_worker=2)``.
 Beside, you can also benefit from using multiple worker in this case.
 Each worker is a separate non blocking process thus they are not locking each other when one of them need to write or
-read on disk. They are however slower than thread to share memory, this can result in the "chatterbox" issue presented
+read on disk. They are however slower than threads to share memory, this can result in the "chatterbox" issue presented
 below.
 
 .. Note::
@@ -346,16 +366,15 @@ In all this document, we mainly recommend to use a single worker with multiple t
 Most of the code icclim runs is relying on dask and numpy, and both release the python GLI (More details on GIL here: https://realpython.com/python-gil/).
 This means we can benefit from multi threading and that's why we usually recommend to use a single process (worker) with
 multiple threads.
-However, some configuration can benefit from spawning multiple workers.
-In dask dashboard, you will see red transparent boxes representing the worker communication.
-If you see a lot of these and especially if they do not overlap with other task, it means the workers are
+However, some configuration can benefit from spawning multiple processes (workers).
+In dask dashboard, you will see red transparent boxes representing the workers communicating between each other.
+If you see a lot of these and if they do not overlap much with other tasks, it means the workers are
 spending most of their CPU times exchanging data.
 This can be caused by either:
-    1. there are too many workers for the amount of work
-    2. the load balancing has a lot to do.
+    1. Too many workers are spawned for the amount of work.
+    2. The load balancer has a lot of work to do.
 In the first case, the solution is simply to reduce the number of workers and eventually to increase the number of
 threads per worker.
-// TODO verify these claims and find a source
 For the second case, when a worker has been given too many task to do, the load balancer is charged of
 redistributing these task to other worker. It can happen when some task take significant time to be processed.
 In icclim/xclim this is for example the case of the ``cal_perc`` function used to compute percentiles.
@@ -364,16 +383,19 @@ There is no easy solution for this case, letting the load balancer do its job se
 Idle threads
 ~~~~~~~~~~~~
 When looking at dask dashboard, the task timelines should be full of colors.
-If you see a lot of emptiness between colored boxes, it means your thread are doing nothing.
-It could be because a blocking operation is in progress (e.g i/o on disk).
-To fix this, you may report to `Disk read and write analysis - Dashboard`_ above.
-It could also be because you have too many available threads and the work cannot be properly divided
-between each thread.
-In that case, you can simply reduce the number of thread in Clint configuration with ``Client(n_workers=1, threads_per_worker=4)``.
+If you see a lot of emptiness between colored boxes, it means the threads are not doing anything.
+It could be caused by a blocking operation in progress (e.g i/o on disk).
+Read `Disk read and write analysis - Dashboard`_ above in that case.
+It could also be because you have set too many threads and the work cannot be properly divided between each thread.
+In that case, you can simply reduce the number of thread in Client configuration with ``Client(n_workers=1, threads_per_worker=4)``.
 
 Conclusion
 ----------
 
-We can't provide a single configuration which fits all possible datasets.
+We can't provide a single configuration which fits all possible datasets and climate indices.
 In this document we tried to summarize the few configurations we found useful while developing icclim.
-You will need to tailor these to your own needs.
+You still need to tailor these configuration to your own needs.
+
+.. Note::
+    This document has been rewritten in january 2022 and the whole stack under icclim is evolving rapidly.
+    Some information presented here might become outdated quickly.

--- a/doc/source/how_to/dask.rst
+++ b/doc/source/how_to/dask.rst
@@ -8,12 +8,12 @@ You can configure dask to limit its memory footprint and CPu usage by instantiat
 dask.config options.
 A configuration working well for small to medium dataset and simple climate indices is :
 
->>>import dask
->>>from distributed import Client
->>>client = Client(memory_limit='10GB', n_workers=1, threads_per_worker=8)
->>>dask.config.set({"array.slicing.split_large_chunks": False})
->>>dask.config.set({"array.chunk-size": "100 MB"})
->>>icclim.index(in_files="data.nc", indice_name='SU', out_file="output.nc")
+>>> import dask
+>>> from distributed import Client
+>>> client = Client(memory_limit='10GB', n_workers=1, threads_per_worker=8)
+>>> dask.config.set({"array.slicing.split_large_chunks": False})
+>>> dask.config.set({"array.chunk-size": "100 MB"})
+>>> icclim.index(in_files="data.nc", indice_name='SU', out_file="output.nc")
 
 ------------------------------------------------------------------------------------------------
 
@@ -27,37 +27,38 @@ in-memory at once, it can bring back memory issues that chunking was meant to av
 
 In this document we first explain some concepts around dask, parallelization and performances, then we propose multiple
 dask configurations to be used with icclim.
-At the bottom, you can also find a few dask pitfall dodging instructions which might help understanding why your
-computation doesn't run.
+You will also find a few dask pitfall dodging instructions which might help understanding why your computation doesn't run.
 Each configuration aims to answer a specific scenario. For you own data, you will likely need to customize these
 configurations to your needs.
 
 The art of chunking
 -------------------
 Dask proposes a way to divide large dataset into multiple smaller chunks that fit in memory.
-This process is known as chunking and with icclim there are 2 ways to control it.
+This process is known as chunking and, with icclim there are 2 ways to control it.
 First, you can open your dataset with xarray and do your own chunking:
 
->>>import xarray
->>>import icclim
->>>ds = xarray.open_dataset("data.nc")
->>>ds = ds.chunk({"time": 10, "lat": 20, "lon": 20})
+>>> import xarray
+>>> import icclim
+>>> ds = xarray.open_dataset("data.nc")
+>>> ds = ds.chunk({"time": 10, "lat": 20, "lon": 20})
 
 And then use ``ds`` dataset object as input for icclim.
 
->>>icclim.index(in_files=ds, indice_name='SU', out_file="output.nc")
+>>> icclim.index(in_files=ds, indice_name='SU', out_file="output.nc")
 
 In that case, icclim will not re-chunk ``ds`` data. It is left to you to find the proper chunking.
 For more information on how to properly chunk see:
-- xarray guide: https://xarray.pydata.org/en/stable/user-guide/dask.html#chunking-and-performance
-- dask best practices: https://docs.dask.org/en/stable/array-best-practices.html
+
+* xarray guide: https://xarray.pydata.org/en/stable/user-guide/dask.html#chunking-and-performance
+* dask best practices: https://docs.dask.org/en/stable/array-best-practices.html
+
 Another option is to leave dask find the best chunking for each dimension.
-This is the recommended way and the default behavior of icclim when using file path inputs.
+This is the recommended way and the default behavior of icclim when using file a path in `in_files` parameter.
 In this case, chunking can still be controlled by limiting the size of each individual chunk:
 
->>>import dask
->>>dask.config.set({"array.chunk-size": "50 MB"})
->>>icclim.index(in_files="data.nc", ...)
+>>> import dask
+>>> dask.config.set({"array.chunk-size": "50 MB"})
+>>> icclim.index(in_files="data.nc", ...)
 
 By default, the dask chunk-size is around 100MB.
 You can also use ``with`` python keyword if you don't want this configuration to spread globally.
@@ -69,31 +70,37 @@ to their initial value but re-chunking is costly and we sometimes prefer to gene
 performances.
 If you wish to avoid this large chunking behavior, you can try the following dask configuration:
 
->>>dask.config.set({"array.slicing.split_large_chunks": True})
+>>> dask.config.set({"array.slicing.split_large_chunks": True})
 
 On performances
 ---------------
 Computation of ECA&D indices can largely be done in parallel on spatial dimensions.
-Indeed, each of these indices are relying on a time series for each pixel. Thus, in a ideal world we could compute
-each pixel independently. In reality this would usually result in a considerable amount of chunks.
-This is not optimal because the smaller each chunk is, the greater dask overhead is.
-By overhead, we mean here the necessary python code running to move around and handle each independent chunk.
-Plus, unless running on cloud or a HPC, we are limited by the number of cores available, so we physically can't
-parallelize everything.
-Another important aspect of dask to consider for performances is the task graph. Dask creates a graph of all the actions
-(tasks) it must accomplish to compute the calculation. This graph, created before the computation, shows for each chunk
-the route to follow in order to compute the climat index.
+Indeed, the 49 ECA&D indices in icclim are all computed on each individual pixel independently.
+In a ideal world it means we could compute each pixel concurrently.
+In reality this would result in considerable efforts necessary to chunk data that much, this would be sub-optimal
+because the smaller chunk are, the greater dask overhead is.
+
+.. note::
+
+    By overhead, we mean here the necessary python code running to move around and handle each independent chunk.
+
+Another important aspect of dask to consider for performances is the generated task graph.
+Dask creates a graph of all the actions (tasks) it must accomplish to compute the calculation.
+This graph, created before the computation, shows for each chunk the route to follow in order to compute the climat index.
 This allows some nice optimizations, for example if some spatial or time selections are done within icclim/xclim, it
 will only read and load in-memory the necessary data.
-However, each task also add some overhead and, most of the time a small graph with a few tasks will compute faster.
-Plus, each chunk has it's own route in the graph, and the more there are chunks the more routes are created.
+However, each task also adds some overhead and, most of the time a small graph will compute faster than a larger.
+
+In this graph each chunk has it's own route of all the intermediary transformation it goes though.
+The more there are chunks the more routes are created.
 In extreme cases, when there are a lot of chunks, the graph may take eons to create and the computation may never start.
-This means that configuring a small chunk size leads to numerous chunks being created and thus to a potentially large
-graph. The graph is also dependant on the actual computation. A climate index like "SU" (count of days above 25ºC)
+This means that configuring a small chunk size leads to a potentially large graph.
+
+The graph is also dependant of the actual calculation. A climate index like "SU" (count of days above 25ºC)
 will obviously create a much simpler graph than WSDI (longest spell of at least 6 consecutive days where maximum daily
 temperature is above the 90th daily percentile).
 Finally the resampling may also play a role in the graph complexity. In icclim we control it with ``slice_mode`` parameter.
-A Yearly slice_mode likely be simpler than a monthly one.
+A yearly slice_mode sampling result in a simpler graph than a monthly sampling.
 
 Beside, when starting dask on a limited system (e.g a laptop) it's quite easy to exhaust all available memory.
 In that case, dask has multiple safety mechanism and can even kill the computing process (a.k.a the worker) once it
@@ -103,29 +110,33 @@ When a worker uses around 60% of its memory, dask will ask it to write to disk t
 These i/o operations are much slower than in RAM manipulation, even on recent SSD disk.
 
 
-Hence, there are multiple things to consider to maximize performances:
+Hence, there are multiple things to consider to maximize performances.
+
 First, if your data (and the intermediary computation) fits in memory, it might be better to use Numpy backend directly.
 To do so, simply provide the opened dataset to icclim:
 
->>>ds = xarray.open_dataset("data.nc")
->>>icclim.index(in_files=ds, indice_name='SU', out_file="output.nc")
+>>> ds = xarray.open_dataset("data.nc")
+>>> icclim.index(in_files=ds, indice_name='SU', out_file="output.nc")
 
 There will be no parallelization but, on small dataset it's unnecessary. Numpy is natively really fast and dask overhead
 may slow it downs.
 
 On the other hand when using dask we must:
-- Minimize the number of task to speed things up, thus divide data into **large enough chunks**.
-- Minimize the workload of each worker to avoid i/o operation, thus divide data into **small enough chunks**.
+
+* Minimize the number of task to speed things up, thus divide data into **large enough chunks**.
+* Minimize the workload of each worker to avoid i/o operation, thus divide data into **small enough chunks**.
+
 In the following we present a few possible configuration for dask.
 
 
 Small to medium dataset (a few MB) - No configuration
 -----------------------------------------------------
 The first approach is to use default values.
-By default icclim relies on dask's "auto" chunking and dask will be started with the threading scheduler.
+By default icclim relies on dask's ``"auto"`` chunking and dask will be started with the threading scheduler.
 This scheduler runs everything in the existing python process and will spawn multiple threads
 to concurrently compute climate indices.
 You can find more information on the default scheduler here: https://docs.dask.org/en/stable/scheduling.html#local-threads
+
 This can work on most cases for small to medium datasets and may yield the best performances.
 However some percentiles based temperature indices (T_90p and T_10p families) may use a lot of memory even on medium datasets.
 This memory footprint is caused by the bootstrapping of percentiles, an algorithm used to correct statistical biais.
@@ -134,7 +145,7 @@ The longer the bootstrap period is, the more resources are necessary. The bootst
 between the period where percentile are computed (a.k.a "in base") and the period where the climate index is computed
 (a.k.a "out of base").
 
-.. Notes::
+.. note::
 
     To control the "in base" period, ``icclim.index`` provides the ``base_period_time_range`` parameter.
     To control the "out of base" period, ``icclim.index`` provides the ``time_range`` parameter.
@@ -147,46 +158,45 @@ By default, dask will run on a default threaded scheduler.
 This behavior can be overwritten by creating you own "cluster" running locally on your machine.
 This LocalCluster is distributed in a separate dask package called "distributed" and is not a mandatory
 dependency of icclim.
+
 To install it run:
 
 >>> conda install dask distributed -c conda-forge
 
 See the documentation for more details: http://distributed.dask.org/en/stable/
+
 Once installed, you can delegate the ``LocalCluster`` instantiation using `distributed.Client` class.
 This ``Client`` object creates both a ``LocalCluster`` and a web application to investigate how your computation is going.
-This web dashboard is very useful to understand where are the computation bottlenecks and to visualize how dask is working.
+This web dashboard is very powerful and helps to understand where are the computation bottlenecks as well as to visualize how dask is working.
 By default it runs on ``localhost:8787``, you can print the client object to see on which port it runs.
 
 >>> from distributed import Client
 >>> client = Client()
+>>> print(client)
+
 By default dask creates a ``LocalCluster`` with 1 worker (process), CPU count threads and a memory limit up to
 the system available memory.
-You can see how cpu are counted here: https://github.com/dask/dask/blob/main/dask/system.py
-And how default memory is computed here: https://github.com/dask/distributed/blob/main/distributed/worker.py#L4237
-Note that depending on your running OS, these values are not exactly computed the same way.
+
+.. note::
+    You can see how dask counts CPU here: https://github.com/dask/dask/blob/main/dask/system.py
+    How dask measures available memory here: https://github.com/dask/distributed/blob/main/distributed/worker.py#L4237
+    Depending on your OS, these values are not exactly computed the same way.
 
 The cluster can be configured directly through Client arguments.
 
 >>> client = Client(memory_limit='16GB', n_workers=1, threads_per_worker=8)
 
 A few notes:
-- The CLient must be started in the same python interpreter as the computation. This is how dask know which scheduler
-to use.
-- If needed, the localCluster can be started independently and the Client connected to a running LocalCluster.
-See dask documentation for how to: http://distributed.dask.org/en/stable/client.html
-- Each worker is an independent python process and memory_limit is set for each of these processes.
-So, if you have 16GB of RAM don't set ``memory_limit='16GB'`` unless you run a single worker.
-- Memory sharing is much more efficient between threads than between processes (workers).
-- On a single worker a good threads number can be a multiple of your CPU cores (usually *2).
-- All threads of the same worker are idle whenever one of the thread is reading or writing on disk.
-- It's useless to spawn too many threads, there are hardware limits on how many of them can run concurrently
-and if they are too numerous, the OS will waste time orchestrating them.
-- A dask worker may write to disk some of its data even if the memory limit is not reached.
-This seems to be a normal behavior happening when dask knows some intermediary results will not be used soon.
-However, this can significantly slow down the computation due to i/o.
-- Percentiles based indices may need up to ``nb_thread * chunk_size * 30`` memory which is unusually high for a
-dask application. We are trying to reduce this memory footprint but it means some costly re-chunking in the middle of
-computation have to be made.
+
+* The CLient must be started in the same python interpreter as the computation. This is how dask know which scheduler to use.
+* If needed, the localCluster can be started independently and the Client connected to a running LocalCluster. See: http://distributed.dask.org/en/stable/client.html
+* Each worker is an independent python process and memory_limit is set for each of these processes. So, if you have 16GB of RAM don't set ``memory_limit='16GB'`` unless you run a single worker.
+* Memory sharing is much more efficient between threads than between processes (workers).
+* On a single worker, a good threads number should be a multiple of your CPU cores (usually \*2).
+* All threads of the same worker are idle whenever one of the thread is reading or writing on disk.
+* It's useless to spawn too many threads, there are hardware limits on how many of them can run concurrently and if they are too numerous, the OS will waste time orchestrating them.
+* A dask worker may write to disk some of its data even if the memory limit is not reached. This seems to be a normal behavior happening when dask knows some intermediary results will not be used soon. However, this can significantly slow down the computation due to i/o.
+* Percentiles based indices may need up to **nb_thread * chunk_size * 30** memory which is unusually high for a dask application. We are trying to reduce this memory footprint but it means some costly re-chunking in the middle of computation have to be made.
 
 Knowing all these, we can consider a few scenarios.
 
@@ -207,54 +217,57 @@ Eventually, to reduce the amount of i/o on disk we can also increase dask memory
 >>> dask.config.set({"distributed.worker.memory.terminate": "0.98"})
 
 These thresholds are fractions of memory_limit used by dask to take a decision.
-Here, at 80% of memory the worker will write to disk its unmanaged memory.
-At 90%, the worker will write all its memory to disk.
-At 95%, the worker pause computation to focus on writing to disk.
-At 98%, the worker is killed to avoid reaching memory limit.
-Increasing these thresholds has a risk. The memory could be filled quicker than expected resulting in a killed worker
+
+* At 80% of memory the worker will write to disk its unmanaged memory.
+* At 90%, the worker will write all its memory to disk.
+* At 95%, the worker pause computation to focus on writing to disk.
+* At 98%, the worker is killed to avoid reaching memory limit.
+
+Increasing these thresholds is risky. The memory could be filled quicker than expected resulting in a killed worker
 and thus loosing all work done by this worker.
 If a single worker is running and it is killed, the whole computation will be restarted (and will likely reach the same
 memory limit).
 
-High resource use
-~~~~~~~~~~~~~~~~~
-If you want to have the result as quickly as possible it's a good idea to give dask the necessary resources.
-However this may render your computer "laggy".
-On my 4 cores, 16GB of RAM laptop I would consider:
+High resources use
+~~~~~~~~~~~~~~~~~~
+If you want to have the result as quickly as possible it's a good idea to give dask all possible resources.
+This may render your computer "laggy" thought.
+On my 4 cores (8 CPU threads), 16GB of RAM laptop I would consider:
 
->>>client = Client(memory_limit='16GB', n_workers=1, threads_per_worker=8)
+>>> client = Client(memory_limit='16GB', n_workers=1, threads_per_worker=8)
 
 On this kind of configuration, it can be useful to add 1 or 2 workers in case a lot of i/o is necessary.
-But memory_limit should be reduced if there are multiple workers on the same computer.
-It can also be necessary to reduce chunk size, dask default value is around 100 MB which on some complex indices
-may result in a large memory usage.
+If there are multiple workers ``memory_limit`` should be reduced accordingly.
+It can also be necessary to reduce chunk size. dask default value is around 100 MB per chunk which on some complex
+indices may result in a large memory usage.
 
 It's over 9000!
 ~~~~~~~~~~~~~~~
 This configuration may put your computer to its knees, use it at your own risk.
 The idea is to bypass all memory safety implemented by dask.
 This may yield very good performances because there will be no i/o on disk by dask itself.
-However, when your OS run out of RAM, it will use your disk swap which is similar to dask spilling mechanism but
+However, when your OS run out of RAM, it will use your disk swap which is sort of similar to dask spilling mechanism but
 probably much slower.
 And if you run out of swap, your computer will likely crash.
 To roll the dices use the following configuration ``memory_limit='0'`` in :
 
->>>client = Client(memory_limit='0')
+>>> client = Client(memory_limit='0')
 
-Dask will spawn a worker with multiple threads without memory limits.
+Dask will spawn a worker with multiple threads without any memory limits.
 
 Large to huge dataset (1GB and above)
-------------------------------------
-If you which to compute climate indices of a large datasets, a personal computer is probably be inappropriate.
+-------------------------------------
+If you which to compute climate indices of a large datasets, a personal computer is probably inappropriate.
 In that case you can deploy a real dask cluster as opposed to the LocalCluster.
 You can find more information on how to deploy dask cluster here: https://docs.dask.org/en/stable/scheduling.html#dask-distributed-cluster
 
 If you must run your computation on limited resources, you can try to:
-- Use only one or two threads on a single worker.
-This will drastically slow down the computation but very few chunks will be in memory at once letting you use quite large chunks.
-- Use small chunk size, but beware the smaller they are the more complex dask graph becomes.
-- Split you data into smaller netcdf inputs and run the computation multiple time.
-This is the most frustrating option because chunking is supposed to do exactly that. But, sometimes
+
+* Use only one or two threads on a single worker. This will drastically slow down the computation but very few chunks will be in memory at once letting you use quite large chunks.
+* Use small chunk size, but beware the smaller they are the more complex dask graph becomes.
+* Split you data into smaller netcdf inputs and run the computation multiple time.
+
+The last point is the most frustrating option because chunking is supposed to do exactly that. But, sometimes
 it can be easier to chunk "by hand" than to find the exact configuration that fit for the input dataset.
 You also want to consider the Pangeo rechunker library to ease this process: https://rechunker.readthedocs.io/en/latest/
 
@@ -262,13 +275,14 @@ Real example
 ------------
 
 On CMIP6 data, when computing the percentile based indices Tx90p for 20 years and, bootstrapping on 19 years we use:
->>>client = Client(memory_limit='16GB', n_workers=1, threads_per_worker=2)
->>>dask.config.set({"array.slicing.split_large_chunks": False})
->>>dask.config.set({"array.chunk-size": "100 MB"})
->>>dask.config.set({"distributed.worker.memory.target": "0.8"})
->>>dask.config.set({"distributed.worker.memory.spill": "0.9"})
->>>dask.config.set({"distributed.worker.memory.pause": "0.95"})
->>>dask.config.set({"distributed.worker.memory.terminate": "0.98"})
+
+>>> client = Client(memory_limit='16GB', n_workers=1, threads_per_worker=2)
+>>> dask.config.set({"array.slicing.split_large_chunks": False})
+>>> dask.config.set({"array.chunk-size": "100 MB"})
+>>> dask.config.set({"distributed.worker.memory.target": "0.8"})
+>>> dask.config.set({"distributed.worker.memory.spill": "0.9"})
+>>> dask.config.set({"distributed.worker.memory.pause": "0.95"})
+>>> dask.config.set({"distributed.worker.memory.terminate": "0.98"})
 
 
 Troubleshooting and dashboard analysis
@@ -282,11 +296,12 @@ Memory overload
 The warning may be ``"distributed.nanny - WARNING - Restarting worker"`` or the error ``"KilledWorker"``.
 This means the computation uses more memory than what is available for the worker.
 Keep in mind that:
-- ``memory_limit`` parameter is a limit set for each individual worker.
-- Some indices, such as percentile based indices (R__p, R__pTOT, T_90p, T_10p families) may use large amount of memory.
-This is especially true on temperature based indices where percentiles are bootstrapped.
-- You can reduce memory footprint by using smaller chunks.
-- Each thread may load multiple chunks in memory at once.
+
+* ``memory_limit`` parameter is a limit set for each individual worker.
+* Some indices, such as percentile based indices (R__p, R__pTOT, T_90p, T_10p families) may use large amount of memory. This is especially true on temperature based indices where percentiles are bootstrapped.
+* You can reduce memory footprint by using smaller chunks.
+* Each thread may load multiple chunks in memory at once.
+
 To solve this issue, you must either increase available memory per worker or reduce the quantity of memory used by the computation.
 You can increase memory_limit up to your physical memory available (RAM) with ``Client(memory_limit="16GB")``.
 This increase can also speed up computation by reducing writes and reads on disk.
@@ -371,8 +386,10 @@ In dask dashboard, you will see red transparent boxes representing the workers c
 If you see a lot of these and if they do not overlap much with other tasks, it means the workers are
 spending most of their CPU times exchanging data.
 This can be caused by either:
-    1. Too many workers are spawned for the amount of work.
-    2. The load balancer has a lot of work to do.
+
+# Too many workers are spawned for the amount of work.
+# The load balancer has a lot of work to do.
+
 In the first case, the solution is simply to reduce the number of workers and eventually to increase the number of
 threads per worker.
 For the second case, when a worker has been given too many task to do, the load balancer is charged of

--- a/doc/source/how_to/index.rst
+++ b/doc/source/how_to/index.rst
@@ -13,6 +13,7 @@ To find more in depth technical knowledge see :ref:`references`.
     :maxdepth: 2
     :caption: Contents:
 
+    Chunk data and parallelize computation <dask>
     Jupyter notebooks <notebooks>
     Compute ECA&D indices <recipes_ecad>
     Customize indices <recipes_custom>

--- a/doc/source/references/ecad_functions_api.rst
+++ b/doc/source/references/ecad_functions_api.rst
@@ -1,5 +1,6 @@
-ECAD functions to compute indices
-=================================
+ECA&D functions to compute indices
+==================================
+
 The `icclim.models.ecad_indices.py <https://github.com/cerfacs-globc/icclim/blob/master/icclim/models/ecad_indices.py>`_
 module contains the enumeration of all ECA&D indices icclim can compute.
 

--- a/doc/source/references/release_notes.rst
+++ b/doc/source/references/release_notes.rst
@@ -2,16 +2,6 @@ Release history
 ===============
 
 
-5.1.0 (not released)
---------------------
-* [maint] Refactored ecad_functions (removed duplicated code, simplified function signatures...)
-* [maint] Refactored IndexConfig to hide some technical knowledge which was leaked to other modules.
-* [maint] Made a basic integration of clix-meta yaml to populate the generated docstring for c3s.
-* [maint] This makes pyyaml an required dependency of icclim.
-* [fix] Fixed an issue with aliasing of "icclim" module and "icclim" package
-* [maint] Added some metadata to qualify the cead_indices and recognize the arguments necessary to compute them.
-
-
 5.0.0rc3 (not released)
 -----------------------
 * [maint] Drop support for python 3.7
@@ -26,6 +16,15 @@ Release history
 * [doc] Various improvements in doc wording and display.
 * [doc] Start to documente ECA&D indices functions.
 * [doc] Add article to distinguish icclim from xclim.
+* [maint] Refactored ecad_functions (removed duplicated code, simplified function signatures...)
+* [maint] Refactored IndexConfig to hide some technical knowledge which was leaked to other modules.
+* [enh] Made a basic integration of clix-meta yaml to populate the generated docstring for c3s.
+* [maint] This makes pyyaml an required dependency of icclim.
+* [fix] Fixed an issue with aliasing of "icclim" module and "icclim" package
+* [maint] Added some metadata to qualify the ecad_indices and recognize the arguments necessary to compute them.
+* [maint] Added readthedocs CI configuration. This is necessary to use python 3.8.
+* [enh] Added `tools/extract-icclim-funs.py` script to extract from icclim stand-alone function for each indices.
+* [enh] Added `icclim.indices` function (notice plural) to list the available indices.
 
 5.0.0rc2
 --------
@@ -44,7 +43,7 @@ We fully rewrote icclim to benefit from Xclim, Xarray, Numpy and Dask.
 A lot of effort has been to minimize the API changes.
 Thus for all scripts using a former version of icclim updating to this new version should be smooth.
 
-In fact, we made a few improvements on the API
+We made a few improvements on the API
     - We replaced everywhere the french singular word "indice" by the proper english "index". You should get a warning if you still use "indice" such as in "indice_name".
     - When ``save_percentile`` is used, the resulting percentiles are saved within the same netcdf file as the climate index.
     - Most of the keywords (such as slice_mode, index_name, are now case insensitive to avoid unnecessary errors.
@@ -66,11 +65,12 @@ Breaking changes
 ~~~~~~~~~~~~~~~~
 Some utility features of icclim has been removed in 5.0.0.
 This include `util.regrid` module as well as `util.spatial_stat` module.
-For regridding, users are encouraged to try  `xESMF <https://pangeo-xesmf.readthedocs.io/en/latest>`_.
+For regridding, users are encouraged to try `xESMF <https://pangeo-xesmf.readthedocs.io/en/latest>`_ or to use xarray
+selection directly.
 For spatial stats, Xarray provides a `DataArrayWeighted <https://xarray.pydata.org/en/stable/generated/xarray.DataArray.weighted.html>`_
 
 
 Notes
 ~~~~~
-It is highly recommended to use Dask distributed scheduler to fully benefit from the performance improvements of version
-5.0.0.
+It is highly recommended to use Dask (eventually with the distributed scheduler) to fully benefit from the performance
+improvements of version 5.0.0.

--- a/doc/source/references/release_notes.rst
+++ b/doc/source/references/release_notes.rst
@@ -1,6 +1,17 @@
 Release history
 ===============
 
+
+5.1.0 (not released)
+--------------------
+* [maint] Refactored ecad_functions (removed duplicated code, simplified function signatures...)
+* [maint] Refactored IndexConfig to hide some technical knowledge which was leaked to other modules.
+* [maint] Made a basic integration of clix-meta yaml to populate the generated docstring for c3s.
+* [maint] This makes pyyaml an required dependency of icclim.
+* [fix] Fixed an issue with aliasing of "icclim" module and "icclim" package
+* [maint] Added some metadata to qualify the cead_indices and recognize the arguments necessary to compute them.
+
+
 5.0.0rc3 (not released)
 -----------------------
 * [maint] Add github templates for issues and pull requests.

--- a/environment.yml
+++ b/environment.yml
@@ -4,17 +4,23 @@ channels:
  - conda-forge
  - defaults
 dependencies:
- - xclim>=0.30
- - numpy>=1.16
- - xarray>=0.17
- - dask>=2.6.0
- - netCDF4>=1.5.7
- - pyyaml>=6.0
- - pre-commit
- - pydata-sphinx-theme
- - pylint
- - pytest
- - sphinx
+ # Core dependencies
+ - xclim
+ - numpy
+ - xarray
+ - dask
+ - netCDF4
+ - pyyaml
+ # Dev dependencies
  - black
  - flake8
  - isort
+ - pip
+ - pre-commit
+ - pylint
+ - pytest
+ - pytest-cov
+ - setuptools
+ # Extra dependencies
+ - matplotlib
+ - cartopy

--- a/environment.yml
+++ b/environment.yml
@@ -9,6 +9,7 @@ dependencies:
  - xarray>=0.17
  - dask>=2.6.0
  - netCDF4>=1.5.7
+ - pyyaml>=6.0
  - pre-commit
  - pydata-sphinx-theme
  - pylint

--- a/icclim/__init__.py
+++ b/icclim/__init__.py
@@ -1,4 +1,4 @@
 # keep line below to expose "main" content in icclim package namespace
-from .main import index, indice
+from .main import index, indice, indices
 
 __version__ = "5.0.0rc3"

--- a/icclim/__init__.py
+++ b/icclim/__init__.py
@@ -1,4 +1,4 @@
 # keep line below to expose "main" content in icclim package namespace
 from .main import index, indice
 
-__version__ = "5.0.0rc2"
+__version__ = "5.0.0rc3"

--- a/icclim/__init__.py
+++ b/icclim/__init__.py
@@ -1,6 +1,3 @@
-# keep line below to alias "main" module to icclim
-from . import main as icclim
-
 # keep line below to expose "main" content in icclim package namespace
 from .main import index, indice
 

--- a/icclim/clix_meta/clix_meta_indices.py
+++ b/icclim/clix_meta/clix_meta_indices.py
@@ -8,8 +8,9 @@ from typing import Any, Dict, Optional, TypedDict
 
 import yaml
 
-THIS_FOLDER = os.path.dirname(os.path.abspath(__file__))
-CLIX_YAML_PATH = Path(THIS_FOLDER) / "index_definitions.yml"
+CLIX_YAML_PATH = (
+    Path(os.path.dirname(os.path.abspath(__file__))) / "index_definitions.yml"
+)
 
 
 class EtMetadata(TypedDict):

--- a/icclim/clix_meta/clix_meta_indices.py
+++ b/icclim/clix_meta/clix_meta_indices.py
@@ -1,0 +1,65 @@
+""" Wrapper for clix-meta yaml file.
+    This read the yaml and make its content accessible an instance of ClixMetaIndices.
+    It also exposes some type hints of yaml content.
+"""
+import os
+from pathlib import Path
+from typing import Any, Dict, Optional, TypedDict
+
+import yaml
+
+THIS_FOLDER = os.path.dirname(os.path.abspath(__file__))
+CLIX_YAML_PATH = Path(THIS_FOLDER) / "index_definitions.yml"
+
+
+class EtMetadata(TypedDict):
+    short_name: str
+    long_name: str
+    definition: str
+    comment: str
+
+
+class OutputMetadata(TypedDict):
+    var_name: str
+    standard_name: str
+    long_name: str
+    units: str
+    cell_methods: Dict
+
+
+class ClixMetaIndex(TypedDict):
+    reference: str
+    period: Dict
+    output: OutputMetadata
+    input: Dict
+    index_function: Dict
+    ET: EtMetadata
+
+
+class ClixMetaIndices:
+    """
+    Singleton to access content of clix-meta yaml file.
+    """
+
+    __instance: Any = None
+    indices_record: Dict[str, ClixMetaIndex]
+
+    @staticmethod
+    def get_instance():
+        if ClixMetaIndices.__instance is None:
+            ClixMetaIndices.__instance = ClixMetaIndices()
+        return ClixMetaIndices.__instance
+
+    def __init__(self):
+        if ClixMetaIndices.__instance is not None:
+            raise Exception("This class is a singleton! Use Clix::get_instance.")
+        else:
+            ClixMetaIndices.__instance = self
+            with open(CLIX_YAML_PATH, "r") as clix_meta_file:
+                self.indices_record = yaml.safe_load(clix_meta_file)["indices"]
+
+    def lookup(self, query: str) -> Optional[ClixMetaIndex]:
+        for index in self.indices_record.keys():
+            if index.upper() == query.upper():
+                return self.indices_record[index]
+        return None

--- a/icclim/clix_meta/index_definitions.yml
+++ b/icclim/clix_meta/index_definitions.yml
@@ -1,0 +1,3881 @@
+# These index definitions are auto-generated from the master table at
+# https://github.com/clix-meta/clix-meta
+
+# This is based on version 0.3.0.
+---
+indices:
+  fd:
+    reference: ETCCDI
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "fd"
+      standard_name: number_of_days_with_air_temperature_below_threshold
+      proposed_standard_name: number_of_occurrences_with_air_temperature_below_threshold
+      long_name: "Number of Frost Days (Tmin < 0C)"
+      units: "1"
+      cell_methods:
+        - time: minimum within days
+        - time: sum over days
+    input:
+      data: tasmin
+    index_function:
+      name: count_occurrences
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: air_temperature
+          data: 0
+          units: "degree_Celsius"
+        condition:
+          kind: operator
+          operator: "<"
+    ET:
+      short_name: "fd"
+      long_name: "Frost days"
+      definition: "Count when TN < 0ºC"
+      comment: "count of days when daily minimum temperature is below 0 degC"
+
+  tnlt2:
+    reference: ET-SCI
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "tnlt2"
+      standard_name: number_of_days_with_air_temperature_below_threshold
+      proposed_standard_name: number_of_occurrences_with_air_temperature_below_threshold
+      long_name: "Number of weak Frost Days (Tmin < +2C)"
+      units: "1"
+      cell_methods:
+        - time: minimum within days
+        - time: sum over days
+    input:
+      data: tasmin
+    index_function:
+      name: count_occurrences
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: air_temperature
+          data: 2
+          units: "degree_Celsius"
+        condition:
+          kind: operator
+          operator: "<"
+    ET:
+      short_name: "fd2"
+      long_name: "Frost days 2"
+      definition: "Count when TN < 2ºC"
+      comment: "count of days when daily minimum temperature is below plus 2 degC"
+
+  tnltm2:
+    reference: ET-SCI
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "tnltm2"
+      standard_name: number_of_days_with_air_temperature_below_threshold
+      proposed_standard_name: number_of_occurrences_with_air_temperature_below_threshold
+      long_name: "Number of sharp Frost Days (Tmin < -2C)"
+      units: "1"
+      cell_methods:
+        - time: minimum within days
+        - time: sum over days
+    input:
+      data: tasmin
+    index_function:
+      name: count_occurrences
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: air_temperature
+          data: -2
+          units: "degree_Celsius"
+        condition:
+          kind: operator
+          operator: "<"
+    ET:
+      short_name: "fdm2"
+      long_name: "Hard freeze"
+      definition: "Count when TN < -2ºC"
+      comment: "count of days when daily minimum temperature is below minus 2 degC"
+
+  tnltm20:
+    reference: ET-SCI
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "tnltm20"
+      standard_name: number_of_days_with_air_temperature_below_threshold
+      proposed_standard_name: number_of_occurrences_with_air_temperature_below_threshold
+      long_name:
+      units: "1"
+      cell_methods:
+        - time: minimum within days
+        - time: sum over days
+    input:
+      data: tasmin
+    index_function:
+      name: count_occurrences
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: air_temperature
+          data: -20
+          units: "degree_Celsius"
+        condition:
+          kind: operator
+          operator: "<"
+    ET:
+      short_name: "fdm20"
+      long_name: "Very hard freeze"
+      definition: "Count when TN < -20ºC"
+      comment: "count of days when daily minimum temperature is below minus 20 degC"
+
+  id:
+    reference: ETCCDI
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "id"
+      standard_name: number_of_days_with_air_temperature_below_threshold
+      proposed_standard_name: number_of_occurrences_with_air_temperature_below_threshold
+      long_name: "Number of sharp Ice Days (Tmax < 0C)"
+      units: "1"
+      cell_methods:
+        - time: maximum within days
+        - time: sum over days
+    input:
+      data: tasmax
+    index_function:
+      name: count_occurrences
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: air_temperature
+          data: 0
+          units: "degree_Celsius"
+        condition:
+          kind: operator
+          operator: "<"
+    ET:
+      short_name: "id"
+      long_name: "Ice days"
+      definition: "Count when TX < 0ºC"
+      comment: "count of days when daily maximum temperature is below 0 degC"
+
+  su:
+    reference: ETCCDI
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "su"
+      standard_name: number_of_days_with_air_temperature_above_threshold
+      proposed_standard_name: number_of_occurrences_with_air_temperature_above_threshold
+      long_name: "Number of Summer Days (Tmax > 25C)"
+      units: "1"
+      cell_methods:
+        - time: maximum within days
+        - time: sum over days
+    input:
+      data: tasmax
+    index_function:
+      name: count_occurrences
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: air_temperature
+          data: 25
+          units: "degree_Celsius"
+        condition:
+          kind: operator
+          operator: ">"
+    ET:
+      short_name: "su"
+      long_name: "Summer days"
+      definition: "Count when TX > 25ºC"
+      comment: "count of days when daily maximum temperature is above plus 25 degC"
+
+  txge30:
+    reference: ET-SCI
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "txge30"
+      standard_name: number_of_days_with_air_temperature_above_threshold
+      proposed_standard_name: number_of_occurrences_with_air_temperature_at_or_above_threshold
+      long_name: "Number of Hot Days (Tmax >= 35C)"
+      units: "1"
+      cell_methods:
+        - time: maximum within days
+        - time: sum over days
+    input:
+      data: tasmax
+    index_function:
+      name: count_occurrences
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: air_temperature
+          data: 30
+          units: "degree_Celsius"
+        condition:
+          kind: operator
+          operator: ">"
+    ET:
+      short_name: "su30"
+      long_name: "Hot days"
+      definition: "Count when TX >= 30ºC"
+      comment: "count of days when daily maximum temperature is above or equal plus 30 degC"
+
+  txge35:
+    reference: ET-SCI
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "txge35"
+      standard_name: number_of_days_with_air_temperature_above_threshold
+      proposed_standard_name: number_of_occurrences_with_air_temperature_at_or_above_threshold
+      long_name: "Number of Very Hot Days (Tmax >= 35C)"
+      units: "1"
+      cell_methods:
+        - time: maximum within days
+        - time: sum over days
+    input:
+      data: tasmax
+    index_function:
+      name: count_occurrences
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: air_temperature
+          data: 35
+          units: "degree_Celsius"
+        condition:
+          kind: operator
+          operator: ">"
+    ET:
+      short_name: "su35"
+      long_name: "Very hot days"
+      definition: "Count when TX >= 35ºC"
+      comment: "count of days when daily maximum temperature is above or equal plus 35 degC"
+
+  tr:
+    reference: ETCCDI
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "tr"
+      standard_name: number_of_days_with_air_temperature_above_threshold
+      proposed_standard_name: number_of_occurrences_with_air_temperature_above_threshold
+      long_name: "Number of Tropical Nights (Tmin > 20C)"
+      units: "1"
+      cell_methods:
+        - time: minimum within days
+        - time: sum over days
+    input:
+      data: tasmin
+    index_function:
+      name: count_occurrences
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: air_temperature
+          data: 20
+          units: "degree_Celsius"
+        condition:
+          kind: operator
+          operator: ">"
+    ET:
+      short_name: "tr"
+      long_name: "Tropical nights"
+      definition: "Count when TN > 20ºC"
+      comment: "count of days when daily minimum temperature is above plus 20 degC"
+
+  tmge5:
+    reference: ET-SCI
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "tmge5"
+      standard_name: number_of_days_with_air_temperature_above_threshold
+      proposed_standard_name: number_of_occurrences_with_air_temperature_at_or_above_threshold
+      long_name: "Number of days with Tmean >= 5C"
+      units: "1"
+      cell_methods:
+        - time: mean within days
+        - time: sum over days
+    input:
+      data: tas
+    index_function:
+      name: count_occurrences
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: air_temperature
+          data: 5
+          units: "degree_Celsius"
+        condition:
+          kind: operator
+          operator: ">"
+    ET:
+      short_name: "tm5a"
+      long_name: "TM above 5C"
+      definition: "Count when TM >= 5ºC"
+      comment: "count of days when daily mean temperature is above plus 5 degC"
+
+  tmlt5:
+    reference: ET-SCI
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "tmlt5"
+      standard_name: number_of_days_with_air_temperature_below_threshold
+      proposed_standard_name: number_of_occurrences_with_air_temperature_below_threshold
+      long_name: "Number of days with Tmean < 5C"
+      units: "1"
+      cell_methods:
+        - time: mean within days
+        - time: sum over days
+    input:
+      data: tas
+    index_function:
+      name: count_occurrences
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: air_temperature
+          data: 5
+          units: "degree_Celsius"
+        condition:
+          kind: operator
+          operator: "<"
+    ET:
+      short_name: "tm5b"
+      long_name: "TM below 5C"
+      definition: "Count when TM < 5ºC"
+      comment: "count of days when daily mean temperature is below plus 5 degC"
+
+  tmge10:
+    reference: ET-SCI
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "tmge10"
+      standard_name: number_of_days_with_air_temperature_above_threshold
+      proposed_standard_name: number_of_occurrences_with_air_temperature_at_or_above_threshold
+      long_name: "Number of days with Tmean >= 10C"
+      units: "1"
+      cell_methods:
+        - time: mean within days
+        - time: sum over days
+    input:
+      data: tas
+    index_function:
+      name: count_occurrences
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: air_temperature
+          data: 10
+          units: "degree_Celsius"
+        condition:
+          kind: operator
+          operator: ">"
+    ET:
+      short_name: "tm10a"
+      long_name: "TM above 10C"
+      definition: "Count when TM >= 10ºC"
+      comment: "count of days when daily mean temperature is above plus 10 degC"
+
+  tmlt10:
+    reference: ET-SCI
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "tmlt10"
+      standard_name: number_of_days_with_air_temperature_below_threshold
+      proposed_standard_name: number_of_occurrences_with_air_temperature_below_threshold
+      long_name: "Number of days with Tmean < 10C"
+      units: "1"
+      cell_methods:
+        - time: mean within days
+        - time: sum over days
+    input:
+      data: tas
+    index_function:
+      name: count_occurrences
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: air_temperature
+          data: 10
+          units: "degree_Celsius"
+        condition:
+          kind: operator
+          operator: "<"
+    ET:
+      short_name: "tm10b"
+      long_name: "TM below 10C"
+      definition: "Count when TM < 10ºC"
+      comment: "count of days when daily mean temperature is below plus 10 degC"
+
+  tngt{TT}:
+    reference: CLIPC
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "tngt{TT}"
+      standard_name: number_of_days_with_air_temperature_above_threshold
+      proposed_standard_name: number_of_occurrences_with_air_temperature_above_threshold
+      long_name: "Number of days with Tmin > {TT}C"
+      units: "1"
+      cell_methods:
+        - time: minimum within days
+        - time: sum over days
+    input:
+      data: tasmin
+    index_function:
+      name: count_occurrences
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: air_temperature
+          data: {TT}
+          units: "degree_Celsius"
+        condition:
+          kind: operator
+          operator: ">"
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment: "count of days when daily minimum temperature is above {TT} degC"
+
+  tnlt{TT}:
+    reference: CLIPC
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "tnlt{TT}"
+      standard_name: number_of_days_with_air_temperature_below_threshold
+      proposed_standard_name: number_of_occurrences_with_air_temperature_below_threshold
+      long_name: "Number of days with Tmin < {TT}C"
+      units: "1"
+      cell_methods:
+        - time: minimum within days
+        - time: sum over days
+    input:
+      data: tasmin
+    index_function:
+      name: count_occurrences
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: air_temperature
+          data: {TT}
+          units: "degree_Celsius"
+        condition:
+          kind: operator
+          operator: "<"
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment: "count of days when daily minimum temperature is below {TT} degC"
+
+  tnge{TT}:
+    reference: CLIPC
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "tnge{TT}"
+      standard_name: number_of_days_with_air_temperature_above_threshold
+      proposed_standard_name: number_of_occurrences_with_air_temperature_at_or_above_threshold
+      long_name: "Number of days with Tmin >= {TT}C"
+      units: "1"
+      cell_methods:
+        - time: minimum within days
+        - time: sum over days
+    input:
+      data: tasmin
+    index_function:
+      name: count_occurrences
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: air_temperature
+          data: {TT}
+          units: "degree_Celsius"
+        condition:
+          kind: operator
+          operator: ">"
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment: "count of days when daily minimum temperature is above or equal {TT} degC"
+
+  tnle{TT}:
+    reference: CLIPC
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "tnle{TT}"
+      standard_name: number_of_days_with_air_temperature_below_threshold
+      proposed_standard_name: number_of_occurrences_with_air_temperature_at_or_below_threshold
+      long_name: "Number of days with Tmin <= {TT}C"
+      units: "1"
+      cell_methods:
+        - time: minimum within days
+        - time: sum over days
+    input:
+      data: tasmin
+    index_function:
+      name: count_occurrences
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: air_temperature
+          data: {TT}
+          units: "degree_Celsius"
+        condition:
+          kind: operator
+          operator: "<"
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment: "count of days when daily minimum temperature is below or equal{TT} degC"
+
+  txgt{TT}:
+    reference: CLIPC
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "txgt{TT}"
+      standard_name: number_of_days_with_air_temperature_above_threshold
+      proposed_standard_name: number_of_occurrences_with_air_temperature_above_threshold
+      long_name: "Number of days with Tmax > {TT}C"
+      units: "1"
+      cell_methods:
+        - time: maximum within days
+        - time: sum over days
+    input:
+      data: tasmax
+    index_function:
+      name: count_occurrences
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: air_temperature
+          data: {TT}
+          units: "degree_Celsius"
+        condition:
+          kind: operator
+          operator: ">"
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment: "count of days when daily maximum temperature is above {TT} degC"
+
+  txlt{TT}:
+    reference: CLIPC
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "txlt{TT}"
+      standard_name: number_of_days_with_air_temperature_below_threshold
+      proposed_standard_name: number_of_occurrences_with_air_temperature_below_threshold
+      long_name: "Number of days with Tmax < {TT}C"
+      units: "1"
+      cell_methods:
+        - time: maximum within days
+        - time: sum over days
+    input:
+      data: tasmax
+    index_function:
+      name: count_occurrences
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: air_temperature
+          data: {TT}
+          units: "degree_Celsius"
+        condition:
+          kind: operator
+          operator: "<"
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment: "count of days when daily maximum temperature is below {TT} degC"
+
+  txge{TT}:
+    reference: CLIPC
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "txge{TT}"
+      standard_name: number_of_days_with_air_temperature_above_threshold
+      proposed_standard_name: number_of_occurrences_with_air_temperature_at_or_above_threshold
+      long_name: "Number of days with Tmax >= {TT}C"
+      units: "1"
+      cell_methods:
+        - time: maximum within days
+        - time: sum over days
+    input:
+      data: tasmax
+    index_function:
+      name: count_occurrences
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: air_temperature
+          data: {TT}
+          units: "degree_Celsius"
+        condition:
+          kind: operator
+          operator: ">"
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment: "count of days when daily maximum temperature is above or equal {TT} degC"
+
+  txle{TT}:
+    reference: CLIPC
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "txle{TT}"
+      standard_name: number_of_days_with_air_temperature_below_threshold
+      proposed_standard_name: number_of_occurrences_with_air_temperature_at_or_below_threshold
+      long_name: "Number of days with Tmax <= {TT}C"
+      units: "1"
+      cell_methods:
+        - time: maximum within days
+        - time: sum over days
+    input:
+      data: tasmax
+    index_function:
+      name: count_occurrences
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: air_temperature
+          data: {TT}
+          units: "degree_Celsius"
+        condition:
+          kind: operator
+          operator: "<"
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment: "count of days when daily maximum temperature is below or equal {TT} degC"
+
+  tmgt{TT}:
+    reference: CLIPC
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "tmgt{TT}"
+      standard_name: number_of_days_with_air_temperature_above_threshold
+      proposed_standard_name: number_of_occurrences_with_air_temperature_above_threshold
+      long_name: "Number of days with Tmean > {TT}C"
+      units: "1"
+      cell_methods:
+        - time: mean within days
+        - time: sum over days
+    input:
+      data: tas
+    index_function:
+      name: count_occurrences
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: air_temperature
+          data: {TT}
+          units: "degree_Celsius"
+        condition:
+          kind: operator
+          operator: ">"
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment: "count of days when daily mean temperature is above {TT} degC"
+
+  tmlt{TT}:
+    reference: CLIPC
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "tmlt{TT}"
+      standard_name: number_of_days_with_air_temperature_below_threshold
+      proposed_standard_name: number_of_occurrences_with_air_temperature_below_threshold
+      long_name: "Number of days with Tmean < {TT}C"
+      units: "1"
+      cell_methods:
+        - time: mean within days
+        - time: sum over days
+    input:
+      data: tas
+    index_function:
+      name: count_occurrences
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: air_temperature
+          data: {TT}
+          units: "degree_Celsius"
+        condition:
+          kind: operator
+          operator: "<"
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment: "count of days when daily mean temperature is below {TT} degC"
+
+  tmge{TT}:
+    reference: CLIPC
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "tmge{TT}"
+      standard_name: number_of_days_with_air_temperature_above_threshold
+      proposed_standard_name: number_of_occurrences_with_air_temperature_at_or_above_threshold
+      long_name: "Number of days with Tmean >= {TT}C"
+      units: "1"
+      cell_methods:
+        - time: mean within days
+        - time: sum over days
+    input:
+      data: tas
+    index_function:
+      name: count_occurrences
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: air_temperature
+          data: {TT}
+          units: "degree_Celsius"
+        condition:
+          kind: operator
+          operator: ">"
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment: "count of days when daily mean temperature is above or equal {TT} degC"
+
+  tmle{TT}:
+    reference: CLIPC
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "tmle{TT}"
+      standard_name: number_of_days_with_air_temperature_below_threshold
+      proposed_standard_name: number_of_occurrences_with_air_temperature_at_or_below_threshold
+      long_name: "Number of days with Tmean <= {TT}C"
+      units: "1"
+      cell_methods:
+        - time: mean within days
+        - time: sum over days
+    input:
+      data: tas
+    index_function:
+      name: count_occurrences
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: air_temperature
+          data: {TT}
+          units: "degree_Celsius"
+        condition:
+          kind: operator
+          operator: "<"
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment: "count of days when daily mean temperature is below or equal{TT} degC"
+
+  ctngt{TT}:
+    reference: CLIPC
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "ctngt{TT}"
+      standard_name: spell_length_of_days_with_air_temperature_above_threshold
+      proposed_standard_name: spell_length_with_air_temperature_above_threshold
+      long_name: "Maximum number of consequtive days with Tmin > {TT}C"
+      units: "day"
+      cell_methods:
+        - time: minimum within days
+        - time: maximum over days
+    input:
+      data: tasmin
+    index_function:
+      name: spell_length
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: air_temperature
+          data: {TT}
+          units: "degree_Celsius"
+        condition:
+          kind: operator
+          operator: ">"
+        reducer:
+          kind: reducer
+          reducer: max
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment: "count of days when daily minimum temperature is above {TT} degC"
+
+  cfd:
+    reference: ECA&D
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "cfd"
+      standard_name: spell_length_of_days_with_air_temperature_below_threshold
+      proposed_standard_name: spell_length_with_air_temperature_below_threshold
+      long_name: "Maximum number of consecutive frost days (Tmin < 0 C)"
+      units: "day"
+      cell_methods:
+        - time: minimum within days
+        - time: maximum over days
+    input:
+      data: tasmin
+    index_function:
+      name: count_occurrences
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: air_temperature
+          data: 0
+          units: "degree_Celsius"
+        condition:
+          kind: operator
+          operator: "<"
+    ET:
+      short_name: "cfd"
+      long_name:
+      definition:
+      comment:
+
+  csu:
+    reference: ECA&D
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "csu"
+      standard_name: spell_length_of_days_with_air_temperature_above_threshold
+      proposed_standard_name: spell_length_with_air_temperature_above_threshold
+      long_name: "Maximum number of consecutive summer days (Tmax >25 C)"
+      units: "day"
+      cell_methods:
+        - time: maximum within days
+        - time: maximum over days
+    input:
+      data: tasmax
+    index_function:
+      name: count_occurrences
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: air_temperature
+          data: 25
+          units: "degree_Celsius"
+        condition:
+          kind: operator
+          operator: ">"
+    ET:
+      short_name: "cfd"
+      long_name:
+      definition:
+      comment:
+
+  ctnlt{TT}:
+    reference: CLIPC
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "ctnlt{TT}"
+      standard_name: spell_length_of_days_with_air_temperature_below_threshold
+      proposed_standard_name: spell_length_with_air_temperature_below_threshold
+      long_name: "Maximum number of consequtive days with Tmin < {TT}C"
+      units: "day"
+      cell_methods:
+        - time: minimum within days
+        - time: maximum over days
+    input:
+      data: tasmin
+    index_function:
+      name: spell_length
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: air_temperature
+          data: {TT}
+          units: "degree_Celsius"
+        condition:
+          kind: operator
+          operator: "<"
+        reducer:
+          kind: reducer
+          reducer: max
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment: "count of days when daily minimum temperature is below {TT} degC"
+
+  ctnge{TT}:
+    reference: CLIPC
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "ctnge{TT}"
+      standard_name: spell_length_of_days_with_air_temperature_above_threshold
+      proposed_standard_name: spell_length_with_air_temperature_at_or_above_threshold
+      long_name: "Maximum number of consequtive days with Tmin >= {TT}C"
+      units: "day"
+      cell_methods:
+        - time: minimum within days
+        - time: maximum over days
+    input:
+      data: tasmin
+    index_function:
+      name: spell_length
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: air_temperature
+          data: {TT}
+          units: "degree_Celsius"
+        condition:
+          kind: operator
+          operator: ">"
+        reducer:
+          kind: reducer
+          reducer: max
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment: "count of days when daily minimum temperature is above or equal {TT} degC"
+
+  ctnle{TT}:
+    reference: CLIPC
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "ctnle{TT}"
+      standard_name: spell_length_of_days_with_air_temperature_below_threshold
+      proposed_standard_name: spell_length_with_air_temperature_at_or_below_threshold
+      long_name: "Maximum number of consequtive days with Tmin <= {TT}C"
+      units: "day"
+      cell_methods:
+        - time: minimum within days
+        - time: maximum over days
+    input:
+      data: tasmin
+    index_function:
+      name: spell_length
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: air_temperature
+          data: {TT}
+          units: "degree_Celsius"
+        condition:
+          kind: operator
+          operator: "<"
+        reducer:
+          kind: reducer
+          reducer: max
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment: "count of days when daily minimum temperature is below or equal{TT} degC"
+
+  ctxgt{TT}:
+    reference: CLIPC
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "ctxgt{TT}"
+      standard_name: spell_length_of_days_with_air_temperature_above_threshold
+      proposed_standard_name: spell_length_with_air_temperature_above_threshold
+      long_name: "Maximum number of consequtive days with Tmax > {TT}C"
+      units: "day"
+      cell_methods:
+        - time: maximum within days
+        - time: maximum over days
+    input:
+      data: tasmax
+    index_function:
+      name: spell_length
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: air_temperature
+          data: {TT}
+          units: "degree_Celsius"
+        condition:
+          kind: operator
+          operator: ">"
+        reducer:
+          kind: reducer
+          reducer: max
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment: "count of days when daily maximum temperature is above {TT} degC"
+
+  ctxlt{TT}:
+    reference: CLIPC
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "ctxlt{TT}"
+      standard_name: spell_length_of_days_with_air_temperature_below_threshold
+      proposed_standard_name: spell_length_with_air_temperature_below_threshold
+      long_name: "Maximum number of consequtive days with Tmax < {TT}C"
+      units: "day"
+      cell_methods:
+        - time: maximum within days
+        - time: maximum over days
+    input:
+      data: tasmax
+    index_function:
+      name: spell_length
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: air_temperature
+          data: {TT}
+          units: "degree_Celsius"
+        condition:
+          kind: operator
+          operator: "<"
+        reducer:
+          kind: reducer
+          reducer: max
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment: "count of days when daily maximum temperature is below {TT} degC"
+
+  ctxge{TT}:
+    reference: CLIPC
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "ctxge{TT}"
+      standard_name: spell_length_of_days_with_air_temperature_above_threshold
+      proposed_standard_name: spell_length_with_air_temperature_at_or_above_threshold
+      long_name: "Maximum number of consequtive days with Tmax >= {TT}C"
+      units: "day"
+      cell_methods:
+        - time: maximum within days
+        - time: maximum over days
+    input:
+      data: tasmax
+    index_function:
+      name: spell_length
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: air_temperature
+          data: {TT}
+          units: "degree_Celsius"
+        condition:
+          kind: operator
+          operator: ">"
+        reducer:
+          kind: reducer
+          reducer: max
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment: "count of days when daily maximum temperature is above or equal {TT} degC"
+
+  ctxle{TT}:
+    reference: CLIPC
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "ctxle{TT}"
+      standard_name: spell_length_of_days_with_air_temperature_below_threshold
+      proposed_standard_name: spell_length_with_air_temperature_at_or_below_threshold
+      long_name: "Maximum number of consequtive days with Tmax <= {TT}C"
+      units: "day"
+      cell_methods:
+        - time: maximum within days
+        - time: maximum over days
+    input:
+      data: tasmax
+    index_function:
+      name: spell_length
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: air_temperature
+          data: {TT}
+          units: "degree_Celsius"
+        condition:
+          kind: operator
+          operator: "<"
+        reducer:
+          kind: reducer
+          reducer: max
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment: "count of days when daily maximum temperature is below or equal {TT} degC"
+
+  ctmgt{TT}:
+    reference: CLIPC
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "ctmgt{TT}"
+      standard_name: spell_length_of_days_with_air_temperature_above_threshold
+      proposed_standard_name: spell_length_with_air_temperature_above_threshold
+      long_name: "Maximum number of consequtive days with Tmean > {TT}C"
+      units: "day"
+      cell_methods:
+        - time: mean within days
+        - time: maximum over days
+    input:
+      data: tas
+    index_function:
+      name: spell_length
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: air_temperature
+          data: {TT}
+          units: "degree_Celsius"
+        condition:
+          kind: operator
+          operator: ">"
+        reducer:
+          kind: reducer
+          reducer: max
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment: "count of days when daily mean temperature is above {TT} degC"
+
+  ctmlt{TT}:
+    reference: CLIPC
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "ctmlt{TT}"
+      standard_name: spell_length_of_days_with_air_temperature_below_threshold
+      proposed_standard_name: spell_length_with_air_temperature_below_threshold
+      long_name: "Maximum number of consequtive days with Tmean < {TT}C"
+      units: "day"
+      cell_methods:
+        - time: mean within days
+        - time: maximum over days
+    input:
+      data: tas
+    index_function:
+      name: spell_length
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: air_temperature
+          data: {TT}
+          units: "degree_Celsius"
+        condition:
+          kind: operator
+          operator: "<"
+        reducer:
+          kind: reducer
+          reducer: max
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment: "count of days when daily mean temperature is below {TT} degC"
+
+  ctmge{TT}:
+    reference: CLIPC
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "ctmge{TT}"
+      standard_name: spell_length_of_days_with_air_temperature_above_threshold
+      proposed_standard_name: spell_length_with_air_temperature_at_or_above_threshold
+      long_name: "Maximum number of consequtive days with Tmean >= {TT}C"
+      units: "day"
+      cell_methods:
+        - time: mean within days
+        - time: maximum over days
+    input:
+      data: tas
+    index_function:
+      name: spell_length
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: air_temperature
+          data: {TT}
+          units: "degree_Celsius"
+        condition:
+          kind: operator
+          operator: ">"
+        reducer:
+          kind: reducer
+          reducer: max
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment: "count of days when daily mean temperature is above or equal {TT} degC"
+
+  ctmle{TT}:
+    reference: CLIPC
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "ctmle{TT}"
+      standard_name: spell_length_of_days_with_air_temperature_below_threshold
+      proposed_standard_name: spell_length_with_air_temperature_at_or_below_threshold
+      long_name: "Maximum number of consequtive days with Tmean <= {TT}C"
+      units: "day"
+      cell_methods:
+        - time: mean within days
+        - time: maximum over days
+    input:
+      data: tas
+    index_function:
+      name: spell_length
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: air_temperature
+          data: {TT}
+          units: "degree_Celsius"
+        condition:
+          kind: operator
+          operator: "<"
+        reducer:
+          kind: reducer
+          reducer: max
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment: "count of days when daily mean temperature is below or equal{TT} degC"
+
+  txx:
+    reference: ETCCDI
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "txx"
+      standard_name: air_temperature
+      long_name: "Maximum daily maximum temperature"
+      units: "degree_Celsius"
+      cell_methods:
+        - time: maximum within days
+        - time: maximum over days
+    input:
+      data: tasmax
+    index_function:
+      name: statistics
+      parameters:
+        reducer:
+          kind: reducer
+          reducer: max
+    ET:
+      short_name: "txx"
+      long_name: "Maximum daily maximum temperature"
+      definition: "Maximum value of daily TX"
+      comment: "maximum of daily maximum temperature"
+
+  tnx:
+    reference: ETCCDI
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "tnx"
+      standard_name: air_temperature
+      long_name: "Maximum daily minimum temperature"
+      units: "degree_Celsius"
+      cell_methods:
+        - time: minimum within days
+        - time: maximum over days
+    input:
+      data: tasmin
+    index_function:
+      name: statistics
+      parameters:
+        reducer:
+          kind: reducer
+          reducer: max
+    ET:
+      short_name: "tnx"
+      long_name: "Maximum daily minimum temperature"
+      definition: "Maximum value of daily TN"
+      comment: "maximum of daily minimum temperature"
+
+  txn:
+    reference: ETCCDI
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "txn"
+      standard_name: air_temperature
+      long_name: "Minimum daily maximum temperature"
+      units: "degree_Celsius"
+      cell_methods:
+        - time: maximum within days
+        - time: minimum over days
+    input:
+      data: tasmax
+    index_function:
+      name: statistics
+      parameters:
+        reducer:
+          kind: reducer
+          reducer: min
+    ET:
+      short_name: "txn"
+      long_name: "Minimum daily maximum temperature"
+      definition: "Minimum value of daily TX"
+      comment: "minimum of daily maximum temperature"
+
+  tnn:
+    reference: ETCCDI
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "tnn"
+      standard_name: air_temperature
+      long_name: "Minimum daily minimum temperature"
+      units: "degree_Celsius"
+      cell_methods:
+        - time: minimum within days
+        - time: minimum over days
+    input:
+      data: tasmin
+    index_function:
+      name: statistics
+      parameters:
+        reducer:
+          kind: reducer
+          reducer: min
+    ET:
+      short_name: "tnn"
+      long_name: "Minimum daily minimum temperature"
+      definition: "Minimum value of daily TN"
+      comment: "minimum of daily minimum temperature"
+
+  txm:
+    reference:
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "txm"
+      standard_name: air_temperature
+      long_name: "Mean daily maximum temperature"
+      units: "degree_Celsius"
+      cell_methods:
+        - time: maximum within days
+        - time: mean over days
+    input:
+      data: tasmax
+    index_function:
+      name: statistics
+      parameters:
+        reducer:
+          kind: reducer
+          reducer: mean
+    ET:
+      short_name: "txm"
+      long_name: "Mean daily maximum temperature"
+      definition: "Mean value of daily TX"
+      comment:
+
+  tnm:
+    reference:
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "tnm"
+      standard_name: air_temperature
+      long_name: "Mean daily minimum temperature"
+      units: "degree_Celsius"
+      cell_methods:
+        - time: minimum within days
+        - time: mean over days
+    input:
+      data: tasmin
+    index_function:
+      name: statistics
+      parameters:
+        reducer:
+          kind: reducer
+          reducer: mean
+    ET:
+      short_name: "tnx"
+      long_name: "Mean daily minimum temperature"
+      definition: "Mean value of daily TN"
+      comment:
+
+  tmx:
+    reference:
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "tmx"
+      standard_name: air_temperature
+      long_name: "Maximum daily mean temperature"
+      units: "degree_Celsius"
+      cell_methods:
+        - time: mean within days
+        - time: maximum over days
+    input:
+      data: tas
+    index_function:
+      name: statistics
+      parameters:
+        reducer:
+          kind: reducer
+          reducer: max
+    ET:
+      short_name: "tmx"
+      long_name: "Maximum daily mean temperature"
+      definition: "Maximum value of daily TM"
+      comment:
+
+  tmn:
+    reference:
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "tmn"
+      standard_name: air_temperature
+      long_name: "Minimum daily mean temperature"
+      units: "degree_Celsius"
+      cell_methods:
+        - time: mean within days
+        - time: minimum over days
+    input:
+      data: tas
+    index_function:
+      name: statistics
+      parameters:
+        reducer:
+          kind: reducer
+          reducer: min
+    ET:
+      short_name: "tmn"
+      long_name: "Minimum daily mean temperature"
+      definition: "Minimum value of daily TM"
+      comment:
+
+  tmm:
+    reference:
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "tmm"
+      standard_name: air_temperature
+      long_name: "Mean daily mean temperature"
+      units: "degree_Celsius"
+      cell_methods:
+        - time: mean within days
+        - time: mean over days
+    input:
+      data: tas
+    index_function:
+      name: statistics
+      parameters:
+        reducer:
+          kind: reducer
+          reducer: mean
+    ET:
+      short_name: "tmm"
+      long_name: "Mean daily mean temperature"
+      definition: "Mean value of daily TM"
+      comment:
+
+  txmax:
+    reference: CLIPC
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "txmax"
+      standard_name: air_temperature
+      long_name: "Maximum daily maximum temperature"
+      units: "degree_Celsius"
+      cell_methods:
+        - time: maximum within days
+        - time: maximum over days
+    input:
+      data: tasmax
+    index_function:
+      name: statistics
+      parameters:
+        reducer:
+          kind: reducer
+          reducer: max
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment: "mean of daily maximum temperature"
+
+  tnmax:
+    reference: CLIPC
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "tnmax"
+      standard_name: air_temperature
+      long_name: "Maximum daily minimum temperature"
+      units: "degree_Celsius"
+      cell_methods:
+        - time: minimum within days
+        - time: maximum over days
+    input:
+      data: tasmin
+    index_function:
+      name: statistics
+      parameters:
+        reducer:
+          kind: reducer
+          reducer: max
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment: "mean of daily minimum temperature"
+
+  txmin:
+    reference: CLIPC
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "txmin"
+      standard_name: air_temperature
+      long_name: "Minimum daily maximum temperature"
+      units: "degree_Celsius"
+      cell_methods:
+        - time: maximum within days
+        - time: minimum over days
+    input:
+      data: tasmax
+    index_function:
+      name: statistics
+      parameters:
+        reducer:
+          kind: reducer
+          reducer: min
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment: "maximum of daily mean temperature"
+
+  tnmin:
+    reference: CLIPC
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "tnmin"
+      standard_name: air_temperature
+      long_name: "Minimum daily minimum temperature"
+      units: "degree_Celsius"
+      cell_methods:
+        - time: minimum within days
+        - time: minimum over days
+    input:
+      data: tasmin
+    index_function:
+      name: statistics
+      parameters:
+        reducer:
+          kind: reducer
+          reducer: min
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment: "minimum of daily mean temperature"
+
+  txmean:
+    reference: CLIPC
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "txmean"
+      standard_name: air_temperature
+      long_name: "Mean daily maximum temperature"
+      units: "degree_Celsius"
+      cell_methods:
+        - time: maximum within days
+        - time: mean over days
+    input:
+      data: tasmax
+    index_function:
+      name: statistics
+      parameters:
+        reducer:
+          kind: reducer
+          reducer: mean
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment: "mean of daily maximum temperature"
+
+  tnmean:
+    reference: CLIPC
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "tnmean"
+      standard_name: air_temperature
+      long_name: "Mean daily minimum temperature"
+      units: "degree_Celsius"
+      cell_methods:
+        - time: minimum within days
+        - time: mean over days
+    input:
+      data: tasmin
+    index_function:
+      name: statistics
+      parameters:
+        reducer:
+          kind: reducer
+          reducer: mean
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment: "mean of daily minimum temperature"
+
+  tmmax:
+    reference: CLIPC
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "tmmax"
+      standard_name: air_temperature
+      long_name: "Maximum daily mean temperature"
+      units: "degree_Celsius"
+      cell_methods:
+        - time: mean within days
+        - time: maximum over days
+    input:
+      data: tas
+    index_function:
+      name: statistics
+      parameters:
+        reducer:
+          kind: reducer
+          reducer: max
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment: "maximum of daily mean temperature"
+
+  tmmin:
+    reference: CLIPC
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "tmmin"
+      standard_name: air_temperature
+      long_name: "Minimum daily mean temperature"
+      units: "degree_Celsius"
+      cell_methods:
+        - time: mean within days
+        - time: maximum over days
+    input:
+      data: tas
+    index_function:
+      name: statistics
+      parameters:
+        reducer:
+          kind: reducer
+          reducer: min
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment: "minimum of daily mean temperature"
+
+  tmmean:
+    reference: CLIPC
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "tmmean"
+      standard_name: air_temperature
+      long_name: "Mean daily mean temperature"
+      units: "degree_Celsius"
+      cell_methods:
+        - time: mean within days
+        - time: mean over days
+    input:
+      data: tas
+    index_function:
+      name: statistics
+      parameters:
+        reducer:
+          kind: reducer
+          reducer: mean
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment: "mean of daily mean temperature"
+
+  tn10p:
+    reference: ETCCDI
+    period:
+      allowed:
+        annual:
+      default: annual
+    output:
+      var_name: "tn10p"
+      standard_name:
+      long_name: "Percentage of days when Tmin < 10th percentile"
+      units: "%"
+      cell_methods:
+    input:
+      data: tasmin
+    index_function:
+      name: count_percentile_occurrences
+      parameters:
+        percentile:
+          kind: quantity
+          standard_name:
+          proposed_standard_name: quantile
+          data: 10
+          units: "%"
+        condition:
+          kind: operator
+          operator: "<"
+    ET:
+      short_name: "tn10p"
+      long_name: "WMO No.1500: Cold nights (count of days)"
+      definition: "Number of days when TN < 10th percentile"
+      comment:
+
+  tx10p:
+    reference: ETCCDI
+    period:
+      allowed:
+        annual:
+      default: annual
+    output:
+      var_name: "tx10p"
+      standard_name:
+      long_name: "Percentage of days when Tmax < 10th percentile"
+      units: "%"
+      cell_methods:
+    input:
+      data: tasmax
+    index_function:
+      name: count_percentile_occurrences
+      parameters:
+        percentile:
+          kind: quantity
+          standard_name:
+          proposed_standard_name: quantile
+          data: 10
+          units: "%"
+        condition:
+          kind: operator
+          operator: "<"
+    ET:
+      short_name: "tx10p"
+      long_name: "WMO No.1500: Cold day-times (count of days)"
+      definition: "Number of days when TX < 10th percentile"
+      comment:
+
+  tn90p:
+    reference: ETCCDI
+    period:
+      allowed:
+        annual:
+      default: annual
+    output:
+      var_name: "tn90p"
+      standard_name:
+      long_name: "Percentage of days when Tmin > 90th percentile"
+      units: "%"
+      cell_methods:
+    input:
+      data: tasmin
+    index_function:
+      name: count_percentile_occurrences
+      parameters:
+        percentile:
+          kind: quantity
+          standard_name:
+          proposed_standard_name: quantile
+          data: 90
+          units: "%"
+        condition:
+          kind: operator
+          operator: ">"
+    ET:
+      short_name: "tn90p"
+      long_name: "WMO No.1500: Warm nights (count of days)"
+      definition: "Number of days when TN > 90th percentile"
+      comment:
+
+  tx90p:
+    reference: ETCCDI
+    period:
+      allowed:
+        annual:
+      default: annual
+    output:
+      var_name: "tx90p"
+      standard_name:
+      long_name: "Percentage of days when Tmax > 90th percentile"
+      units: "%"
+      cell_methods:
+    input:
+      data: tasmax
+    index_function:
+      name: count_percentile_occurrences
+      parameters:
+        percentile:
+          kind: quantity
+          standard_name:
+          proposed_standard_name: quantile
+          data: 90
+          units: "%"
+        condition:
+          kind: operator
+          operator: ">"
+    ET:
+      short_name: "tx90p"
+      long_name: "WMO No.1500: Warm day-times (count of days)"
+      definition: "Number of days when TX > 90th percentile"
+      comment:
+
+  tg10p:
+    reference: ECA&D
+    period:
+      allowed:
+        annual:
+      default: annual
+    output:
+      var_name: "tg10p"
+      standard_name:
+      long_name: "Percentage of days when Tmean < 10th percentile"
+      units: "%"
+      cell_methods:
+    input:
+      data: tas
+    index_function:
+      name: count_percentile_occurrences
+      parameters:
+        percentile:
+          kind: quantity
+          standard_name:
+          proposed_standard_name: quantile
+          data: 10
+          units: "%"
+        condition:
+          kind: operator
+          operator: "<"
+    ET:
+      short_name: "tg10p"
+      long_name:
+      definition:
+      comment:
+
+  tg90p:
+    reference: ECA&D
+    period:
+      allowed:
+        annual:
+      default: annual
+    output:
+      var_name: "tg90p"
+      standard_name:
+      long_name: "Percentage of days when Tmean > 90th percentile"
+      units: "%"
+      cell_methods:
+    input:
+      data: tas
+    index_function:
+      name: count_percentile_occurrences
+      parameters:
+        percentile:
+          kind: quantity
+          standard_name:
+          proposed_standard_name: quantile
+          data: 90
+          units: "%"
+        condition:
+          kind: operator
+          operator: ">"
+    ET:
+      short_name: "tg90p"
+      long_name:
+      definition:
+      comment:
+
+  txgt50p:
+    reference: ET-SCI
+    period:
+      allowed:
+        annual:
+      default: annual
+    output:
+      var_name: "txgt50p"
+      standard_name:
+      long_name: "Percentage of days when Tmax > 50th percentile"
+      units: "%"
+      cell_methods:
+    input:
+      data: tasmax
+    index_function:
+      name: count_percentile_occurrences
+      parameters:
+        percentile:
+          kind: quantity
+          standard_name:
+          proposed_standard_name: quantile
+          data: 50
+          units: "%"
+        condition:
+          kind: operator
+          operator: ">"
+    ET:
+      short_name: "tx50p"
+      long_name: "Above average days"
+      definition: "Number of days where TX > 50th percentile"
+      comment:
+
+  txgt{PRC}p:
+    reference: CLIPC
+    period:
+      allowed:
+        annual:
+      default: annual
+    output:
+      var_name: "txgt{PRC}p"
+      standard_name:
+      long_name: "Percentage of days when Tmax > {PRC}th percentile"
+      units: "%"
+      cell_methods:
+    input:
+      data: tasmax
+    index_function:
+      name: count_percentile_occurrences
+      parameters:
+        percentile:
+          kind: quantity
+          standard_name:
+          proposed_standard_name: quantile
+          data: {PRC}
+          units: "%"
+        condition:
+          kind: operator
+          operator: ">"
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment:
+
+  tngt{PRC}p:
+    reference: CLIPC
+    period:
+      allowed:
+        annual:
+      default: annual
+    output:
+      var_name: "tngt{PRC}p"
+      standard_name:
+      long_name: "Percentage of days when Tmin > {PRC}th percentile"
+      units: "%"
+      cell_methods:
+    input:
+      data: tasmin
+    index_function:
+      name: count_percentile_occurrences
+      parameters:
+        percentile:
+          kind: quantity
+          standard_name:
+          proposed_standard_name: quantile
+          data: {PRC}
+          units: "%"
+        condition:
+          kind: operator
+          operator: ">"
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment:
+
+  tmgt{PRC}p:
+    reference: CLIPC
+    period:
+      allowed:
+        annual:
+      default: annual
+    output:
+      var_name: "tmgt{PRC}p"
+      standard_name:
+      long_name: "Percentage of days when Tmean > {PRC}th percentile"
+      units: "%"
+      cell_methods:
+    input:
+      data: tas
+    index_function:
+      name: count_percentile_occurrences
+      parameters:
+        percentile:
+          kind: quantity
+          standard_name:
+          proposed_standard_name: quantile
+          data: {PRC}
+          units: "%"
+        condition:
+          kind: operator
+          operator: ">"
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment:
+
+  txlt{PRC}p:
+    reference: CLIPC
+    period:
+      allowed:
+        annual:
+      default: annual
+    output:
+      var_name: "txlt{PRC}p"
+      standard_name:
+      long_name: "Percentage of days when Tmax < {PRC}th percentile"
+      units: "%"
+      cell_methods:
+    input:
+      data: tasmax
+    index_function:
+      name: count_percentile_occurrences
+      parameters:
+        percentile:
+          kind: quantity
+          standard_name:
+          proposed_standard_name: quantile
+          data: {PRC}
+          units: "%"
+        condition:
+          kind: operator
+          operator: "<"
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment:
+
+  tnlt{PRC}p:
+    reference: CLIPC
+    period:
+      allowed:
+        annual:
+      default: annual
+    output:
+      var_name: "tnlt{PRC}p"
+      standard_name:
+      long_name: "Percentage of days when Tmin < {PRC}th percentile"
+      units: "%"
+      cell_methods:
+    input:
+      data: tasmin
+    index_function:
+      name: count_percentile_occurrences
+      parameters:
+        percentile:
+          kind: quantity
+          standard_name:
+          proposed_standard_name: quantile
+          data: {PRC}
+          units: "%"
+        condition:
+          kind: operator
+          operator: "<"
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment:
+
+  tmlt{PRC}p:
+    reference: CLIPC
+    period:
+      allowed:
+        annual:
+      default: annual
+    output:
+      var_name: "tmlt{PRC}p"
+      standard_name:
+      long_name: "Percentage of days when Tmean < {PRC}th percentile"
+      units: "%"
+      cell_methods:
+    input:
+      data: tas
+    index_function:
+      name: count_percentile_occurrences
+      parameters:
+        percentile:
+          kind: quantity
+          standard_name:
+          proposed_standard_name: quantile
+          data: {PRC}
+          units: "%"
+        condition:
+          kind: operator
+          operator: "<"
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment:
+
+  dtr:
+    reference: ETCCDI
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: monthly
+    output:
+      var_name: "dtr"
+      standard_name:
+      proposed_standard_name: air_temperature_range
+      long_name: "Mean Diurnal Temperature Range"
+      units: "degree_Celsius"
+      cell_methods:
+        - time: range within days
+        - time: mean over days
+    input:
+      low_data: tasmin
+      high_data: tasmax
+    index_function:
+      name: diurnal_temperature_range
+      parameters:
+    ET:
+      short_name: "dtr"
+      long_name: "Daily temperature range"
+      definition: "Monthly mean difference between TX and TN"
+      comment: "mean of daily temperature range"
+
+  vdtr:
+    reference: ECA&D
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: monthly
+    output:
+      var_name: "vdtr"
+      standard_name:
+      proposed_standard_name: air_temperature_difference
+      long_name: "Mean day-to-day variation in Diurnal Temperature Range"
+      units: "degree_Celsius"
+      cell_methods:
+    input:
+      low_data: tasmin
+      high_data: tasmax
+    index_function:
+      name: interday_diurnal_temperature_range
+      parameters:
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment:
+
+  etr:
+    reference: ECA&D
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: monthly
+    output:
+      var_name: "etr"
+      standard_name:
+      proposed_standard_name: air_temperature_range
+      long_name: "Intra-period extreme temperature range"
+      units: "degree_Celsius"
+      cell_methods:
+        - time: range
+    input:
+      low_data: tasmin
+      high_data: tasmax
+    index_function:
+      name: extreme_temperature_range
+      parameters:
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment:
+
+  tx{PRC}pctl:
+    reference: CLIPC
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "tx{PRC}pctl"
+      standard_name: air_temperature
+      long_name: "{PRC}th percentile of Tmax"
+      units: "degree_Celsius"
+      cell_methods:
+    input:
+      data: tasmax
+    index_function:
+      name: percentile
+      parameters:
+        percentiles:
+          kind: quantity
+          standard_name:
+          proposed_standard_name: quantile
+          data: {PRC}
+          units: "%"
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment:
+
+  tn{PRC}pctl:
+    reference: CLIPC
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "tn{PRC}pctl"
+      standard_name: air_temperature
+      long_name: "{PRC}th percentile of Tmin"
+      units: "degree_Celsius"
+      cell_methods:
+    input:
+      data: tasmin
+    index_function:
+      name: percentile
+      parameters:
+        percentiles:
+          kind: quantity
+          standard_name:
+          proposed_standard_name: quantile
+          data: {PRC}
+          units: "%"
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment:
+
+  tm{PRC}pctl:
+    reference: CLIPC
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "tm{PRC}pctl"
+      standard_name: air_temperature
+      long_name: "{PRC}th percentile of Tmean"
+      units: "degree_Celsius"
+      cell_methods:
+    input:
+      data: tas
+    index_function:
+      name: percentile
+      parameters:
+        percentiles:
+          kind: quantity
+          standard_name:
+          proposed_standard_name: quantile
+          data: {PRC}
+          units: "%"
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment:
+
+  hd17:
+    reference: ECA&D
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "hd17"
+      standard_name: integral_wrt_time_of_air_temperature_excess
+      long_name: "Heating degree days (sum of Tmean < 17 C)"
+      units: "degree_Celsius day"
+      cell_methods:
+        - time: mean within days
+        - time: sum over days
+    input:
+      data: tas
+    index_function:
+      name: temperature_sum
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: air_temperature
+          data: 17
+          units: "degree_Celsius"
+        condition:
+          kind: operator
+          operator: "<"
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment:
+
+  hddheat{TT}:
+    reference: ET-SCI
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "hddheat{TT}"
+      standard_name: integral_wrt_time_of_air_temperature_deficit
+      long_name: "Heating Degree Days (Tmean < {TT}C)"
+      units: "degree_Celsius day"
+      cell_methods:
+        - time: mean within days
+        - time: sum over days
+    input:
+      data: tas
+    index_function:
+      name: temperature_sum
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: air_temperature
+          data: {TT}
+          units: "degree_Celsius"
+        condition:
+          kind: operator
+          operator: "<"
+    ET:
+      short_name: "hddheat"
+      long_name: "Heating degree days"
+      definition: "Sum of Tb- TM (where Tb is a user- defined location-specific base temperature and TM < Tb)"
+      comment:
+
+  ddgt{TT}:
+    reference: CLIPC
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "ddgt{TT}"
+      standard_name: integral_wrt_time_of_air_temperature_excess
+      long_name: "Degree Days (Tmean > {TT}C)"
+      units: "degree_Celsius day"
+      cell_methods:
+        - time: mean within days
+        - time: sum over days
+    input:
+      data: tas
+    index_function:
+      name: temperature_sum
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: air_temperature
+          data: {TT}
+          units: "degree_Celsius"
+        condition:
+          kind: operator
+          operator: ">"
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment:
+
+  cddcold{TT}:
+    reference: ET-SCI
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "cddcold{TT}"
+      standard_name: integral_wrt_time_of_air_temperature_excess
+      long_name: "Cooling Degree Days (Tmean > {TT}C)"
+      units: "degree_Celsius day"
+      cell_methods:
+        - time: mean within days
+        - time: sum over days
+    input:
+      data: tas
+    index_function:
+      name: temperature_sum
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: air_temperature
+          data: {TT}
+          units: "degree_Celsius"
+        condition:
+          kind: operator
+          operator: ">"
+    ET:
+      short_name: "cddcold"
+      long_name: "Cooling degree days"
+      definition: "Sum of TM - Tb (where Tb is a user- defined location-specific base temperature and TM > Tb)"
+      comment:
+
+  ddlt{TT}:
+    reference: CLIPC
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "ddlt{TT}"
+      standard_name: integral_wrt_time_of_air_temperature_deficit
+      long_name: "Degree Days (Tmean < {TT}C)"
+      units: "degree_Celsius day"
+      cell_methods:
+        - time: mean within days
+        - time: sum over days
+    input:
+      data: tas
+    index_function:
+      name: temperature_sum
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: air_temperature
+          data: {TT}
+          units: "degree_Celsius"
+        condition:
+          kind: operator
+          operator: "<"
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment:
+
+  gddgrow{TT}:
+    reference: ET-SCI
+    period:
+      allowed:
+        annual:
+      default: annual
+    output:
+      var_name: "gddgrow{TT}"
+      standard_name: integral_wrt_time_of_air_temperature_excess
+      long_name: "Annual Growing Degree Days (Tmean > {TT}C)"
+      units: "degree_Celsius day"
+      cell_methods:
+        - time: mean within days
+        - time: sum over days
+    input:
+      data: tas
+    index_function:
+      name: temperature_sum
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: air_temperature
+          data: {TT}
+          units: "degree_Celsius"
+        condition:
+          kind: operator
+          operator: ">"
+    ET:
+      short_name: "gddgrow"
+      long_name: "Growing degree days"
+      definition: "Annual sum of TM - Tb (where Tb is a user- defined location-specific base temperature and TM >Tb)"
+      comment:
+
+  gd4:
+    reference: ECA&D
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "gd4"
+      standard_name: integral_wrt_time_of_air_temperature_excess
+      long_name: "Growing degree days (sum of Tmean > 4 C)"
+      units: "degree_Celsius day"
+      cell_methods:
+        - time: mean within days
+        - time: sum over days
+    input:
+      data: tas
+    index_function:
+      name: temperature_sum
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: air_temperature
+          data: 4
+          units: "degree_Celsius"
+        condition:
+          kind: operator
+          operator: ">"
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment:
+
+  r10mm:
+    reference: ETCCDI
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "r10mm"
+      standard_name: number_of_days_with_lwe_thickness_of_precipitation_amount_above_threshold
+      proposed_standard_name: number_of_occurrences_with_lwe_thickness_of_precipitation_amount_at_or_above_threshold
+      long_name: "Number of heavy precipitation days (Precip >=10mm)"
+      units: "1"
+      cell_methods:
+        - time: sum within days
+        - time: sum over days
+    input:
+      data: pr
+    index_function:
+      name: count_occurrences
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: lwe_precipitation_rate
+          data: 10
+          units: "mm day-1"
+        condition:
+          kind: operator
+          operator: ">"
+    ET:
+      short_name: "r10mm"
+      long_name: "Number of heavy precipitation days"
+      definition: "Count of days when P>=10mm"
+      comment: "count of days when daily total precipitation is above 10 mm"
+
+  r20mm:
+    reference: ETCCDI
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "r20mm"
+      standard_name: number_of_days_with_lwe_thickness_of_precipitation_amount_above_threshold
+      proposed_standard_name: number_of_occurrences_with_lwe_thickness_of_precipitation_amount_at_or_above_threshold
+      long_name: "Number of very heavy precipitation days (Precip >= 20mm)"
+      units: "1"
+      cell_methods:
+        - time: sum within days
+        - time: sum over days
+    input:
+      data: pr
+    index_function:
+      name: count_occurrences
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: lwe_precipitation_rate
+          data: 20
+          units: "mm day-1"
+        condition:
+          kind: operator
+          operator: ">"
+    ET:
+      short_name: "r20mm"
+      long_name: "Number of very heavy precipitation days"
+      definition: "Count of days when P>=20mm"
+      comment: "count of days when daily total precipitation is above 20 mm"
+
+  r{RT}mm:
+    reference: ETCCDI
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "r{RT}mm"
+      standard_name: number_of_days_with_lwe_thickness_of_precipitation_amount_above_threshold
+      proposed_standard_name: number_of_occurrences_with_lwe_thickness_of_precipitation_amount_at_or_above_threshold
+      long_name: "Number of days with daily Precip >= {RT}mm)"
+      units: "1"
+      cell_methods:
+        - time: sum within days
+        - time: sum over days
+    input:
+      data: pr
+    index_function:
+      name: count_occurrences
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: lwe_precipitation_rate
+          data: {RT}
+          units: "mm day-1"
+        condition:
+          kind: operator
+          operator: ">"
+    ET:
+      short_name: "rnnmm"
+      long_name: "Number of days above a user-defined threshold"
+      definition:
+      comment: "count of days when daily total precipitation is above X mm"
+
+  wetdays:
+    reference: CLIPC
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "wetdays"
+      standard_name: number_of_days_with_lwe_thickness_of_precipitation_amount_above_threshold
+      proposed_standard_name: number_of_occurrences_with_lwe_thickness_of_precipitation_amount_at_or_above_threshold
+      long_name: "Number of Wet Days (precip >= 1 mm)"
+      units: "1"
+      cell_methods:
+        - time: sum within days
+        - time: sum over days
+    input:
+      data: pr
+    index_function:
+      name: count_occurrences
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: lwe_precipitation_rate
+          long_name: "Wet day threshold"
+          data: 1
+          units: "mm day-1"
+        condition:
+          kind: operator
+          operator: ">"
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment:
+
+  rr1:
+    reference: ECA&D
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "rr1"
+      standard_name: number_of_days_with_lwe_thickness_of_precipitation_amount_above_threshold
+      proposed_standard_name: number_of_occurrences_with_lwe_thickness_of_precipitation_amount_at_or_above_threshold
+      long_name: "Number of Wet Days (precip >= 1 mm)"
+      units: "1"
+      cell_methods:
+        - time: sum within days
+        - time: sum over days
+    input:
+      data: pr
+    index_function:
+      name: count_occurrences
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: lwe_precipitation_rate
+          long_name: "Wet day threshold"
+          data: 1
+          units: "mm day-1"
+        condition:
+          kind: operator
+          operator: ">"
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment:
+
+  cdd:
+    reference: ETCCDI
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "cdd"
+      standard_name: spell_length_of_days_with_lwe_thickness_of_precipitation_amount_below_threshold
+      proposed_standard_name: spell_length_with_lwe_thickness_of_precipitation_amount_below_threshold
+      long_name: "Maximum consecutive dry days (Precip < 1mm)"
+      units: "day"
+      cell_methods:
+        - time: sum within days
+        - time: sum over days
+    input:
+      data: pr
+    index_function:
+      name: spell_length
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: lwe_precipitation_rate
+          long_name: "Wet day threshold"
+          data: 1
+          units: "mm day-1"
+        condition:
+          kind: operator
+          operator: "<"
+        reducer:
+          kind: reducer
+          reducer: max
+    ET:
+      short_name: "cdd"
+      long_name: "Consecutive dry days"
+      definition: "Maximum number of consecutive days with P<1mm"
+      comment: "maximum consecutive days when daily total precipitation is below 1 mm"
+
+  cwd:
+    reference: ETCCDI
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "cwd"
+      standard_name: spell_length_of_days_with_lwe_thickness_of_precipitation_amount_above_threshold
+      proposed_standard_name: spell_length_with_lwe_thickness_of_precipitation_amount_at_or_above_threshold
+      long_name: "Maximum consecutive wet days (Precip >= 1mm)"
+      units: "day"
+      cell_methods:
+        - time: sum within days
+        - time: sum over days
+    input:
+      data: pr
+    index_function:
+      name: spell_length
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: lwe_precipitation_rate
+          long_name: "Wet day threshold"
+          data: 1
+          units: "mm day-1"
+        condition:
+          kind: operator
+          operator: ">"
+        reducer:
+          kind: reducer
+          reducer: max
+    ET:
+      short_name: "cwd"
+      long_name: "Consecutive wet days"
+      definition: "Maximum number of consecutive days with P>=1mm"
+      comment: "maximum consecutive days when daily total precipitation is at least 1 mm"
+
+  prcptot:
+    reference: ETCCDI
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "prcptot"
+      standard_name: lwe_thickness_of_precipitation_amount
+      long_name: "Total precipitation during Wet Days"
+      units: "mm"
+      cell_methods:
+        - time: sum within days
+        - time: mean over days
+    input:
+      data: pr
+    index_function:
+      name: thresholded_statistics
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: lwe_precipitation_rate
+          long_name: "Wet day threshold"
+          data: 1
+          units: "mm day-1"
+        condition:
+          kind: operator
+          operator: ">"
+        reducer:
+          kind: reducer
+          reducer: sum
+    ET:
+      short_name: "prcptot"
+      long_name: "Total wet- day precipitation"
+      definition: "PRCP from wet days (P>=1mm)"
+      comment: "sum of total daily precipitation during days having at least 1 mm"
+
+  sdii:
+    reference: ETCCDI
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "sdii"
+      standard_name: lwe_precipitation_rate
+      long_name: "Average precipitation during Wet Days (SDII)"
+      units: "mm day-1"
+      cell_methods:
+        - time: sum within days
+        - time: mean over days
+    input:
+      data: pr
+    index_function:
+      name: thresholded_statistics
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: lwe_precipitation_rate
+          long_name: "Wet day threshold"
+          data: 1
+          units: "mm day-1"
+        condition:
+          kind: operator
+          operator: ">"
+        reducer:
+          kind: reducer
+          reducer: mean
+    ET:
+      short_name: "sdii"
+      long_name: "Simple precipitation intensity index"
+      definition: "PRCPTOT / Nwetdays"
+      comment: "mean daily total precipitation during days having at least 1 mm"
+
+  r{PRC}pctl:
+    reference: CLIPC
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "r{PRC}pctl"
+      standard_name: lwe_thickness_of_precipitation_amount
+      long_name: "{PRC}th percentile of precipitation during wet days (Precip >= 1mm)"
+      units: "mm"
+      cell_methods:
+    input:
+      data: pr
+    index_function:
+      name: thresholded_percentile
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: lwe_precipitation_rate
+          long_name: "Wet day threshold"
+          data: 1
+          units: "mm day-1"
+        condition:
+          kind: operator
+          operator: ">"
+        percentiles:
+          kind: quantity
+          standard_name:
+          proposed_standard_name: quantile
+          data: {PRC}
+          units: "%"
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment:
+
+  rx1day:
+    reference: ETCCDI
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "rx1day"
+      standard_name: lwe_thickness_of_precipitation_amount
+      long_name: "Maximum 1-day precipitation"
+      units: "mm"
+      cell_methods:
+        - time: sum within days
+        - time: maximum over days
+    input:
+      data: pr
+    index_function:
+      name: thresholded_statistics
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: lwe_precipitation_rate
+          long_name: "Wet day threshold"
+          data: 1
+          units: "mm day-1"
+        condition:
+          kind: operator
+          operator: ">"
+        reducer:
+          kind: reducer
+          reducer: max
+    ET:
+      short_name: "rx1day"
+      long_name: "Monthly maximum 1-day precipitation"
+      definition: "Maximum one-day precipitation"
+      comment:
+
+  rx5day:
+    reference: ETCCDI
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "rx5day"
+      standard_name: lwe_thickness_of_precipitation_amount
+      long_name: "Maximum 5-day precipitation"
+      units: "mm"
+      cell_methods:
+    input:
+      data: pr
+    index_function:
+      name: thresholded_running_statistics
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: lwe_precipitation_rate
+          long_name: "Wet day threshold"
+          data: 1
+          units: "mm day-1"
+        condition:
+          kind: operator
+          operator: ">"
+        rolling_aggregator:
+          kind: reducer
+          reducer: sum
+        window_size:
+          kind: quantity
+          standard_name:
+          proposed_standard_name: temporal_window_size
+          data: 5
+          units: "day"
+        reducer:
+          kind: reducer
+          reducer: max
+    ET:
+      short_name: "rx5day"
+      long_name: "Monthly maximum 5-day precipitation"
+      definition: "Maximum consecutive five-day precipitation"
+      comment:
+
+  rx{ND}day:
+    reference: ET-SCI
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "rx{ND}day"
+      standard_name: lwe_thickness_of_precipitation_amount
+      long_name: "Maximum {ND}-day precipitation"
+      units: "mm"
+      cell_methods:
+    input:
+      data: pr
+    index_function:
+      name: thresholded_running_statistics
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: lwe_precipitation_rate
+          long_name: "Wet day threshold"
+          data: 1
+          units: "mm day-1"
+        condition:
+          kind: operator
+          operator: ">"
+        rolling_aggregator:
+          kind: reducer
+          reducer: sum
+        window_size:
+          kind: quantity
+          standard_name:
+          proposed_standard_name: temporal_window_size
+          data: {ND}
+          units: "day"
+        reducer:
+          kind: reducer
+          reducer: max
+    ET:
+      short_name: "rxnday"
+      long_name: "User-defined consecutive days precipitation amount"
+      definition: "Maximum consecutive n-day precipitation"
+      comment:
+
+  rh:
+    reference: ECA&D
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: monthly
+    output:
+      var_name: "rh"
+      standard_name: relative_humidity
+      long_name: "Mean of daily relative humidity"
+      units: "%"
+      cell_methods:
+        - time: mean
+    input:
+      data: hurs
+    index_function:
+      name: statistics
+      parameters:
+        reducer:
+          kind: reducer
+          reducer: mean
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment:
+
+  rr:
+    reference: ECA&D
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: monthly
+    output:
+      var_name: "rr"
+      standard_name: lwe_thickness_of_precipitation_amount
+      long_name: "Precipitation sum"
+      units: "mm"
+      cell_methods:
+        - time: mean within days
+        - time: mean over days
+    input:
+      data: pr
+    index_function:
+      name: thresholded_statistics
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: lwe_precipitation_rate
+          long_name: "Wet day threshold"
+          data: 1
+          units: "mm day-1"
+        condition:
+          kind: operator
+          operator: ">"
+        reducer:
+          kind: reducer
+          reducer: sum
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment:
+
+  pp:
+    reference: ECA&D
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: monthly
+    output:
+      var_name: "pp"
+      standard_name: air_pressure_at_sea_level
+      long_name: "Mean of daily sea level pressure"
+      units: "hPa"
+      cell_methods:
+        - time: mean
+    input:
+      data: psl
+    index_function:
+      name: statistics
+      parameters:
+        reducer:
+          kind: reducer
+          reducer: mean
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment:
+
+  tg:
+    reference: ECA&D
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: monthly
+    output:
+      var_name: "tg"
+      standard_name: air_temperature
+      long_name: "Mean of daily mean temperature"
+      units: "degree_Celsius"
+      cell_methods:
+        - time: mean
+    input:
+      data: tas
+    index_function:
+      name: statistics
+      parameters:
+        reducer:
+          kind: reducer
+          reducer: mean
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment:
+
+  tn:
+    reference: ECA&D
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: monthly
+    output:
+      var_name: "tn"
+      standard_name: air_temperature
+      long_name: "Mean of daily minimum temperature"
+      units: "degree_Celsius"
+      cell_methods:
+        - time: mean
+    input:
+      data: tasmin
+    index_function:
+      name: statistics
+      parameters:
+        reducer:
+          kind: reducer
+          reducer: mean
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment:
+
+  tx:
+    reference: ECA&D
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: monthly
+    output:
+      var_name: "tx"
+      standard_name: air_temperature
+      long_name: "Mean of daily maximum temperature"
+      units: "degree_Celsius"
+      cell_methods:
+        - time: mean
+    input:
+      data: tasmax
+    index_function:
+      name: statistics
+      parameters:
+        reducer:
+          kind: reducer
+          reducer: mean
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment:
+
+  sd:
+    reference: ECA&D
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: monthly
+    output:
+      var_name: "sd"
+      standard_name: surface_snow_thickness
+      long_name: "Mean of daily snow depth"
+      units: "cm"
+      cell_methods:
+        - time: mean
+    input:
+      data: snd
+    index_function:
+      name: statistics
+      parameters:
+        reducer:
+          kind: reducer
+          reducer: mean
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment:
+
+  sd1:
+    reference: ECA&D
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: monthly
+    output:
+      var_name: "sd1"
+      standard_name: number_of_days_with_surface_snow_thickness_above_threshold
+      proposed_standard_name: number_of_occurrences_with_surface_snow_thickness_at_or_above_threshold
+      long_name: "Snow days (SD >= 1 cm)"
+      units: "1"
+      cell_methods:
+        - time: mean within days
+        - time: sum over days
+    input:
+      data: snd
+    index_function:
+      name: count_occurrences
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: surface_snow_thickness
+          data: 1
+          units: "cm"
+        condition:
+          kind: operator
+          operator: ">"
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment:
+
+  sd5cm:
+    reference: ECA&D
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: monthly
+    output:
+      var_name: "sd5cm"
+      standard_name: number_of_days_with_surface_snow_thickness_above_threshold
+      proposed_standard_name: number_of_occurrences_with_surface_snow_thickness_at_or_above_threshold
+      long_name: "Number of days with snow depth >= 5 cm"
+      units: "1"
+      cell_methods:
+        - time: mean within days
+        - time: sum over days
+    input:
+      data: snd
+    index_function:
+      name: count_occurrences
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: surface_snow_thickness
+          data: 5
+          units: "cm"
+        condition:
+          kind: operator
+          operator: ">"
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment:
+
+  sd50cm:
+    reference: ECA&D
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: monthly
+    output:
+      var_name: "sd50cm"
+      standard_name: number_of_days_with_surface_snow_thickness_above_threshold
+      proposed_standard_name: number_of_occurrences_with_surface_snow_thickness_at_or_above_threshold
+      long_name: "Number of days with snow depth >= 50 cm"
+      units: "1"
+      cell_methods:
+        - time: mean within days
+        - time: sum over days
+    input:
+      data: snd
+    index_function:
+      name: count_occurrences
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: surface_snow_thickness
+          data: 50
+          units: "cm"
+        condition:
+          kind: operator
+          operator: ">"
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment:
+
+  sd{D}cm:
+    reference: ECA&D
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: monthly
+    output:
+      var_name: "sd{D}cm"
+      standard_name: number_of_days_with_surface_snow_thickness_above_threshold
+      proposed_standard_name: number_of_occurrences_with_surface_snow_thickness_at_or_above_threshold
+      long_name: "Number of days with snow depth >= {D} cm"
+      units: "1"
+      cell_methods:
+        - time: mean within days
+        - time: sum over days
+    input:
+      data: snd
+    index_function:
+      name: count_occurrences
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: surface_snow_thickness
+          data: {D}
+          units: "cm"
+        condition:
+          kind: operator
+          operator: ">"
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment:
+
+  ss:
+    reference: ECA&D
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: monthly
+    output:
+      var_name: "ss"
+      standard_name: duration_of_sunshine
+      long_name: "Sunshine duration, sum"
+      units: "hour"
+      cell_methods:
+    input:
+      data: sund
+    index_function:
+      name: statistics
+      parameters:
+        reducer:
+          kind: reducer
+          reducer: sum
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment:
+
+  fxx:
+    reference: ECA&D
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: monthly
+    output:
+      var_name: "fxx"
+      standard_name: wind_speed_of_gust
+      long_name: "Maximum value of daily maximum wind gust strength"
+      units: "meter second-1"
+      cell_methods:
+        - time: maximum
+    input:
+      data: wsgsmax
+    index_function:
+      name: statistics
+      parameters:
+        reducer:
+          kind: reducer
+          reducer: max
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment:
+
+  fg6bft:
+    reference: ECA&D
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: monthly
+    output:
+      var_name: "fg6bft"
+      standard_name: number_of_days_with_wind_speed_above_threshold
+      proposed_standard_name: number_of_occurrences_with_wind_speed_at_or_above_threshold
+      long_name: "Days with daily averaged wind strength >= 6 Bft (>=10.8 m/s)"
+      units: "1"
+      cell_methods:
+        - time: mean within days
+        - time: sum over days
+    input:
+      data: sfcWind
+    index_function:
+      name: count_occurrences
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: wind_speed
+          data: 10.8
+          units: "meter second-1"
+        condition:
+          kind: operator
+          operator: ">"
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment:
+
+  fgcalm:
+    reference: ECA&D
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: monthly
+    output:
+      var_name: "fgcalm"
+      standard_name: number_of_days_with_wind_speed_below_threshold
+      proposed_standard_name: number_of_occurrences_with_wind_speed_at_or_below_threshold
+      long_name: "Calm days (daily mean wind strength <= 2 m/s)"
+      units: "1"
+      cell_methods:
+        - time: mean within days
+        - time: sum over days
+    input:
+      data: sfcWind
+    index_function:
+      name: count_occurrences
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: wind_speed
+          data: 2
+          units: "meter second-1"
+        condition:
+          kind: operator
+          operator: "<"
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment:
+
+  fg:
+    reference: ECA&D
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: monthly
+    output:
+      var_name: "fg"
+      standard_name: wind_speed
+      long_name: "Mean of daily mean wind strength"
+      units: "meter second-1"
+      cell_methods:
+        - time: mean
+    input:
+      data: sfcWind
+    index_function:
+      name: statistics
+      parameters:
+        reducer:
+          kind: reducer
+          reducer: mean
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment:
+
+  nzero:
+    reference: SMHI
+    period:
+      allowed:
+        annual:
+        seasonal:
+        monthly:
+      default: annual
+    output:
+      var_name: "nzero"
+      standard_name:
+      proposed_standard_name: number_of_occurrences_with_air_temperature_level_crossings
+      long_name: "Number of zero-crossing days (days when Tmin < 0 degC < Tmax)"
+      units: "1"
+      cell_methods:
+        - time: sum over days
+    input:
+      low_data: tasmin
+      high_data: tasmax
+    index_function:
+      name: count_level_crossings
+      parameters:
+        threshold:
+          kind: quantity
+          standard_name: air_temperature
+          long_name: "Level crossing value for daily air temperature"
+          data: 0
+          units: "degree_Celsius"
+    ET:
+      short_name:
+      long_name:
+      definition:
+      comment:

--- a/icclim/ecad_functions.py
+++ b/icclim/ecad_functions.py
@@ -743,13 +743,9 @@ def ww(config: IndexConfig) -> DataArray:
 def _can_run_bootstrap(
     cf_var: CfVariable, percentile_period: slice, interpolation: QuantileInterpolation
 ) -> bool:
-    da = cf_var.da
-    time_index = da.indexes.get("time")
-    if isinstance(time_index, xr.CFTimeIndex):
-        years = time_index.year
-    else:
-        years = da.time.dt.year
-    overlapping_years = np.unique(years)
+    overlapping_years = np.unique(
+        cf_var.da.sel(time=percentile_period).indexes.get("time").year
+    )
     # No bootstrap if there is one single year overlapping
     # or no year overlapping
     # or all year overlapping

--- a/icclim/ecad_functions.py
+++ b/icclim/ecad_functions.py
@@ -2,7 +2,7 @@
 All ECA&D functions. Each function wraps its xclim equivalent functions adding icclim
 metadata to it.
 """
-from typing import Callable, Optional, Tuple, Union
+from typing import Callable, Optional, Tuple
 from warnings import warn
 
 import numpy as np
@@ -19,10 +19,6 @@ from icclim.models.constants import IN_BASE_IDENTIFIER, PERCENTILES_COORD
 from icclim.models.frequency import Frequency
 from icclim.models.index_config import CfVariable, IndexConfig
 from icclim.models.quantile_interpolation import QuantileInterpolation
-
-ComputeIndexFun = Callable[
-    [IndexConfig], Union[DataArray, Tuple[DataArray, Optional[DataArray]]]
-]
 
 
 def gd4(config: IndexConfig) -> DataArray:
@@ -637,7 +633,7 @@ def cd(config: IndexConfig) -> DataArray:
             returns a Tuple of index_result, computed_percentiles
         Otherwise, returns the index_result
     """
-    return _compute_compound_index(
+    return compute_compound_index(
         tas=config.tas,
         pr=config.pr,
         freq=config.freq.panda_freq,
@@ -672,7 +668,7 @@ def cw(config: IndexConfig) -> DataArray:
             returns a Tuple of index_result, computed_percentiles
         Otherwise, returns the index_result
     """
-    return _compute_compound_index(
+    return compute_compound_index(
         tas=config.tas,
         pr=config.pr,
         freq=config.freq.panda_freq,
@@ -707,7 +703,7 @@ def wd(config: IndexConfig) -> DataArray:
             returns a Tuple made of  index_result, computed_percentiles
         Otherwise, returns the index_result
     """
-    return _compute_compound_index(
+    return compute_compound_index(
         tas=config.tas,
         pr=config.pr,
         freq=config.freq.panda_freq,
@@ -730,7 +726,7 @@ def ww(config: IndexConfig) -> DataArray:
     Days with TG > 75th percentile of daily mean temperature and RR > 75th percentile of
     daily precipitation sum (warm/wet days)
     """
-    return _compute_compound_index(
+    return compute_compound_index(
         tas=config.tas,
         pr=config.pr,
         freq=config.freq.panda_freq,
@@ -907,7 +903,7 @@ def _compute_spell_duration(
     return result, None
 
 
-def _compute_compound_index(
+def compute_compound_index(
     tas: CfVariable,
     pr: CfVariable,
     freq: str,
@@ -991,24 +987,6 @@ def _compute_rxxptot(
     per_interpolation: QuantileInterpolation,
     save_percentile: bool,
 ) -> Tuple[DataArray, Optional[DataArray]]:
-    """
-    R99ptot, R95ptot, R75ptot.
-    Not computed on doy percentiles.
-
-    Source ECAD.
-
-    Parameters
-    ----------
-    pr :
-    freq :
-    pr_per_thresh :
-    per_interpolation :
-    save_percentile :
-
-    Returns
-    -------
-
-    """
     base_wet_days = _filter_in_wet_days(pr.in_base_da, dry_day_value=np.nan)
     per = _compute_percentile_over_period(
         base_wet_days, per_interpolation, pr_per_thresh
@@ -1035,22 +1013,6 @@ def _compute_rxxp(
     save_percentile: bool,
     is_percent: bool,
 ) -> Tuple[DataArray, Optional[DataArray]]:
-    """
-    R95P,
-
-    Parameters
-    ----------
-    pr :
-    freq :
-    pr_per_thresh :
-    per_interpolation :
-    save_percentile :
-    is_percent :
-
-    Returns
-    -------
-
-    """
     base_wet_days = _filter_in_wet_days(pr.in_base_da, dry_day_value=np.nan)
     per = _compute_percentile_over_period(
         base_wet_days, per_interpolation, pr_per_thresh

--- a/icclim/icclim_logger.py
+++ b/icclim/icclim_logger.py
@@ -28,6 +28,10 @@ class Verbosity(Enum):
 
 
 class IcclimLogger:
+    """
+    Singleton to display and control logs in icclim library.
+    """
+
     __instance = None
     verbosity: Verbosity = Verbosity.LOW
     timezone: str
@@ -40,7 +44,9 @@ class IcclimLogger:
 
     def __init__(self, verbosity: Verbosity):
         if IcclimLogger.__instance is not None:
-            raise Exception("This class is a singleton!")
+            raise Exception(
+                "This class is a singleton! Use IcclimLogger::get_instance."
+            )
         else:
             IcclimLogger.__instance = self
             self.verbosity = verbosity
@@ -148,3 +154,6 @@ class IcclimLogger:
         logging.warning(
             f"DEPRECATION_WARNING: `{old}` is deprecated. Use `{new}` instead."
         )
+
+    def callback(self, percent):
+        logging.info(f"Processing: {percent}%")

--- a/icclim/icclim_logger.py
+++ b/icclim/icclim_logger.py
@@ -150,10 +150,15 @@ class IcclimLogger:
             "   ********************************************************************************************"
         )
 
-    def deprecation_warning(self, old: str, new: str):
-        logging.warning(
-            f"DEPRECATION_WARNING: `{old}` is deprecated. Use `{new}` instead."
-        )
+    def deprecation_warning(self, old: str, new: str = None) -> None:
+        if new:
+            logging.warning(
+                f"DEPRECATION_WARNING: `{old}` is deprecated. Use `{new}` instead."
+            )
+        else:
+            logging.warning(
+                f"DEPRECATION_WARNING: `{old}` is deprecated and will be removed. Its value is ignored."
+            )
 
-    def callback(self, percent):
+    def callback(self, percent) -> None:
         logging.info(f"Processing: {percent}%")

--- a/icclim/main.py
+++ b/icclim/main.py
@@ -54,7 +54,7 @@ def indice(*args, **kwargs):
 
 def index(
     in_files: Union[str, List[str], Dataset],
-    index_name: str,
+    index_name: str = None,  # optional when computing user_indices
     var_name: Optional[Union[str, List[str]]] = None,
     slice_mode: SliceMode = Frequency.YEAR,
     time_range: List[datetime] = None,
@@ -272,7 +272,7 @@ def _compute_user_index_dataset(config: IndexConfig, user_index: dict) -> Datase
     user_indice_config = UserIndexConfig(
         **user_index,
         freq=config.freq,
-        cf_vars=config.cf_variables,
+        cf_vars=config._cf_variables,
         is_percent=config.is_percent,
         save_percentile=config.save_percentile,
     )

--- a/icclim/main.py
+++ b/icclim/main.py
@@ -32,6 +32,17 @@ __all__ = ["index"]
 log: IcclimLogger = IcclimLogger.get_instance(Verbosity.LOW)
 
 
+def indices():
+    """
+    List the available indices.
+    todo: include a representation of custom indices.
+    Returns
+    -------
+        A list of indices to be used as input of icclim.index `index_name` parameter.
+    """
+    return [f"{i.short_name}: {i.definition}" for i in EcadIndex]
+
+
 def indice(*args, **kwargs):
     """
     Proxy for `index`

--- a/icclim/models/IcclimDaskConfiguration.py
+++ b/icclim/models/IcclimDaskConfiguration.py
@@ -1,0 +1,33 @@
+from enum import Enum
+from typing import Any
+
+from icclim_exceptions import InvalidIcclimArgumentError
+
+
+class IcclimDaskConfiguration(Enum):
+    MOUNTAIN = (100, True, 0, 8, 1)
+    HILL = (50, True, 0, 8, 1)
+    TALUS = (50, True, 0, 8, 1)
+
+    def __init__(
+        self,
+        chunk_size,
+        start_local_cluster,
+        mem_limit,
+        nb_threads,
+        nb_process,
+    ):
+        self.chunk_size = chunk_size
+        self.start_local_cluster = start_local_cluster
+        self.nb_threads = nb_threads
+        self.nb_process = nb_process
+
+    @staticmethod
+    def lookup(query: str) -> Any:
+        for e in IcclimDaskConfiguration:
+            if e.index_name.upper() == query.upper():
+                return e
+        raise InvalidIcclimArgumentError(
+            f"Unknown configuration {query}."
+            f"Use one of {[f for f in IcclimDaskConfiguration]}"
+        )

--- a/icclim/models/constants.py
+++ b/icclim/models/constants.py
@@ -26,3 +26,12 @@ PR = ["pr", "pradjust", "prec", "rr", "precip", "PREC", "Prec", "RR", "PRECIP", 
 TAS = ["tas", "tavg", "ta", "tasadjust", "tmean", "tm", "tg", "meant", "TMEAN", "Tmean", "TM", "TG", "MEANT", "meanT", "tasmidpoint"]
 TAS_MAX = ["tasmax", "tasmaxadjust", "tmax", "tx", "maxt", "TMAX", "Tmax", "TX", "MAXT", "maxT"]
 TAS_MIN = ["tasmin", "tasminadjust", "tmin", "tn", "mint", "TMIN", "Tmin", "TN", "MINT", "minT"]
+
+# Source of index definition
+ECAD_ATBD = "Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11"
+
+# Index qualifiers
+QUANTILE_BASED = "QUANTILE_BASED"  # fields: QUANTILE_INDEX_FIELDS
+MODIFIABLE_UNIT = "MODIFIABLE_UNIT"  # fields: out_unit
+MODIFIABLE_THRESHOLD = "MODIFIABLE_THRESHOLD"  # fields: threshold
+MODIFIABLE_QUANTILE_WINDOW = "MODIFIABLE_QUANTILE_WINDOW"  # fields: window_width

--- a/icclim/models/ecad_indices.py
+++ b/icclim/models/ecad_indices.py
@@ -1,8 +1,10 @@
 from enum import Enum
-from typing import Any, List
+from typing import Any, Callable, List, Optional, Tuple, Union
+
+from clix_meta.clix_meta_indices import ClixMetaIndices
+from xarray import DataArray
 
 from icclim.ecad_functions import (
-    ComputeIndexFun,
     cd,
     cdd,
     cfd,
@@ -58,8 +60,13 @@ from icclim.models.constants import (
     COLD_GROUP,
     COMPOUND_GROUP,
     DROUGHT_GROUP,
+    ECAD_ATBD,
     HEAT_GROUP,
+    MODIFIABLE_QUANTILE_WINDOW,
+    MODIFIABLE_THRESHOLD,
+    MODIFIABLE_UNIT,
     PR,
+    QUANTILE_BASED,
     RAIN_GROUP,
     SNOW_GROUP,
     TAS,
@@ -67,6 +74,13 @@ from icclim.models.constants import (
     TAS_MIN,
     TEMPERATURE_GROUP,
 )
+from icclim.models.index_config import IndexConfig
+
+ComputeIndexFun = Callable[
+    [IndexConfig], Union[DataArray, Tuple[DataArray, Optional[DataArray]]]
+]
+
+clix_indices: ClixMetaIndices = ClixMetaIndices.get_instance()
 
 
 class EcadIndex(Enum):
@@ -78,84 +92,374 @@ class EcadIndex(Enum):
             The function to compute the index. It wraps Xclim functions.
         group: str
             The index group category. one of
-            `{"temperature", "heat", "cold", "drought", "rain", "snow", "compound"}`
+            ``{"temperature", "heat", "cold", "drought", "rain", "snow", "compound"}``
         variables: List[List[str]]
             The Cf variables needed to compute the index.
             The variable are individually described by a list of aliases.
+        qualifiers: List[str]
+            ``optional`` List of configuration to compute the index.
+            Used internally to generate modules for C3S.
     """
 
-    # temperature
-    TG = ("TG", tg, TEMPERATURE_GROUP, [TAS])
-    TN = ("TN", tn, TEMPERATURE_GROUP, [TAS_MIN])
-    TX = ("TX", tx, TEMPERATURE_GROUP, [TAS_MAX])
-    DTR = ("DTR", dtr, TEMPERATURE_GROUP, [TAS_MAX, TAS_MIN])
-    ETR = ("ETR", etr, TEMPERATURE_GROUP, [TAS_MAX, TAS_MIN])
-    VDTR = ("vDTR", vdtr, TEMPERATURE_GROUP, [TAS_MAX, TAS_MIN])
-    # heat
-    SU = ("SU", su, HEAT_GROUP, [TAS_MAX])
-    TR = ("TR", tr, HEAT_GROUP, [TAS_MIN])
-    WSDI = ("WSDI", wsdi, HEAT_GROUP, [TAS_MAX])
-    TG90P = ("TG90p", tg90p, HEAT_GROUP, [TAS])
-    TN90P = ("TN90p", tn90p, HEAT_GROUP, [TAS_MIN])
-    TX90P = ("TX90p", tx90p, HEAT_GROUP, [TAS_MAX])
-    TXX = ("TXx", txx, HEAT_GROUP, [TAS_MAX])
-    TNX = ("TNx", tnx, HEAT_GROUP, [TAS_MIN])
-    CSU = ("CSU", csu, HEAT_GROUP, [TAS_MAX])
-    # cold
-    GD4 = ("GD4", gd4, COLD_GROUP, [TAS])
-    FD = ("FD", fd, COLD_GROUP, [TAS_MIN])
-    CFD = ("CFD", cfd, COLD_GROUP, [TAS_MIN])
-    HD17 = ("HD17", hd17, COLD_GROUP, [TAS])
-    ID = ("ID", id, COLD_GROUP, [TAS_MAX])
-    TG10P = ("TG10p", tg10p, COLD_GROUP, [TAS])
-    TN10P = ("TN10p", tn10p, COLD_GROUP, [TAS_MIN])
-    TX10P = ("TX10p", tx10p, COLD_GROUP, [TAS_MAX])
-    TXN = ("TXn", txn, COLD_GROUP, [TAS_MAX])
-    TNN = ("TNn", tnn, COLD_GROUP, [TAS_MIN])
-    CSDI = ("CSDI", csdi, COLD_GROUP, [TAS_MIN])
-    # drought
-    CDD = ("CDD", cdd, DROUGHT_GROUP, [PR])
-    # rain
-    PRCPTOT = ("PRCPTOT", prcptot, RAIN_GROUP, [PR])
-    RR1 = ("RR1", rr1, RAIN_GROUP, [PR])
-    SDII = ("SDII", sdii, RAIN_GROUP, [PR])
-    CWD = ("CWD", cwd, RAIN_GROUP, [PR])
-    R10MM = ("R10mm", r10mm, RAIN_GROUP, [PR])
-    R20MM = ("R20mm", r20mm, RAIN_GROUP, [PR])
-    RX1DAY = ("RX1day", rx1day, RAIN_GROUP, [PR])
-    RX5DAY = ("RX5day", rx5day, RAIN_GROUP, [PR])
-    R75P = ("R75p", r75p, RAIN_GROUP, [PR])
-    R75PTOT = ("R75pTOT", r75ptot, RAIN_GROUP, [PR])
-    R95P = ("R95p", r95p, RAIN_GROUP, [PR])
-    R95PTOT = ("R95pTOT", r95ptot, RAIN_GROUP, [PR])
-    R99P = ("R99p", r99p, RAIN_GROUP, [PR])
-    R99PTOT = ("R99pTOT", r99ptot, RAIN_GROUP, [PR])
-    # snow
-    SD = ("SD", sd, SNOW_GROUP, [PR])
-    SD1 = ("SD1", sd1, SNOW_GROUP, [PR])
-    SD5CM = ("SD5cm", sd5cm, SNOW_GROUP, [PR])
-    SD50CM = ("SD50cm", sd50cm, SNOW_GROUP, [PR])
-    # compound
-    CD = ("CD", cd, COMPOUND_GROUP, [TAS, PR])
-    CW = ("CW", cw, COMPOUND_GROUP, [TAS, PR])
-    WD = ("WD", wd, COMPOUND_GROUP, [TAS, PR])
-    WW = ("WW", ww, COMPOUND_GROUP, [TAS, PR])
+    # Temperature
+    TG = (
+        "TG",
+        lambda c: tg(c),
+        TEMPERATURE_GROUP,
+        [TAS],
+    )
+    TN = (
+        "TN",
+        lambda c: tn(c),
+        TEMPERATURE_GROUP,
+        [TAS_MIN],
+    )
+    TX = (
+        "TX",
+        lambda c: tx(c),
+        TEMPERATURE_GROUP,
+        [TAS_MAX],
+    )
+    DTR = (
+        "DTR",
+        lambda c: dtr(c),
+        TEMPERATURE_GROUP,
+        [TAS_MAX, TAS_MIN],
+    )
+    ETR = (
+        "ETR",
+        lambda c: etr(c),
+        TEMPERATURE_GROUP,
+        [TAS_MAX, TAS_MIN],
+    )
+    VDTR = (
+        "vDTR",
+        lambda c: vdtr(c),
+        TEMPERATURE_GROUP,
+        [TAS_MAX, TAS_MIN],
+    )
+
+    # Heat
+    SU = (
+        "SU",
+        lambda c: su(c),
+        HEAT_GROUP,
+        [TAS_MAX],
+        [MODIFIABLE_THRESHOLD],
+    )
+    TR = (
+        "TR",
+        lambda c: tr(c),
+        HEAT_GROUP,
+        [TAS_MIN],
+        [MODIFIABLE_THRESHOLD],
+    )
+    WSDI = (
+        "WSDI",
+        lambda c: wsdi(c),
+        HEAT_GROUP,
+        [TAS_MAX],
+        [QUANTILE_BASED, MODIFIABLE_QUANTILE_WINDOW, MODIFIABLE_UNIT],
+    )
+    TG90P = (
+        "TG90p",
+        lambda c: tg90p(c),
+        HEAT_GROUP,
+        [TAS],
+        [QUANTILE_BASED, MODIFIABLE_QUANTILE_WINDOW, MODIFIABLE_UNIT],
+    )
+    TN90P = (
+        "TN90p",
+        lambda c: tn90p(c),
+        HEAT_GROUP,
+        [TAS_MIN],
+        [QUANTILE_BASED, MODIFIABLE_QUANTILE_WINDOW, MODIFIABLE_UNIT],
+    )
+    TX90P = (
+        "TX90p",
+        lambda c: tx90p(c),
+        HEAT_GROUP,
+        [TAS_MAX],
+        [QUANTILE_BASED, MODIFIABLE_QUANTILE_WINDOW, MODIFIABLE_UNIT],
+    )
+    TXX = (
+        "TXx",
+        lambda c: txx(c),
+        HEAT_GROUP,
+        [TAS_MAX],
+    )
+    TNX = (
+        "TNx",
+        lambda c: tnx(c),
+        HEAT_GROUP,
+        [TAS_MIN],
+    )
+    CSU = (
+        "CSU",
+        lambda c: csu(c),
+        HEAT_GROUP,
+        [TAS_MAX],
+        [MODIFIABLE_THRESHOLD],
+    )
+
+    # Cold
+    GD4 = (
+        "GD4",
+        lambda c: gd4(c),
+        COLD_GROUP,
+        [TAS],
+        [MODIFIABLE_THRESHOLD],
+    )
+    FD = (
+        "FD",
+        lambda c: fd(c),
+        COLD_GROUP,
+        [TAS_MIN],
+        [MODIFIABLE_THRESHOLD],
+    )
+    CFD = (
+        "CFD",
+        lambda c: cfd(c),
+        COLD_GROUP,
+        [TAS_MIN],
+        [MODIFIABLE_THRESHOLD],
+    )
+    HD17 = (
+        "HD17",
+        lambda c: hd17(c),
+        COLD_GROUP,
+        [TAS],
+        [MODIFIABLE_THRESHOLD],
+    )
+    ID = (
+        "ID",
+        lambda c: id(c),
+        COLD_GROUP,
+        [TAS_MAX],
+        [MODIFIABLE_THRESHOLD],
+    )
+    TG10P = (
+        "TG10p",
+        lambda c: tg10p(c),
+        COLD_GROUP,
+        [TAS],
+        [QUANTILE_BASED, MODIFIABLE_QUANTILE_WINDOW, MODIFIABLE_UNIT],
+    )
+    TN10P = (
+        "TN10p",
+        lambda c: tn10p(c),
+        COLD_GROUP,
+        [TAS_MIN],
+        [QUANTILE_BASED, MODIFIABLE_QUANTILE_WINDOW, MODIFIABLE_UNIT],
+    )
+    TX10P = (
+        "TX10p",
+        lambda c: tx10p(c),
+        COLD_GROUP,
+        [TAS_MAX],
+        [QUANTILE_BASED, MODIFIABLE_QUANTILE_WINDOW, MODIFIABLE_UNIT],
+    )
+    TXN = (
+        "TXn",
+        lambda c: txn(c),
+        COLD_GROUP,
+        [TAS_MAX],
+    )
+    TNN = (
+        "TNn",
+        lambda c: tnn(c),
+        COLD_GROUP,
+        [TAS_MIN],
+    )
+    CSDI = (
+        "CSDI",
+        lambda c: csdi(c),
+        COLD_GROUP,
+        [TAS_MIN],
+        [QUANTILE_BASED, MODIFIABLE_QUANTILE_WINDOW],
+    )
+
+    # Drought
+    CDD = (
+        "CDD",
+        lambda c: cdd(c),
+        DROUGHT_GROUP,
+        [PR],
+    )
+
+    # Rain
+    PRCPTOT = (
+        "PRCPTOT",
+        lambda c: prcptot(c),
+        RAIN_GROUP,
+        [PR],
+    )
+    RR1 = (
+        "RR1",
+        lambda c: rr1(c),
+        RAIN_GROUP,
+        [PR],
+    )
+    SDII = (
+        "SDII",
+        lambda c: sdii(c),
+        RAIN_GROUP,
+        [PR],
+    )
+    CWD = (
+        "CWD",
+        lambda c: cwd(c),
+        RAIN_GROUP,
+        [PR],
+    )
+    R10MM = (
+        "R10mm",
+        lambda c: r10mm(c),
+        RAIN_GROUP,
+        [PR],
+    )
+    R20MM = (
+        "R20mm",
+        lambda c: r20mm(c),
+        RAIN_GROUP,
+        [PR],
+    )
+    RX1DAY = (
+        "RX1day",
+        lambda c: rx1day(c),
+        RAIN_GROUP,
+        [PR],
+    )
+    RX5DAY = (
+        "RX5day",
+        lambda c: rx5day(c),
+        RAIN_GROUP,
+        [PR],
+    )
+    R75P = (
+        "R75p",
+        lambda c: r75p(c),
+        RAIN_GROUP,
+        [PR],
+        [QUANTILE_BASED, MODIFIABLE_UNIT],
+    )
+    R75PTOT = (
+        "R75pTOT",
+        lambda c: r75ptot(c),
+        RAIN_GROUP,
+        [PR],
+        [QUANTILE_BASED],
+    )
+    R95P = (
+        "R95p",
+        lambda c: r95p(c),
+        RAIN_GROUP,
+        [PR],
+        [QUANTILE_BASED, MODIFIABLE_UNIT],
+    )
+    R95PTOT = (
+        "R95pTOT",
+        lambda c: r95ptot(c),
+        RAIN_GROUP,
+        [PR],
+        [QUANTILE_BASED],
+    )
+    R99P = (
+        "R99p",
+        lambda c: r99p(c),
+        RAIN_GROUP,
+        [PR],
+        [QUANTILE_BASED, MODIFIABLE_UNIT],
+    )
+    R99PTOT = (
+        "R99pTOT",
+        lambda c: r99ptot(c),
+        RAIN_GROUP,
+        [PR],
+        [QUANTILE_BASED],
+    )
+
+    # Snow
+    SD = (
+        "SD",
+        lambda c: sd(c),
+        SNOW_GROUP,
+        [PR],
+    )
+    SD1 = (
+        "SD1",
+        lambda c: sd1(c),
+        SNOW_GROUP,
+        [PR],
+    )
+    SD5CM = (
+        "SD5cm",
+        lambda c: sd5cm(c),
+        SNOW_GROUP,
+        [PR],
+    )
+    SD50CM = (
+        "SD50cm",
+        lambda c: sd50cm(c),
+        SNOW_GROUP,
+        [PR],
+    )
+
+    # Compound (precipitation and temperature)
+    CD = (
+        "CD",
+        lambda c: cd(c),
+        COMPOUND_GROUP,
+        [TAS, PR],
+        [QUANTILE_BASED, MODIFIABLE_QUANTILE_WINDOW],
+    )
+    CW = (
+        "CW",
+        lambda c: cw(c),
+        COMPOUND_GROUP,
+        [TAS, PR],
+        [QUANTILE_BASED, MODIFIABLE_QUANTILE_WINDOW],
+    )
+    WD = (
+        "WD",
+        lambda c: wd(c),
+        COMPOUND_GROUP,
+        [TAS, PR],
+        [QUANTILE_BASED, MODIFIABLE_QUANTILE_WINDOW],
+    )
+    WW = (
+        "WW",
+        lambda c: ww(c),
+        COMPOUND_GROUP,
+        [TAS, PR],
+        [QUANTILE_BASED, MODIFIABLE_QUANTILE_WINDOW],
+    )
 
     def __init__(
         self,
-        index_name: str,
+        short_name: str,
         compute: ComputeIndexFun,
         group: str,
         variables: List[List[str]],
+        qualifiers: List[str] = None,
     ):
-        self.index_name = index_name
+        self.short_name = short_name
         self.compute = compute
         self.group = group
         self.variables = variables
+        if qualifiers is None:
+            qualifiers = []
+        self.qualifiers = qualifiers
+        definition = ""
+        clix_index = clix_indices.lookup(short_name)
+        if clix_index is not None:
+            definition = clix_index["output"]["long_name"]
+        self.definition = definition
+        self.source = ECAD_ATBD
 
     @staticmethod
     def lookup(query: str) -> Any:
         for e in EcadIndex:
-            if e.index_name.upper() == query.upper():
+            if e.short_name.upper() == query.upper():
                 return e
         raise InvalidIcclimArgumentError(f"Unknown index {query}.")

--- a/icclim/models/ecad_indices.py
+++ b/icclim/models/ecad_indices.py
@@ -1,9 +1,9 @@
 from enum import Enum
 from typing import Any, Callable, List, Optional, Tuple, Union
 
-from clix_meta.clix_meta_indices import ClixMetaIndices
 from xarray import DataArray
 
+from icclim.clix_meta.clix_meta_indices import ClixMetaIndices
 from icclim.ecad_functions import (
     cd,
     cdd,

--- a/icclim/models/index_config.py
+++ b/icclim/models/index_config.py
@@ -67,7 +67,7 @@ class IndexConfig:
     """
 
     freq: Frequency
-    cf_variables: List[CfVariable]
+    _cf_variables: List[CfVariable]
     save_percentile: bool = False
     is_percent: bool = False
     netcdf_version: NetcdfVersion
@@ -105,7 +105,7 @@ class IndexConfig:
             base_period_time_range = [
                 x.strftime("%Y-%m-%d") for x in base_period_time_range
             ]
-        self.cf_variables = [
+        self._cf_variables = [
             _build_cf_variable(
                 da=ds[cf_var_name],
                 time_range=time_range,
@@ -129,6 +129,26 @@ class IndexConfig:
         self.threshold = threshold
         self.callback = callback
         self.index = index
+
+    @property
+    def tas(self) -> CfVariable:
+        return self._cf_variables[0]
+
+    @property
+    def tasmax(self) -> CfVariable:
+        return self._cf_variables[0]
+
+    @property
+    def tasmin(self) -> CfVariable:
+        if len(self._cf_variables) > 1:
+            return self._cf_variables[1]
+        return self._cf_variables[0]
+
+    @property
+    def pr(self) -> CfVariable:
+        if len(self._cf_variables) > 1:
+            return self._cf_variables[1]
+        return self._cf_variables[0]
 
 
 def _build_cf_variable(

--- a/icclim/models/index_config.py
+++ b/icclim/models/index_config.py
@@ -95,6 +95,7 @@ class IndexConfig:
             QuantileInterpolation
         ] = QuantileInterpolation.MEDIAN_UNBIASED,
         callback: Optional[Callable] = None,
+        chunk_it: bool = False,
     ):
         self.freq = Frequency.lookup(slice_mode)
         if time_range is not None:
@@ -110,6 +111,7 @@ class IndexConfig:
                 ignore_Feb29th=ignore_Feb29th,
                 base_period_time_range=base_period_time_range,
                 only_leap_years=only_leap_years,
+                chunk_it=chunk_it,
             )
             for cf_var_name in var_name
         ]
@@ -153,7 +155,11 @@ def _build_cf_variable(
     ignore_Feb29th: bool,
     base_period_time_range: Optional[List[datetime]],
     only_leap_years: bool,
+    chunk_it: bool,
 ) -> CfVariable:
+    if chunk_it:
+        # todo maybe do it only on indices where parallelization will be useful
+        da = da.chunk("auto")  # typing fixed in next xarray version
     out_of_base_da = _build_data_array(da, time_range, ignore_Feb29th)
     if base_period_time_range is not None:
         in_base_da = _build_in_base_da(da, base_period_time_range, only_leap_years)

--- a/icclim/models/index_config.py
+++ b/icclim/models/index_config.py
@@ -26,6 +26,7 @@ class CfVariable:
         The variable studied limited to the in base period.
     """
 
+    # TODO: seems unnecessary abstraction between ds and da. Replace by a Dataset.
     da: DataArray
     in_base_da: DataArray
 

--- a/icclim/tests/unit_tests/test_ecad_indices.py
+++ b/icclim/tests/unit_tests/test_ecad_indices.py
@@ -358,7 +358,7 @@ class TestTx90p:
             time_range=[datetime.datetime(2043, 1, 1), datetime.datetime(2045, 12, 31)],
             index=EcadIndex.TX90P,
         )
-        res = tx90p(conf)
+        res, _ = tx90p(conf)
         assert "reference_epoch" not in res.attrs.keys()
 
     @pytest.mark.parametrize("use_dask", [True, False])
@@ -377,7 +377,7 @@ class TestTx90p:
             time_range=[datetime.datetime(2042, 1, 1), datetime.datetime(2045, 12, 31)],
             index=EcadIndex.TX90P,
         )
-        res = tx90p(conf)
+        res, _ = tx90p(conf)
         assert "reference_epoch" not in res.attrs.keys()
 
     @pytest.mark.parametrize("use_dask", [True, False])
@@ -396,5 +396,5 @@ class TestTx90p:
             time_range=[datetime.datetime(2042, 1, 1), datetime.datetime(2045, 12, 31)],
             index=EcadIndex.TX90P,
         )
-        res = tx90p(conf)
+        res, _ = tx90p(conf)
         assert res.attrs["reference_epoch"] == ["2042-01-01", "2043-12-31"]

--- a/icclim/tests/unit_tests/test_ecad_indices.py
+++ b/icclim/tests/unit_tests/test_ecad_indices.py
@@ -29,27 +29,6 @@ class Test_index_from_string:
 
 
 @pytest.mark.parametrize("use_dask", [True, False])
-def test_tn10p_interpolation_error(use_dask):
-    ds = Dataset()
-    ds["tas"] = stub_tas(use_dask=use_dask)
-    conf = IndexConfig(
-        ds=ds,
-        slice_mode=Frequency.MONTH,
-        var_name=["tas"],
-        index=EcadIndex.TN10P,
-        netcdf_version=NetcdfVersion.NETCDF4,
-        base_period_time_range=[
-            ds.time.values[0].astype("M8[D]").astype("O"),
-            ds.time.values[-1].astype("M8[D]").astype("O"),
-        ],
-        window_width=2,
-        interpolation=QuantileInterpolation.LINEAR,
-    )
-    with pytest.raises(InvalidIcclimArgumentError):
-        tn10p(conf)
-
-
-@pytest.mark.parametrize("use_dask", [True, False])
 def test_tn10p(use_dask):
     ds = Dataset()
     ds["tas"] = stub_tas(use_dask=use_dask)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ netCDF4~=1.5.7
 numpy~=1.21.1
 pandas~=1.3.1
 pytest~=6.2.4
+pyyaml=6.0
 setuptools~=49.6.0
 xarray~=0.19.0
 xclim~=0.30.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ netCDF4~=1.5.7
 numpy~=1.21.1
 pandas~=1.3.1
 pytest~=6.2.4
-pyyaml=6.0
+pyyaml==6.0
 setuptools~=49.6.0
 xarray~=0.19.0
 xclim~=0.30.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,7 +2,6 @@ black
 cftime~=1.5.0
 flake8
 isort
-nbsphinx
 netCDF4~=1.5.7
 numpy~=1.21.1
 pandas~=1.3.1

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ MINIMAL_REQUIREMENTS = [
     "dask[array]>=2.6",
     "netCDF4>=1.5.7",
     "pyyaml>=6.0",
+    "setuptools-git",
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ MINIMAL_REQUIREMENTS = [
     "cftime>=1.4.1",
     "dask[array]>=2.6",
     "netCDF4>=1.5.7",
+    "pyyaml>=6.0",
 ]
 
 setup(

--- a/tools/extract-icclim-funs.py
+++ b/tools/extract-icclim-funs.py
@@ -1,0 +1,154 @@
+"""
+Icclim indices extractor.
+It creates a new python module which wraps each icclim indices as a function.
+These functions signature is coherent with icclim.index with all the unnecessary
+parameters trimmed from it.
+
+To use is from icclim root do:
+.. code-block:: sh
+
+    python3 -m ./tool/extract-icclim-funs.py
+"""
+
+import inspect
+import re
+from typing import List
+
+from models.constants import (
+    MODIFIABLE_QUANTILE_WINDOW,
+    MODIFIABLE_THRESHOLD,
+    MODIFIABLE_UNIT,
+    QUANTILE_BASED,
+)
+from models.ecad_indices import EcadIndex
+
+import icclim
+
+ICCLIM_MANDATORY_FIELDS = ["in_files", "index_name"]
+# Note: callback args are not included below
+ICCLIM_OPTIONAL_FIELDS = [
+    "slice_mode",
+    "netcdf_version",
+    "out_file",
+    "transfer_limit_Mbytes",
+    "ignore_Feb29th",
+    "var_name",
+    "time_range",
+]
+QUANTILE_INDEX_FIELDS = [
+    "base_period_time_range",
+    "only_leap_years",
+    "interpolation",
+    "save_percentile",
+]
+
+MODIFIABLE_QUANTILE_WINDOW_FIELD = "window_width"
+MODIFIABLE_THRESHOLD_FIELD = "threshold"
+MODIFIABLE_UNIT_FIELD = "out_unit"
+
+TAB = "    "
+
+
+def run():
+    with open("../icclim_wrapped.py", "w") as f:
+        acc = '''"""
+This module has been auto-generated.
+It exposes convenient index functions proxying to icclim.index function.
+"""
+import icclim
+import xarray
+import typing
+import datetime
+from icclim.icclim_logger import Verbosity\n
+from icclim.models.frequency import Frequency
+from icclim.models.netcdf_version import NetcdfVersion
+from icclim.models.quantile_interpolation import QuantileInterpolation
+
+
+'''
+        for index in EcadIndex:
+            acc += get_ecad_index_declaration(index)
+        f.write(acc)
+
+
+def get_ecad_index_declaration(index: EcadIndex):
+    arguments = dict(inspect.signature(icclim.index).parameters)
+    pop_args = []
+    # Pop deprecated args
+    pop_args.append("indice_name")
+    pop_args.append("user_indice")
+    # Pop unnecessary args
+    pop_args.append("user_index")
+    pop_args.append("callback")
+    pop_args.append("callback_percentage_start_value")
+    pop_args.append("callback_percentage_total")
+    pop_args.append("index_name")  # specified with function name
+    if QUANTILE_BASED not in index.qualifiers:
+        for arg in QUANTILE_INDEX_FIELDS:
+            pop_args.append(arg)
+    if MODIFIABLE_QUANTILE_WINDOW not in index.qualifiers:
+        pop_args.append(MODIFIABLE_QUANTILE_WINDOW_FIELD)
+    if MODIFIABLE_THRESHOLD not in index.qualifiers:
+        pop_args.append(MODIFIABLE_THRESHOLD_FIELD)
+    if MODIFIABLE_UNIT not in index.qualifiers:
+        pop_args.append(MODIFIABLE_UNIT_FIELD)
+
+    for pop_arg in pop_args:
+        arguments.pop(pop_arg)
+    # TODO replace these concatenation mess with a proper template (jinja or similar)...
+    fun_signature_args = f"\n{TAB}" + f",\n{TAB}".join(map(get_arg, arguments.values()))
+    fun_signature = (
+        f"\n\ndef {index.name.lower()}({fun_signature_args}) -> xarray.Dataset:\n"
+    )
+    params = get_params_docstring(list(arguments.keys()), icclim.index.__doc__)
+    end_note = """
+    Notes:
+    ------
+    This function has been auto-generated."""
+    docstring = (
+        f'{TAB}"""\n'
+        f"{TAB}{index.definition}\n"
+        f"{TAB}Source: {index.source}\n\n"
+        f"{params}"
+        f"{end_note}\n"
+        f'{TAB}"""\n'
+    )
+    index_name_arg = f'\n{TAB}{TAB}index_name="{index.name}",\n{TAB}{TAB}'
+    fun_call_args = index_name_arg + f",\n{TAB}{TAB}".join(
+        [a + "=" + a for a in arguments]
+    )
+    fun_call = f"{TAB}return icclim.index({fun_call_args})\n"
+    return f"{fun_signature}{docstring}{fun_call}"
+
+
+def get_arg(a: inspect.Parameter):
+    annotation = a.annotation
+    if type(annotation) is type:
+        annotation = annotation.__name__
+    annotation = annotation.__str__().replace("NoneType", "None")
+    annotation = annotation.__str__().replace(
+        "xarray.core.dataset.Dataset", "xarray.Dataset"
+    )
+    prefix = f"{a.name}: {annotation}"
+    if a.default is inspect._empty:
+        return prefix
+    default = a.default
+    if type(default) is str:
+        default = f'"{default.__str__()}"'
+    return f"{prefix} = {default}"
+
+
+def get_params_docstring(args: List[str], index_docstring: str):
+    result = f"{TAB}Parameters\n{TAB}----------\n"
+    matches = list(re.compile(".+ : .*").finditer(index_docstring))
+    for arg in args:
+        for i in range(0, len(matches) - 2):
+            if matches[i].group().strip().startswith(arg):
+                result += index_docstring[matches[i].start() : matches[i + 1].start()]
+        if matches[-1].group().strip().startswith(arg):
+            result += index_docstring[matches[-1].start() :]
+    return result
+
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
<!--
The following checklist points should all be checked before merging the PR.

Please replace xxx by your issue number (leave the prefixing '#').
-->

### Pull Request for the issue "C3S integration" (not logged in github)
- [x] These changes were tested with real data and unit tests cover them as well.
- [x] The relevant documentation has been added (or updated).
- [x] A short description of the changes has been added to doc/source/references/release_notes.rst

### Describe the changes you made
This PR covers multiple issues that c3s integration highlighted:
- Refactored ecad_functions (removed duplicated code, simplified function signatures...)
- Refactored IndexConfig to hide some technical knowledge which was leaked to other modules.
- Made a basic integration of clix-meta yaml to populate the generated docstring for c3s.
This makes pyyaml an required dependency of icclim.
- Fixed an issue with aliasing of "icclim" module and "icclim" package
- Added some metadata to qualify the cead_indices and recognize the arguments necessary to compute them.

<details>
 <summary>Example of generated code with index TG (click me!)</summary>

  ```
  def tg(
      in_files: typing.Union[str, typing.List[str], xarray.Dataset],
      var_name: typing.Union[str, typing.List[str], None] = None,
      slice_mode: typing.Union[typing.Any, str, typing.List[typing.Union[str, typing.Tuple, int]]] = Frequency.YEAR,
      time_range: typing.List[datetime.datetime] = None,
      out_file: str = "icclim_out.nc",
      transfer_limit_Mbytes: float = None,
      ignore_Feb29th: bool = False,
      netcdf_version: typing.Union[str, icclim.models.netcdf_version.NetcdfVersion] = NetcdfVersion.NETCDF4,
      logs_verbosity: typing.Union[icclim.icclim_logger.Verbosity, str] = Verbosity.LOW) -> xarray.Dataset:
      """
      Mean of daily mean temperature
      Source: Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11
  
      Parameters
      ----------
      in_files : Union[str, List[str], Dataset]
          Absolute path(s) to NetCDF dataset(s) (including OPeNDAP URLs),
          or xarray.Dataset.
      var_name : str
          ``optional`` Target variable name to process corresponding to ``in_files``.
          If None (default) on ECA&D index, the variable is guessed based on the climate
          index wanted.
          Mandatory for a user index.
      slice_mode : str
          Type of temporal aggregation:
          {"year", "month", "DJF", "MAM", "JJA", "SON", "ONDJFM" or "AMJJAS"}.
          Default is "year".
          See :ref:`slice_mode` for details.
      time_range : List[datetime.datetime]
          ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
          If ``None``, whole period of input files will be processed.
          Default is ``None``.
      out_file : str
          Output NetCDF file name (default: "icclim_out.nc" in the current directory).
          Default is "icclim_out.nc".
          If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
          Use the function returned value instead to retrieve the computed value.
          If ``out_file`` already exists, icclim will overwrite it!
      transfer_limit_Mbytes : float
          ``optional`` Maximum Dask chunk size in memory.
          The value should be around 200 MB.
          If empty, no chunking is performed, the whole dataset will be in memory and the
          performance might be poor.
      ignore_Feb29th : bool
          ``optional`` Ignoring or not February 29th (default: False).
      netcdf_version : icclim.models.netcdf_version.NetcdfVersion
          ``optional`` NetCDF version to create (default: "NETCDF3_CLASSIC").
      logs_verbosity : Union[str, Verbosity]
          ``optional`` Configure how verbose icclim is.
          Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
  
      Notes:
      ------
      This function has been auto-generated.
      """
      return icclim.index(
          index_name="TG",
          in_files=in_files,
          var_name=var_name,
          slice_mode=slice_mode,
          time_range=time_range,
          out_file=out_file,
          transfer_limit_Mbytes=transfer_limit_Mbytes,
          ignore_Feb29th=ignore_Feb29th,
          netcdf_version=netcdf_version,
          logs_verbosity=logs_verbosity)
  
  ```
</details>


Work in progress: 
- unit tests for clix-meta module
- in extractor, replace the concatenation with a template (jinja or equivalent)
- we must consider integrating the generated code directly in icclim, it can certainly be useful to some users.
Also, for user who would try icclim first in c3s toolbox, it would exposes a similar API to them.
- ~We should consider extracting  **user_index** as well~
- Add documentation links for clix-meta module
- Add tutorial to extract icclim functions 