### PR TITLE
Enh/rechunker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,17 +16,8 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.8
-      - name: Install pytest
-        run: pip install pytest
-      - name: Install pytest-cov
-        run: pip install pytest-cov
-      # Todo replace all those install by install from requirements.txt ?
-      - name: Install pandas # todo removed once 1.4 is fixed
-        run: pip install pandas==1.3.5
-      - name: Install xarray
-        run: pip install xarray
-      - name: Install xclim
-        run: pip install xclim
+      - name: Install requirements
+        run: pip install -r requirements.txt
       - name: Install icclim
         run: python -m pip install -e .
       - name: Build coverage file

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
           python-version: 3.8
       - name: Install requirements
         run: pip install -r requirements.txt
+      - name: Install pytest-cov
+        run: pip install pytest-cov
       - name: Install icclim
         run: python -m pip install -e .
       - name: Build coverage file

--- a/.gitignore
+++ b/.gitignore
@@ -50,10 +50,12 @@ pip-delete-this-directory.txt
 # Unit test / coverage reports
 htmlcov/
 .tox/
-.coverage
+.coverage*
 .cache
 nosetests.xml
 coverage.xml
+pytest.xml
+pytest-coverage.txt
 
 # Translations
 *.mo

--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,5 @@ target/
 .idea
 
 dask-worker-space/
+
+*.zarr

--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ For a detailed description of each ECA index, please visit: https://www.ecad.eu/
 ..
   Pytest Coverage Comment:Begin
 
-.. |coverage| image:: https://img.shields.io/badge/Coverage-82%25-green.svg
+.. |coverage| image:: https://img.shields.io/badge/Coverage-025-red.svg
         :target: https://github.com/cerfacs-globc/icclim/blob/master/README.rst#code-coverage
         :alt: Code coverage
 

--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ For a detailed description of each ECA index, please visit: https://www.ecad.eu/
 ..
   Pytest Coverage Comment:Begin
 
-.. |coverage| image:: https://img.shields.io/badge/Coverage-82%25-green.svg
+.. |coverage| image:: https://img.shields.io/badge/Coverage-84%25-green.svg
         :target: https://github.com/cerfacs-globc/icclim/blob/master/README.rst#code-coverage
         :alt: Code coverage
 

--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ For a detailed description of each ECA index, please visit: https://www.ecad.eu/
 ..
   Pytest Coverage Comment:Begin
 
-.. |coverage| image:: https://img.shields.io/badge/Coverage-84%25-green.svg
+.. |coverage| image:: https://img.shields.io/badge/Coverage-83%25-green.svg
         :target: https://github.com/cerfacs-globc/icclim/blob/master/README.rst#code-coverage
         :alt: Code coverage
 

--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ For a detailed description of each ECA index, please visit: https://www.ecad.eu/
 ..
   Pytest Coverage Comment:Begin
 
-.. |coverage| image:: https://img.shields.io/badge/Coverage-025-red.svg
+.. |coverage| image:: https://img.shields.io/badge/Coverage-82%25-green.svg
         :target: https://github.com/cerfacs-globc/icclim/blob/master/README.rst#code-coverage
         :alt: Code coverage
 

--- a/doc/source/how_to/dask.rst
+++ b/doc/source/how_to/dask.rst
@@ -191,7 +191,7 @@ A few notes:
 * The CLient must be started in the same python interpreter as the computation. This is how dask know which scheduler to use.
 * If needed, the localCluster can be started independently and the Client connected to a running LocalCluster. See: http://distributed.dask.org/en/stable/client.html
 * Each worker is an independent python process and memory_limit is set for each of these processes. So, if you have 16GB of RAM don't set ``memory_limit='16GB'`` unless you run a single worker.
-* Memory sharing is much more efficient between threads than between processes (workers).
+* Memory sharing is much more efficient between threads than between processes (workers), see `dask doc <http://distributed.dask.org/en/stable/worker.html#thread-pool>`_
 * On a single worker, a good threads number should be a multiple of your CPU cores (usually \*2).
 * All threads of the same worker are idle whenever one of the thread is reading or writing on disk.
 * It's useless to spawn too many threads, there are hardware limits on how many of them can run concurrently and if they are too numerous, the OS will waste time orchestrating them.

--- a/doc/source/references/release_notes.rst
+++ b/doc/source/references/release_notes.rst
@@ -14,6 +14,7 @@ Release history
 * [maint] Refactored ``icclim.main`` module to ease maintainability.
 * [maint] **BREAKING CHANGE** Parameter ``out_file`` of icclim.index default value is now ``None``. When None, icclim.index only returns a xarray.Dataset.
 * [doc] Add contribution guide.
+* [enh] Add API endpoint `icclim.create_optimized_zarr_store`. It is a context manager wrapping `rechunker` in order to rechunk a dataset without any chunk a time dimension.
 
 .. _`9ac35c2f`: https://github.com/cerfacs-globc/icclim/commit/9ac35c2f7bda76b26427fd433a79f7b4334776e7
 

--- a/environment.yml
+++ b/environment.yml
@@ -13,6 +13,7 @@ dependencies:
  - netCDF4>=1.5.7
  - cftime>=1.5.0
  - pyyaml>=6.0
+ - rechunker==0.33.3
  # Dev dependencies
  - pre-commit
  - pydata-sphinx-theme

--- a/environment.yml
+++ b/environment.yml
@@ -14,6 +14,7 @@ dependencies:
  - cftime>=1.5.0
  - pyyaml>=6.0
  - rechunker==0.33.3
+ - psutil
  # Dev dependencies
  - pre-commit
  - pydata-sphinx-theme

--- a/icclim/__init__.py
+++ b/icclim/__init__.py
@@ -1,4 +1,5 @@
-# keep line below to expose "main" content in icclim package namespace
-from .main import index, indice, indices
+# keep imports below to expose api in `icclim` namespace
+from .main import index, indice, list_indices
+from .pre_processing.rechunk import create_optimized_zarr_store
 
 __version__ = "5.0.2"

--- a/icclim/main.py
+++ b/icclim/main.py
@@ -234,15 +234,17 @@ def _write_output_file(
     Write `result_ds` to a netCDF file on `out_file` path.
     """
     if input_time_encoding:
-        if input_time_encoding.get("chunksizes"):
-            del input_time_encoding["chunksizes"]
-        time_encoding = input_time_encoding
+        time_encoding = {
+            "calendar": input_time_encoding.get("calendar"),
+            "units": input_time_encoding.get("units"),
+            "dtype": input_time_encoding.get("dtype"),
+        }
     else:
         time_encoding = {"units": "days since 1850-1-1"}
     result_ds.to_netcdf(
         file_path,
         format=netcdf_version.value,
-        encoding={"time": time_encoding},  # todo might not work with zarr input
+        encoding={"time": time_encoding},
     )
 
 

--- a/icclim/main.py
+++ b/icclim/main.py
@@ -8,7 +8,7 @@ Main module of icclim.
 import logging
 import time
 from datetime import datetime
-from typing import Callable, Dict, List, Literal, Optional, Union
+from typing import Callable, Dict, List, Optional, Tuple, Union
 from warnings import warn
 
 import xarray as xr
@@ -31,7 +31,7 @@ from icclim.user_indices.dispatcher import compute_user_index
 log: IcclimLogger = IcclimLogger.get_instance(Verbosity.LOW)
 
 
-def list_indices() -> List:
+def list_indices() -> List[str]:
     """
     List the available indices.
 
@@ -74,7 +74,6 @@ def index(
     user_index: UserIndexDict = None,
     save_percentile: bool = False,
     logs_verbosity: Union[Verbosity, str] = Verbosity.LOW,
-    rechunk_it: Literal["nope", "yes and delete zarr", "yes and save zarr"] = "nope",
     # deprecated parameters
     indice_name: str = None,
     user_indice: UserIndexDict = None,
@@ -248,7 +247,7 @@ def _write_output_file(
 
 def _handle_deprecated_params(
     index_name, indice_name, transfer_limit_Mbytes, user_index, user_indice
-):
+) -> Tuple[str, UserIndexDict]:
     if indice_name is not None:
         log.deprecation_warning(old="indice_name", new="index_name")
         index_name = indice_name

--- a/icclim/main.py
+++ b/icclim/main.py
@@ -181,13 +181,14 @@ def index(
         index = None
     input_dataset, chunk_it = read_dataset(in_files, index, var_name)
     ds, reset_coords_dict = update_to_standard_coords(input_dataset)
-    time_chunk_count = len(ds.chunks["time"])
-    if time_chunk_count > 1:
-        warn(
-            f"Your dataset has {time_chunk_count} chunks for time dimension."
-            f" You could significantly speed up your computations by rechunking it"
-            f" with `icclim.create_optimized_zarr_store`."
-        )
+    if ds.chunks:
+        time_chunk_count = len(ds.chunks["time"])
+        if time_chunk_count > 1:
+            warn(
+                f"Your dataset has {time_chunk_count} chunks for time dimension."
+                f" You could significantly speed up your computations by rechunking it"
+                f" with `icclim.create_optimized_zarr_store`."
+            )
     config = IndexConfig(
         base_period_time_range=base_period_time_range,
         ds=ds,

--- a/icclim/main.py
+++ b/icclim/main.py
@@ -256,7 +256,6 @@ def _handle_deprecated_params(
         user_index = user_indice
     if transfer_limit_Mbytes is not None:
         log.deprecation_warning(old="transfer_limit_Mbytes")
-    # TODO deprecate in_files
     return index_name, user_index
 
 

--- a/icclim/pre_processing/input_parsing.py
+++ b/icclim/pre_processing/input_parsing.py
@@ -1,0 +1,70 @@
+from typing import Dict, List, Optional, Tuple, Union
+
+import xarray as xr
+from xarray.core.dataarray import DataArray
+from xarray.core.dataset import Dataset
+
+from icclim.icclim_exceptions import InvalidIcclimArgumentError
+from icclim.models.ecad_indices import EcadIndex
+
+
+def read_dataset(
+    data: Union[str, List[str], Dataset, DataArray],
+    index: Optional[EcadIndex],
+    var_names: Union[str, List[str], None],
+) -> Tuple[Dataset, bool]:
+    # TODO add unit test
+    if isinstance(data, Dataset):
+        input_dataset = data
+        chunk_da = False
+    elif isinstance(data, DataArray):
+        if index is None:
+            # user index case
+            if isinstance(var_names, str):
+                var_names = [var_names]
+            if len(var_names) > 1 or var_names[0] is None:
+                raise InvalidIcclimArgumentError(
+                    "When the input is a DataArray, var_names must be a string"
+                )
+            name = var_names
+        else:
+            if len(index.variables) > 1:
+                raise InvalidIcclimArgumentError(
+                    f"Index {index.name} need {len(index.variables)} variables."
+                    f"Please provides them with an xarray.Dataset or a netCDF file."
+                )
+            name = index.variables[0][0]  # first alias of the unique variable
+        input_dataset = data.to_dataset(name=name, promote_attrs=True)
+        chunk_da = False
+    elif isinstance(data, list):
+        input_dataset = xr.open_mfdataset(data, parallel=True)
+        chunk_da = True
+    elif isinstance(data, str):
+        if ".nc" in data:
+            input_dataset = xr.open_dataset(data)
+            chunk_da = True
+        else:  # assume it's a zarr store
+            input_dataset = xr.open_zarr(data)
+            chunk_da = True
+    else:
+        raise NotImplementedError("in_files format was not recognized.")
+    return input_dataset, chunk_da
+
+
+def update_to_standard_coords(ds: Dataset) -> Tuple[Dataset, Dict]:
+    """
+    Mutate input ds to use more icclim friendly coordinate name.
+    """
+    # TODO add unit test
+    # TODO see if cf-xarray could replace this
+    revert = {}
+    if ds.coords.get("latitude") is not None:
+        ds = ds.rename({"latitude": "lat"})
+        revert.update({"lat": "latitude"})
+    if ds.coords.get("longitude") is not None:
+        ds = ds.rename({"longitude": "lon"})
+        revert.update({"lon": "longitude"})
+    if ds.coords.get("t") is not None:
+        ds = ds.rename({"t": "time"})
+        revert.update({"time": "t"})
+    return ds, revert

--- a/icclim/pre_processing/rechunk.py
+++ b/icclim/pre_processing/rechunk.py
@@ -1,0 +1,132 @@
+import contextlib
+import shutil
+from typing import List, Union
+
+import dask
+import distributed
+import xarray as xr
+from rechunker import rechunk
+from xarray.core.dataarray import DataArray
+from xarray.core.dataset import Dataset
+
+from icclim.pre_processing.input_parsing import read_dataset
+
+TMP_STORE_1 = "icclim-tmp-store-1.zarr"
+TMP_STORE_2 = "icclim-tmp-store-2.zarr"
+
+
+def _get_mem_limit(factor: float = 0.9) -> int:
+    if factor > 1 or factor < 0:
+        raise ValueError(f"factor was {factor} but, it must be between 0 and 1.")
+    try:
+        max_sys_mem = (
+            distributed.get_client()
+            .submit(lambda: distributed.get_worker().memory_limit)
+            .result()
+        )
+    except ValueError:
+        # Assumes default scheduler is used
+        max_sys_mem = distributed.system.MEMORY_LIMIT
+    return int(factor * max_sys_mem)
+
+
+@contextlib.contextmanager
+def create_optimized_zarr_store(
+    in_files: Union[str, List[str], Dataset, DataArray],
+    var_names: Union[str, List[str]],
+    target_zarr_store_name: str = "icclim-target-store.zarr",
+    dim="time",
+    keep_target_store: bool = False,
+):
+    """
+    EXPERIMENTAL FEATURE
+
+    todo fill doc
+
+    Parameters
+    ----------
+    in_files :
+    var_names :
+    target_zarr_store_name :
+    dim :
+    keep_target_store :
+
+    Returns
+    -------
+
+    """
+    # According to
+    # https://github.com/pangeo-data/rechunker/issues/54#issuecomment-700748875
+    # we should limit rechunk mem usage to around 0.9 and avoid spilling to disk
+    with dask.config.set(
+        {
+            "distributed.worker.memory.target": "0.95",
+            "distributed.worker.memory.spill": "0.95",
+            "distributed.worker.memory.pause": "0.95",
+            "distributed.worker.memory.terminate": "0.98",
+        }
+    ):
+        try:
+            shutil.rmtree(target_zarr_store_name, ignore_errors=True)
+            yield _unsafe_create_optimized_zarr_store(
+                in_files, var_names, target_zarr_store_name, dim, _get_mem_limit()
+            )
+        finally:
+            shutil.rmtree(TMP_STORE_1, ignore_errors=True)
+            shutil.rmtree(TMP_STORE_2, ignore_errors=True)
+            if not keep_target_store:
+                shutil.rmtree(target_zarr_store_name, ignore_errors=True)
+
+
+def _unsafe_create_optimized_zarr_store(
+    in_files: Union[str, List[str], Dataset, DataArray],
+    var_names: Union[str, List[str]],
+    zarr_store_name: str,
+    dim: str,
+    max_mem: int,
+):
+    """
+    Create a single zarr store for for the variables var_names initialy stored in
+    in_files.
+    This zarr store chunking is optimized for analysis on `dim` dimension.
+    Thus, it's optimal for icclim when dim=="time.
+
+    Parameters
+    ----------
+    in_files :
+    var_names :
+    zarr_store_name :
+    dim :
+
+    Returns
+    -------
+
+    """
+    ds, _ = read_dataset(in_files, index=None, var_names=var_names)
+    # drop all non essential data variables
+    ds = ds.drop_vars(filter(lambda v: v not in var_names, ds.data_vars.keys()))
+    ds = ds.chunk("auto")
+    ds.to_zarr(TMP_STORE_1, mode="w")
+    # Leave dask find the best chunking schema for all dimensions but `dim`
+    chunking = {d: "auto" for d in ds.dims}
+    chunking[dim] = -1  # no chunking on dim to use map_block
+    ds_zarr = xr.open_zarr(TMP_STORE_1).chunk(chunking)
+    target_chunks = {}
+    for data_var in ds_zarr.data_vars:
+        ds_zarr[data_var].encoding = {}
+        acc = {}
+        for dim in ds_zarr[data_var].dims:
+            # fixme: `.chunksizes` is only available on xarray v0.20.0
+            acc.update({dim: ds_zarr[data_var].chunksizes[dim][0]})
+        target_chunks.update({data_var: acc})
+    for c in ds_zarr.coords:
+        ds_zarr[c].encoding = {}
+        target_chunks.update({c: None})
+    rechunk(
+        source=ds_zarr,
+        target_chunks=target_chunks,
+        max_mem=max_mem,
+        target_store=zarr_store_name,
+        temp_store=TMP_STORE_2,
+    ).execute()
+    return xr.open_zarr(zarr_store_name)

--- a/icclim/tests/unit_tests/test_dispatcher.py
+++ b/icclim/tests/unit_tests/test_dispatcher.py
@@ -16,7 +16,7 @@ from icclim.user_indices.dispatcher import CalcOperation
 class Test_compute:
     def test_error_bad_operation(self):
         # GIVEN
-        cf_var = CfVariable(stub_tas(), stub_tas())
+        cf_var = CfVariable("tas", stub_tas(), stub_tas())
         user_index = stub_user_index([cf_var])
         user_index.calc_operation = "pouet pouet"
         user_index.freq = Frequency.MONTH
@@ -26,7 +26,7 @@ class Test_compute:
 
     def test_simple(self):
         # GIVEN
-        cf_var = CfVariable(stub_tas(), stub_tas())
+        cf_var = CfVariable("tas", stub_tas(), stub_tas())
         user_index = stub_user_index([cf_var])
         user_index.calc_operation = "max"
         user_index.freq = Frequency.MONTH
@@ -37,7 +37,7 @@ class Test_compute:
 
     def test_simple_percentile_pr(self):
         # GIVEN
-        cf_var = CfVariable(stub_pr(5), stub_pr(5))
+        cf_var = CfVariable("tas", stub_pr(5), stub_pr(5))
         cf_var.da.data[15:30] += 10
         cf_var.da.data[366 + 15 : 366 + 30] = 2  # Ignore because not in base
         cf_var.reference_da = cf_var.da.sel(time=cf_var.da.time.dt.year == 2042)
@@ -53,7 +53,7 @@ class Test_compute:
         assert result.data[0] == 5
 
     def test_simple_percentile_temp(self):
-        cf_var = CfVariable(stub_tas(5), stub_tas(5))
+        cf_var = CfVariable("tas", stub_tas(5), stub_tas(5))
         cf_var.da.data[15:30] = 1
         cf_var.reference_da = cf_var.da.sel(
             time=cf_var.da.time.dt.year.isin([2042, 2043])

--- a/icclim/tests/unit_tests/test_input_parsing.py
+++ b/icclim/tests/unit_tests/test_input_parsing.py
@@ -1,0 +1,216 @@
+import os
+import shutil
+
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+
+from icclim.icclim_exceptions import InvalidIcclimArgumentError
+from icclim.models.ecad_indices import EcadIndex
+from icclim.pre_processing.input_parsing import read_dataset, update_to_standard_coords
+
+
+def test_update_to_standard_coords():
+    # GIVEN
+    ds = xr.Dataset(
+        {
+            "pouet": xr.DataArray(
+                data=np.full(10, 42).reshape((10, 1, 1)),
+                coords=dict(
+                    latitude=[42],
+                    longitude=[42],
+                    t=pd.date_range("2042-01-01", periods=10, freq="D"),
+                ),
+                dims=["t", "latitude", "longitude"],
+                name="pr",
+                attrs={"units": "kg m-2 d-1"},
+            )
+        }
+    )
+    # WHEN
+    res, revert = update_to_standard_coords(ds)
+    # THEN
+    assert "lat" in res.coords
+    assert "time" in res.coords
+    assert "lon" in res.coords
+    assert res.rename(revert).coords.keys() == ds.coords.keys()
+
+
+class Test_ReadDataset:
+    OUTPUT_NC_FILE = "tmp.nc"
+    OUTPUT_NC_FILE_2 = "tmp-2.nc"
+    OUTPUT_ZARR_STORE = "tmp.zarr"
+    OUTPUT_UNKNOWN_FORMAT = "tmp.cacahuete"
+
+    @pytest.fixture(autouse=True)
+    def cleanup(self):
+        # setup
+        yield
+        # teardown
+        shutil.rmtree(self.OUTPUT_ZARR_STORE, ignore_errors=True)
+        for f in [
+            self.OUTPUT_NC_FILE,
+            self.OUTPUT_NC_FILE_2,
+            self.OUTPUT_UNKNOWN_FORMAT,
+        ]:
+            try:
+                os.remove(f)
+            except FileNotFoundError:
+                pass
+
+    def test_read_dataset_xr_da_user_index_error(self):
+        da = xr.DataArray(
+            data=np.full(10, 42).reshape((10, 1, 1)),
+            coords=dict(
+                latitude=[42],
+                longitude=[42],
+                t=pd.date_range("2042-01-01", periods=10, freq="D"),
+            ),
+            dims=["t", "latitude", "longitude"],
+            name="pr",
+            attrs={"units": "kg m-2 d-1"},
+        )
+        with pytest.raises(InvalidIcclimArgumentError):
+            read_dataset(da)
+
+    def test_read_dataset_xr_da_ecad_index_error(self):
+        da = xr.DataArray(
+            data=np.full(10, 42).reshape((10, 1, 1)),
+            coords=dict(
+                latitude=[42],
+                longitude=[42],
+                t=pd.date_range("2042-01-01", periods=10, freq="D"),
+            ),
+            dims=["t", "latitude", "longitude"],
+            name="pr",
+            attrs={"units": "kg m-2 d-1"},
+        )
+        with pytest.raises(InvalidIcclimArgumentError):
+            read_dataset(da, EcadIndex.WW)
+
+    def test_read_dataset_xr_da_ecad_index_success(self):
+        da = xr.DataArray(
+            data=np.full(10, 42).reshape((10, 1, 1)),
+            coords=dict(
+                latitude=[42],
+                longitude=[42],
+                t=pd.date_range("2042-01-01", periods=10, freq="D"),
+            ),
+            dims=["t", "latitude", "longitude"],
+            name="pr",
+            attrs={"units": "kg m-2 d-1"},
+        )
+        ds_res, chunk_it = read_dataset(da, EcadIndex.TX90P)
+        xr.testing.assert_equal(ds_res.tasmax, da)
+        assert chunk_it is False
+
+    def test_read_dataset_xr_da_user_index_success(self):
+        da = xr.DataArray(
+            data=np.full(10, 42).reshape((10, 1, 1)),
+            coords=dict(
+                latitude=[42],
+                longitude=[42],
+                t=pd.date_range("2042-01-01", periods=10, freq="D"),
+            ),
+            dims=["t", "latitude", "longitude"],
+            name="pr",
+            attrs={"units": "kg m-2 d-1"},
+        )
+        ds_res, chunk_it = read_dataset(da, None, "doto")
+        xr.testing.assert_equal(ds_res.doto, da)
+        assert chunk_it is False
+
+    def test_read_dataset_xr_ds_success(self):
+        ds = xr.Dataset(
+            {
+                "pouet": xr.DataArray(
+                    data=np.full(10, 42).reshape((10, 1, 1)),
+                    coords=dict(
+                        latitude=[42],
+                        longitude=[42],
+                        t=pd.date_range("2042-01-01", periods=10, freq="D"),
+                    ),
+                    dims=["t", "latitude", "longitude"],
+                    name="pr",
+                    attrs={"units": "kg m-2 d-1"},
+                )
+            }
+        )
+        ds_res, chunk_it = read_dataset(ds)
+        xr.testing.assert_equal(ds_res.pouet, ds.pouet)
+        assert chunk_it is False
+
+    def test_read_dataset_netcdf_success(self):
+        ds = xr.Dataset(
+            {
+                "pouet": xr.DataArray(
+                    data=np.full(10, 42).reshape((10, 1, 1)),
+                    coords=dict(
+                        latitude=[42],
+                        longitude=[42],
+                        t=pd.date_range("2042-01-01", periods=10, freq="D"),
+                    ),
+                    dims=["t", "latitude", "longitude"],
+                    name="pr",
+                    attrs={"units": "kg m-2 d-1"},
+                )
+            }
+        )
+        ds.to_netcdf(self.OUTPUT_NC_FILE)
+        ds_res, chunk_it = read_dataset(self.OUTPUT_NC_FILE)
+        xr.testing.assert_equal(ds_res.pouet, ds.pouet)
+        assert chunk_it is True
+
+    def test_read_dataset_multi_netcdf_success(self):
+        ds = xr.Dataset(
+            {
+                "pouet": xr.DataArray(
+                    data=np.full(10, 42).reshape((10, 1, 1)),
+                    coords=dict(
+                        latitude=[42],
+                        longitude=[42],
+                        t=pd.date_range("2042-01-01", periods=10, freq="D"),
+                    ),
+                    dims=["t", "latitude", "longitude"],
+                    name="pr",
+                    attrs={"units": "kg m-2 d-1"},
+                )
+            }
+        )
+        ds.to_netcdf(self.OUTPUT_NC_FILE)
+        ds.rename({"pouet": "patapouet"}).to_netcdf(self.OUTPUT_NC_FILE_2)
+        # WHEN
+        ds_res, chunk_it = read_dataset([self.OUTPUT_NC_FILE, self.OUTPUT_NC_FILE_2])
+        # THEN
+        xr.testing.assert_equal(ds_res.pouet, ds.pouet)
+        xr.testing.assert_equal(ds_res.patapouet, ds.pouet)
+        assert chunk_it is True
+
+    def test_read_dataset_zarr_store_success(self):
+        ds = xr.Dataset(
+            {
+                "pouet": xr.DataArray(
+                    data=np.full(10, 42).reshape((10, 1, 1)),
+                    coords=dict(
+                        latitude=[42],
+                        longitude=[42],
+                        t=pd.date_range("2042-01-01", periods=10, freq="D"),
+                    ),
+                    dims=["t", "latitude", "longitude"],
+                    name="pr",
+                    attrs={"units": "kg m-2 d-1"},
+                )
+            }
+        )
+        ds.to_zarr(self.OUTPUT_ZARR_STORE)
+        # WHEN
+        ds_res, chunk_it = read_dataset(self.OUTPUT_ZARR_STORE)
+        # THEN
+        xr.testing.assert_equal(ds_res.pouet, ds.pouet)
+        assert chunk_it is True
+
+    def test_read_dataset_not_implemented_error(self):
+        # WHEN
+        with pytest.raises(NotImplementedError):
+            read_dataset(42)  # noqa

--- a/icclim/tests/unit_tests/test_main.py
+++ b/icclim/tests/unit_tests/test_main.py
@@ -11,7 +11,7 @@ from icclim.models.ecad_indices import EcadIndex
 
 
 def test_indices():
-    res = icclim.indices()
+    res = icclim.list_indices()
     assert len(res) == len(EcadIndex)
 
 

--- a/icclim/tests/unit_tests/test_rechunk.py
+++ b/icclim/tests/unit_tests/test_rechunk.py
@@ -1,8 +1,12 @@
+from unittest.mock import MagicMock, patch
+
 import numpy as np
 import pandas as pd
+import pytest
 import xarray as xr
 
 from icclim import create_optimized_zarr_store
+from icclim.icclim_exceptions import InvalidIcclimArgumentError
 
 
 def test_create_optimized_zarr_store_success():
@@ -30,3 +34,59 @@ def test_create_optimized_zarr_store_success():
         assert len(result.chunks["time"]) == 1
         np.testing.assert_array_equal(result.tas.values, ds.tas.values)
         np.testing.assert_array_equal(result.data_vars.keys(), ds.data_vars.keys())
+
+
+def test_create_optimized_zarr_store_error():
+    ds = xr.Dataset(
+        {
+            "tas": xr.DataArray(
+                data=np.full(10, 42).reshape((10, 1, 1)),
+                coords=dict(
+                    lat=[42],
+                    lon=[42],
+                    time=pd.date_range("2042-01-01", periods=10, freq="D"),
+                ),
+                dims=["time", "lat", "lon"],
+                name="pr",
+                attrs={"units": "kg m-2 d-1"},
+            )
+        }
+    ).chunk({"time": 2})
+    # Then
+    with pytest.raises(InvalidIcclimArgumentError):
+        # When
+        with create_optimized_zarr_store(
+            in_files=ds,
+            var_names="TATAYOYO!",
+            target_zarr_store_name="yolo.zarr",
+            dim="time",
+        ):
+            pass
+
+
+@patch("rechunker.rechunk")
+def test_create_optimized_zarr_store_no_rechunk(rechunk_mock: MagicMock):
+    ds = xr.Dataset(
+        {
+            "tas": xr.DataArray(
+                data=np.full(10, 42).reshape((10, 1, 1)),
+                coords=dict(
+                    lat=[42],
+                    lon=[42],
+                    time=pd.date_range("2042-01-01", periods=10, freq="D"),
+                ),
+                dims=["time", "lat", "lon"],
+                name="pr",
+                attrs={"units": "kg m-2 d-1"},
+            )
+        }
+    ).chunk({"time": -1})
+    # When
+    with create_optimized_zarr_store(
+        in_files=ds,
+        var_names="tas",
+        target_zarr_store_name="n/a",
+        dim="time",
+    ) as result:
+        xr.testing.assert_equal(ds, result)
+        rechunk_mock.assert_not_called()

--- a/icclim/tests/unit_tests/test_rechunk.py
+++ b/icclim/tests/unit_tests/test_rechunk.py
@@ -1,0 +1,32 @@
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+from icclim import create_optimized_zarr_store
+
+
+def test_create_optimized_zarr_store_success():
+    ds = xr.Dataset(
+        {
+            "tas": xr.DataArray(
+                data=np.full(10, 42).reshape((10, 1, 1)),
+                coords=dict(
+                    lat=[42],
+                    lon=[42],
+                    time=pd.date_range("2042-01-01", periods=10, freq="D"),
+                ),
+                dims=["time", "lat", "lon"],
+                name="pr",
+                attrs={"units": "kg m-2 d-1"},
+            )
+        }
+    ).chunk({"time": 2})
+    with create_optimized_zarr_store(
+        in_files=ds,
+        var_names="tas",
+        target_zarr_store_name="yolo.zarr",
+        dim="time",
+    ) as result:
+        assert len(result.chunks["time"]) == 1
+        np.testing.assert_array_equal(result.tas.values, ds.tas.values)
+        np.testing.assert_array_equal(result.data_vars.keys(), ds.data_vars.keys())

--- a/icclim/tests/unit_tests/test_user_indices.py
+++ b/icclim/tests/unit_tests/test_user_indices.py
@@ -18,7 +18,7 @@ class Test_UserindexConfig:
         }
         tas = stub_tas(use_dask=use_dask)
         config = UserIndexConfig(
-            **dico, freq=Frequency.MONTH, cf_vars=[CfVariable(tas, tas)]
+            **dico, freq=Frequency.MONTH, cf_vars=[CfVariable("tas", tas, tas)]
         )
         assert config.index_name == "my_index"
         assert config.calc_operation == "min"

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ pandas~=1.3.1
 psutil
 pytest~=6.2.4
 pyyaml==6.0
-rechunker==0.33.3
+rechunker==0.3.3
 setuptools~=49.6.0
 xarray~=0.19.0
 xclim~=0.34.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ pandas~=1.3.1
 psutil
 pytest~=6.2.4
 pyyaml==6.0
-rechunker=0.33.3
+rechunker==0.33.3
 setuptools~=49.6.0
 xarray~=0.19.0
 xclim~=0.34.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ numpy~=1.21.1
 pandas~=1.3.1
 pytest~=6.2.4
 pyyaml==6.0
+rechunker=0.33.3
 setuptools~=49.6.0
 xarray~=0.19.0
 xclim~=0.34.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ dask[array]>=2021.10.0
 netCDF4~=1.5.7
 numpy~=1.21.1
 pandas~=1.3.1
+psutil
 pytest~=6.2.4
 pyyaml==6.0
 rechunker=0.33.3

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -12,7 +12,7 @@ pydata-sphinx-theme
 pylint
 pytest
 pytest-cov
-rechunker=0.33.3
+rechunker==0.33.3
 setuptools>=49.6.0
 sphinx
 xarray~=0.19.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -12,7 +12,7 @@ pydata-sphinx-theme
 pylint
 pytest
 pytest-cov
-rechunker==0.33.3
+rechunker==0.3.3
 setuptools>=49.6.0
 sphinx
 xarray~=0.19.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,6 +7,7 @@ numpy~=1.21.1
 pandas~=1.3.1
 pip
 pre-commit>=2.9
+psutil
 pydata-sphinx-theme
 pylint
 pytest

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -11,7 +11,8 @@ pydata-sphinx-theme
 pylint
 pytest
 pytest-cov
+rechunker=0.33.3
 setuptools>=49.6.0
 sphinx
 xarray~=0.19.0
-xclim~=0.30.0
+xclim~=0.34.0

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,9 @@ MINIMAL_REQUIREMENTS = [
     "dask[array]>=2021.10.0",
     "netCDF4>=1.5.7",
     "pyyaml>=6.0",
+    # todo unpin rechunker once https://github.com/pangeo-data/rechunker/issues/92 is
+    #      fixed
+    "rechunker>=0.3,<0.4",
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ MINIMAL_REQUIREMENTS = [
     "dask[array]>=2021.10.0",
     "netCDF4>=1.5.7",
     "pyyaml>=6.0",
+    "psutil",
     # todo unpin rechunker once https://github.com/pangeo-data/rechunker/issues/92 is
     #      fixed
     "rechunker>=0.3,<0.4",


### PR DESCRIPTION
<!--
The following checklist points should all be checked before merging the PR.

Please replace xxx by your issue number (leave the prefixing '#').
-->

### Pull Request for the issue #126 
- [x] Unit tests cover the changes.
- [x] These changes were tested on real data.
- [x] The relevant documentation has been added or updated.
- [x] A short description of the changes has been added to `doc/source/references/release_notes.rst`.

### Describe the changes you made

This pr adds a context manager `icclim.create_optimized_zarr_store` which yield a rechunked Dataset using the ``rechunker`` library (https://github.com/pangeo-data/rechunker/).
The idea is to allow user to rechunk their Datasets in a time series optimized format to speed up computation of indices.

This implementation relies on an access to a storage in order to create intermediary zarr store and a final optimized zarr store. It's unsure how it would work when run on a Cloud.

