### PR TITLE
Bump to 5.0.1

### DIFF
--- a/doc/source/references/release_notes.rst
+++ b/doc/source/references/release_notes.rst
@@ -1,9 +1,8 @@
 Release history
 ===============
 
-5.0.1 (unreleased)
-------------------
-
+5.0.1
+-----
 * [fix] Modify LICENCE and NOTICE to follow Apache guidelines. LICENCE has also been renamed to english LICENSE.
 
 

--- a/icclim/__init__.py
+++ b/icclim/__init__.py
@@ -1,4 +1,4 @@
 # keep line below to expose "main" content in icclim package namespace
 from .main import index, indice, indices
 
-__version__ = "5.0.1_dev"
+__version__ = "5.0.1"


### PR DESCRIPTION
Bump to 5.0.1 for license fixes.

This should solve conda release issues.