### PR TITLE
MAINT: Bump to 5.0.0

### DIFF
--- a/doc/source/references/release_notes.rst
+++ b/doc/source/references/release_notes.rst
@@ -1,44 +1,8 @@
 Release history
 ===============
 
-
-5.0.0rc3 (not released)
------------------------
-* [maint] Drop support for python 3.7
-* [maint] Add github templates for issues and pull requests.
-* [maint] Simplify ecad functions output to a single DataArray in most cases.
-* [fix] Fix lint for doc conf.
-* [fix] Add all requirements to requirements_dev.txt
-* [doc] Update Readme from md to rst format. Also changed content.
-* [doc] Add a dev documentation article "how to release".
-* [doc] Add a dev documentation article "continuous integration".
-* [doc] Update installation tutorial.
-* [doc] Various improvements in doc wording and display.
-* [doc] Start to documente ECA&D indices functions.
-* [doc] Add article to distinguish icclim from xclim.
-* [maint] Refactored ecad_functions (removed duplicated code, simplified function signatures...)
-* [maint] Refactored IndexConfig to hide some technical knowledge which was leaked to other modules.
-* [enh] Made a basic integration of clix-meta yaml to populate the generated docstring for c3s.
-* [maint] This makes pyyaml an required dependency of icclim.
-* [fix] Fixed an issue with aliasing of "icclim" module and "icclim" package
-* [maint] Added some metadata to qualify the ecad_indices and recognize the arguments necessary to compute them.
-* [maint] Added readthedocs CI configuration. This is necessary to use python 3.8.
-* [enh] Added `tools/extract-icclim-funs.py` script to extract from icclim stand-alone function for each indices.
-* [enh] Added `icclim.indices` function (notice plural) to list the available indices.
-
-5.0.0rc2
---------
-
-* [fix] Make HD17 expect tas instead of tas_min.
-* [fix] Fix performance issue with indices computed on consecutive days such as CDD.
-* [maint] Add Github action CI to run unit tests.
-* [maint] Add pre-commit CI to fix lint issues on PRs.
-* [maint] Update sphinx and remove old static files.
-* [doc] Restructure documentation to follow diataxis principles.
-* [doc] Add some articles to documentation.
-
-5.0.0rc1
---------
+5.0.0
+-----
 We fully rewrote icclim to benefit from Xclim, Xarray, Numpy and Dask.
 A lot of effort has been to minimize the API changes.
 Thus for all scripts using a former version of icclim updating to this new version should be smooth.
@@ -69,8 +33,38 @@ For regridding, users are encouraged to try `xESMF <https://pangeo-xesmf.readthe
 selection directly.
 For spatial stats, Xarray provides a `DataArrayWeighted <https://xarray.pydata.org/en/stable/generated/xarray.DataArray.weighted.html>`_
 
+.. note::
+    It is highly recommended to use Dask (eventually with the distributed scheduler) to fully benefit from the performance
+    improvements of version 5.0.0.
 
-Notes
-~~~~~
-It is highly recommended to use Dask (eventually with the distributed scheduler) to fully benefit from the performance
-improvements of version 5.0.0.
+
+Release candidates (rc1, rc2, rc3) change logs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* [fix] Make HD17 expect tas instead of tas_min.
+* [fix] Fix performance issue with indices computed on consecutive days such as CDD.
+* [maint] Add Github action CI to run unit tests.
+* [maint] Add pre-commit CI to fix lint issues on PRs.
+* [maint] Update sphinx and remove old static files.
+* [doc] Restructure documentation to follow diataxis principles.
+* [doc] Add some articles to documentation.
+* [maint] Drop support for python 3.7
+* [maint] Add github templates for issues and pull requests.
+* [maint] Simplify ecad functions output to a single DataArray in most cases.
+* [fix] Fix lint for doc conf.
+* [fix] Add all requirements to requirements_dev.txt
+* [doc] Update Readme from md to rst format. Also changed content.
+* [doc] Add a dev documentation article "how to release".
+* [doc] Add a dev documentation article "continuous integration".
+* [doc] Update installation tutorial.
+* [doc] Various improvements in doc wording and display.
+* [doc] Start to documente ECA&D indices functions.
+* [doc] Add article to distinguish icclim from xclim.
+* [maint] Refactored ecad_functions (removed duplicated code, simplified function signatures...)
+* [maint] Refactored IndexConfig to hide some technical knowledge which was leaked to other modules.
+* [enh] Made a basic integration of clix-meta yaml to populate the generated docstring for c3s.
+* [maint] This makes pyyaml an required dependency of icclim.
+* [fix] Fixed an issue with aliasing of "icclim" module and "icclim" package
+* [maint] Added some metadata to qualify the ecad_indices and recognize the arguments necessary to compute them.
+* [maint] Added readthedocs CI configuration. This is necessary to use python 3.8.
+* [enh] Added `tools/extract-icclim-funs.py` script to extract from icclim stand-alone function for each indices.
+* [enh] Added `icclim.indices` function (notice plural) to list the available indices.

--- a/doc/source/tutorials/installation.rst
+++ b/doc/source/tutorials/installation.rst
@@ -57,7 +57,7 @@ To get the version of installed library, do the following:
 .. code-block:: sh
 
     >>> icclim.__version__
-    5.0.0rc2
+    5.0.0
 
 
 .. note:: icclim was not tested on Windows platform...

--- a/icclim/__init__.py
+++ b/icclim/__init__.py
@@ -1,4 +1,4 @@
 # keep line below to expose "main" content in icclim package namespace
 from .main import index, indice, indices
 
-__version__ = "5.0.0rc3"
+__version__ = "5.0.0"


### PR DESCRIPTION
<!--
The following checklist points should all be checked before merging the PR.

Please replace xxx by your issue number (leave the prefixing '#').
-->

### Describe the changes you made
At last the official release of icclim v5 (5.0.0).
See `release-notes.rst` for all changes brought by this version.

Some issues raised in #101 will be part of future releases:
- Contribution guide
- Comparison with climdex/climpact (in progress)
- Example update in our doc.
- Add a gallery
- Windows OS test campaign an bug fixes
- Unit tests...
- icclim logo (in progress within is-enes3)