### PR TITLE
MAINT: pin and unpin versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
           hide-comment: false
           report-only-changed-files: false
           junitxml-path: ./pytest.xml
-          junitxml-title: My JUnit Xml Summary Title
+          junitxml-title: Test results
       - name: create local ref
         run: |
           git fetch origin ${{ github.head_ref }}
@@ -48,7 +48,7 @@ jobs:
           sed -i '/  Pytest Coverage Comment:Begin/,/  Pytest Coverage Comment:End/c\  Pytest Coverage Comment:Begin\n\n.. |coverage| image:: https://img.shields.io/badge/Coverage-${{ steps.coverageComment.outputs.coverage }}25-${{ steps.coverageComment.outputs.color }}.svg\n        :target: https://github.com/cerfacs-globc/icclim/blob/master/README.rst#code-coverage\n        :alt: Code coverage\n\n..\n  Pytest Coverage Comment:End' ./README.rst
       - name: setup git config
         run: |
-          # setup the username and email. I tend to use 'GitHub Actions Bot' with no email by default
+          # setup the username and email.
           git config user.name "GitHub Actions Bot"
           git config user.email "<>"
       - name: commit

--- a/doc/source/references/release_notes.rst
+++ b/doc/source/references/release_notes.rst
@@ -18,6 +18,7 @@ Release history
 * [fix] Add zarr dependency, needed to update zarr store metadata after rechunking.
 * [fix] Fix installation from sources. The import in setup.py to get ``__version__`` meant we needed to have the environment setup before the moment it is installed...
 * [enh] Add API endpoint ``icclim.indices``. This allows to compute multiple indices at once.
+* [maint] Pin dask to versions before `2022.01.1`. This is necessary for rechunker 0.3.3 to work.
 
 .. _`9ac35c2f`: https://github.com/cerfacs-globc/icclim/commit/9ac35c2f7bda76b26427fd433a79f7b4334776e7
 

--- a/setup.py
+++ b/setup.py
@@ -4,17 +4,21 @@
 from setuptools import find_packages, setup
 
 MINIMAL_REQUIREMENTS = [
-    "numpy>=1.21,<1.22",  # todo unpin 1.22 once numba works with it
-    "xarray>=0.19",
+    # todo: Unpin numpy 1.22 once numba work with it
+    #       https://github.com/numba/numba/issues/7754
+    "numpy>=1.16,<1.22",
+    "xarray>=0.17",
     "xclim>=0.34",
-    "cftime>=1.5.0",
-    "dask[array]>=2021.10.0",
+    "cftime>=1.4.1",
+    # todo: unpin dask once we can move to rechunker 0.4
+    #       https://github.com/pangeo-data/rechunker/issues/110
+    "dask[array]<2022.01.1",
     "netCDF4>=1.5.7",
-    "pyyaml>=6.0",
+    "pyyaml",
     "psutil",
     "zarr",
-    # todo unpin rechunker once https://github.com/pangeo-data/rechunker/issues/92 is
-    #      fixed
+    # todo: unpin rechunker once
+    #       https://github.com/pangeo-data/rechunker/issues/92 is fixed
     "rechunker>=0.3,<0.4",
 ]
 


### PR DESCRIPTION
- Pinned dask to <2022.01.1
- Lower and remove some unnecessarily high pinned numbers

<!--
The following checklist points should all be checked before merging the PR.

Please replace xxx by your issue number (leave the prefixing '#').
-->

### Pull Request for the issue #141 
- [n/a] Unit tests cover the changes.
- [n/a] These changes were tested on real data.
- [n/a] The relevant documentation has been added or updated.
- [ ] A short description of the changes has been added to `doc/source/references/release_notes.rst`.

### Describe the changes you made
Update version pinning
For rechunker to work we must pin dask to <2022.01.1. 
We were also pinning to high version numbers some dependency for no reason.

