### PR TITLE
FIX: installation from sources

### DIFF
--- a/doc/source/references/release_notes.rst
+++ b/doc/source/references/release_notes.rst
@@ -16,6 +16,7 @@ Release history
 * [doc] Add contribution guide.
 * [enh] Add API endpoint `icclim.create_optimized_zarr_store`. It is a context manager wrapping `rechunker` in order to rechunk a dataset without any chunk a time dimension.
 * [fix] Add zarr dependency, needed to update zarr store metadata after rechunking.
+* [fix] Fix installation from sources. The import in setup.py to get ``__version__`` meant we needed to have the environment setup before the moment it is installed...
 
 .. _`9ac35c2f`: https://github.com/cerfacs-globc/icclim/commit/9ac35c2f7bda76b26427fd433a79f7b4334776e7
 

--- a/icclim/pre_processing/rechunk.py
+++ b/icclim/pre_processing/rechunk.py
@@ -156,6 +156,8 @@ def _unsafe_create_optimized_zarr_store(
             target_store=zarr_store_name,
             temp_store=TMP_STORE_2,
         ).execute()
+        shutil.rmtree(TMP_STORE_1, ignore_errors=True)
+        shutil.rmtree(TMP_STORE_2, ignore_errors=True)
         zarr.consolidate_metadata(zarr_store_name)
         return xr.open_zarr(zarr_store_name)
 

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,6 @@
 
 from setuptools import find_packages, setup
 
-from icclim import __version__
-
 MINIMAL_REQUIREMENTS = [
     "numpy>=1.21,<1.22",  # todo unpin 1.22 once numba works with it
     "xarray>=0.19",
@@ -22,7 +20,7 @@ MINIMAL_REQUIREMENTS = [
 
 setup(
     name="icclim",
-    version=__version__,
+    version="5.0.2",
     packages=find_packages(),
     author="Christian P.",
     author_email="christian.page@cerfacs.fr",


### PR DESCRIPTION
<!--
The following checklist points should all be checked before merging the PR.

Please replace xxx by your issue number (leave the prefixing '#').
-->

### Pull Request for the issue #140 
- [n/a] Unit tests cover the changes.
- [n/a] These changes were tested on real data.
- [n/a] The relevant documentation has been added or updated.
- [x] A short description of the changes has been added to `doc/source/references/release_notes.rst`.

### Describe the changes you made
- Fixed installation from sources
When doing `import icclim.__version__` in setup.py, we were trying to import the whole API declared in __init__.py.
This would fail because when doing `pip install setup.py`, the installation of dependency packages is done long after the initial import. Thus we remove the import and duplicated the version number.
The side effect is the duplication of icclim version number instead of relying on a single constant.
This will have a low maintenance cost.

- Also made a small disk usage optimization for rechunker.
We try to remove the temporary zarr stores as soon as they are unnecessary.

