### PR TITLE
Fix CI not properly failling on errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         run: python -m pip install -e .
       - name: Build coverage file
         run: |
-            pytest --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=icclim icclim/tests | tee pytest-coverage.txt
+            pytest --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=icclim icclim/tests | tee pytest-coverage.txt; ( exit ${PIPESTATUS[0]} )
       - name: Pytest coverage comment
         id: coverageComment
         uses: MishaKav/pytest-coverage-comment@main

--- a/doc/source/references/release_notes.rst
+++ b/doc/source/references/release_notes.rst
@@ -20,6 +20,7 @@ Release history
 * [enh] Add API endpoint ``icclim.indices``. This allows to compute multiple indices at once.
 * [maint] Pin dask to versions before `2022.01.1`. This is necessary for rechunker 0.3.3 to work.
 * [maint] Update types to use modern python typing syntax.
+* [fix] CI was passing even when tests were in failure.
 
 .. _`9ac35c2f`: https://github.com/cerfacs-globc/icclim/commit/9ac35c2f7bda76b26427fd433a79f7b4334776e7
 


### PR DESCRIPTION
<!--
The following checklist points should all be checked before merging the PR.

Please replace xxx by your issue number (leave the prefixing '#').
-->

### Pull Request for the issue #146 
- [n/a] Unit tests cover the changes.
- [n/a] These changes were tested on real data.
- [n/a] The relevant documentation has been added or updated.
- [x] A short description of the changes has been added to `doc/source/references/release_notes.rst`.

### Describe the changes you made

Within the CI, make `test` job fail when tests are failing.
This was cause by the pipe to `tee` which was overriding the exit code of pytest.
