### PR TITLE
MAINT: Rework rechunking

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ For more examples on how to use icclim, see our `How to ... <https://icclim.read
 Who use icclim
 --------------
 
-icclim is part of `C4I platform <https://dev.climate4impact.eu>`_ backend and is integrated in `CLIPC Portal <http://www.clipc.eu>`_
+icclim is part of `C4I platform <https://dev.climate4impact.eu>`_ backend and is integrated in `CLIPC Portal <http://www.clipc.eu>`_.
 You may also (soon) find icclim within the Copernicus C3S Climate Data Store (CDS).
 icclim is also used by some independent researchers.
 

--- a/README.rst
+++ b/README.rst
@@ -20,9 +20,9 @@ From sources:
 How to use icclim
 -----------------
 
-Let's count the number of days above 25ºC, which is the index ``SU``, from a `tasmax` variable scattered in multiple netcdf files.
+Let's count the number of days above 25ºC, which correspond the index ``SU``, from a `tasmax` variable scattered in multiple netcdf files.
 
-`SU` is one of the many index that can be computed with icclim. See `the documentation <https://icclim.readthedocs.io/en/latest/explanation/climate_indices.html#icclim-capabilities>`_ to see what other index icclim can compute.
+`SU` is one of the many index that can be computed with icclim. See `the documentation <https://icclim.readthedocs.io/en/latest/explanation/climate_indices.html#icclim-capabilities>`_ to explore what other index you can compute with icclim.
 
 .. code-block:: python
 

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ How to use icclim
 
 Let's count the number of days above 25ºC, which is the index ``SU``, from a `tasmax` variable scattered in multiple netcdf files.
 
-`SU` is one of the many index that can be computed with icclim. See `the documentation <https://icclim.readthedocs.io/en/latest/explanation/climate_indices.html#icclim-capabilities>`_ to see what other index icclim can compute. 
+`SU` is one of the many index that can be computed with icclim. See `the documentation <https://icclim.readthedocs.io/en/latest/explanation/climate_indices.html#icclim-capabilities>`_ to see what other index icclim can compute.
 
 .. code-block:: python
 

--- a/doc/source/how_to/dask.rst
+++ b/doc/source/how_to/dask.rst
@@ -6,9 +6,9 @@ Chunk data and parallelize computation
 TL;DR
 -----
 icclim make use of dask to chunk and parallelize computations.
-You can configure dask to limit its memory footprint and CPu usage by instantiating a distributed Client and by tuning
+You can configure dask to limit its memory footprint and CPU usage by instantiating a distributed Cluster and by tuning
 dask.config options.
-A configuration working well for small to medium dataset and simple climate indices is :
+A configuration working well for small to medium dataset and simple climate indices could be:
 
 >>> import dask
 >>> from distributed import Client
@@ -73,6 +73,56 @@ performances.
 If you wish to avoid this large chunking behavior, you can try the following dask configuration:
 
 >>> dask.config.set({"array.slicing.split_large_chunks": True})
+
+Create an optimized chunking on disk
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Sometimes, you have to work with data that were originally chunked and stored in a way that is suboptimal.
+Often climat data are stored in a one year per file format thus the natural chunking of the dataset will be one year per chunk.
+Here, by "natural" we mean the most efficient way to read data on disk would be to organize data in memory the same way it is scattered on the disk.
+So, _basically_ one chunk per file, if they fit within `array.chunk-size`.
+
+This scattering in many files may limit the performances on some indices because you would either need to
+    - Rechunk in memory to have an optimized chunking. This generate many dask tasks.
+    - Use the "natural" chunking and suffer from the potentially poor performances it provides.
+
+To tackle this issue, icclim 5.1.0 comes with a new feature to first rewrite the data on disk before starting any computation.
+We heavily rely on the `rechunker library <https://rechunker.readthedocs.io/en/latest/index.html>`_ to make this possible.
+``icclim.create_optimized_zarr_store`` is a context manager which allow you to rewrite an input data into a zarr store
+with a specific chunking schema for optimal computation of climat indices.
+
+Now, depending on the climat index you want to compute, the optimal chunking schema might differ.
+
+For most indices, if you consider chunking on time dimension, you should never chunk below the target resampling period.
+For example, with ``slice_mode="month"``, ideally each chunk should include whole month and never chunk in the middle of a month.
+But month being of variable lengths, it might actually be much easier to have one chunk per year.
+Leap years would add another difficulty to this.
+
+However, on indice where a bootstrapping of percentile is necessary (e.g Tg90p), it is actually optimal to
+have no chunk at all on time dimension. This is true only because the bootstrapping algorithm rely on `map_block <https://xarray.pydata.org/en/stable/generated/xarray.map_blocks.html>`_.
+In that case could use ``icclim.create_optimized_zarr_store`` to first create a zarr store not chunked at all on time dimension:
+
+.. code-block:: python
+    import icclim
+
+    with icclim.create_optimized_zarr_store(
+        in_files="netcdf_files/tas.nc",
+        var_names="tas",
+        target_zarr_store_name="opti.zarr",
+        keep_target_store = False
+        chunking={"time": -1, "lat":"auto", "lon":"auto" },
+    ) as opti_tas :
+         icclim.index(
+            index_name="TG90p",
+            in_files=opti_tas,
+            slice_mode="YS",
+            base_period_time_range=[datetime.datetime(1980, 1, 1), datetime.datetime(2009, 12, 31)],
+            out_file="netcdf_files/output/tg90p.nc",
+        )
+
+Actually this is the default behavior of `chunking` parameter and it could be omitted in the above example.
+
+You can also control if you want to keep the optimized zarr store on disk by turning ``keep_target_store`` to True.
+This can be useful if you wish to compute other indices using the same chunking.
 
 On performances
 ---------------

--- a/doc/source/references/release_notes.rst
+++ b/doc/source/references/release_notes.rst
@@ -4,6 +4,7 @@ Release history
 5.1.1-dev
 ---------
 [maint] Update release process.
+[enh] Improve `create_optimized_zarr_store` to accept a chunking schema instead of a single dim.
 
 5.1.0
 -----

--- a/icclim/ecad_functions.py
+++ b/icclim/ecad_functions.py
@@ -741,18 +741,27 @@ def ww(config: IndexConfig) -> DataArray:
     )
 
 
-def _can_run_bootstrap(
-    cf_var: CfVariable, percentile_period: slice, interpolation: QuantileInterpolation
-) -> bool:
+def _can_run_bootstrap(cf_var: CfVariable) -> bool:
     """
     Avoid bootstrapping if there is one single year overlapping or no year overlapping
     or all year overlapping.
     """
-    da_years = np.unique(cf_var.study_da.indexes.get("time").year)
+    study_years = np.unique(cf_var.study_da.indexes.get("time").year)
     overlapping_years = np.unique(
-        cf_var.study_da.sel(time=percentile_period).indexes.get("time").year
+        cf_var.study_da.sel(time=_get_ref_period_slice(cf_var.reference_da))
+        .indexes.get("time")
+        .year
     )
-    return len(overlapping_years) > 1 and len(overlapping_years) < len(da_years)
+    return len(overlapping_years) > 1 and len(overlapping_years) < len(study_years)
+
+
+def _get_ref_period_slice(da: DataArray) -> slice:
+    time_length = len(da.reference_da.time)
+    return (
+        da.reference_da.time[0 :: time_length - 1]
+        .dt.strftime("%Y-%m-%d")
+        .values.tolist()
+    )
 
 
 def _to_percent(da: DataArray, sampling_freq: Frequency) -> DataArray:
@@ -785,7 +794,7 @@ def _to_percent(da: DataArray, sampling_freq: Frequency) -> DataArray:
     else:
         # TODO improve this for custom resampling
         warn(
-            "For now, '%' unit can only be used with slice_mode being one of "
+            "For now, '%' unit can only be used when `slice_mode` is one of: "
             "{MONTH, YEAR, AMJJAS, ONDJFM, DJF, MAM, JJA, SON}."
         )
         return da
@@ -882,9 +891,7 @@ def _compute_spell_duration(
         per_interpolation,
         callback,
     )
-    run_bootstrap = _can_run_bootstrap(
-        cf_var, slice(*per.climatology_bounds), per_interpolation
-    )
+    run_bootstrap = _can_run_bootstrap(cf_var)
     result = xclim_index_fun(
         cf_var.study_da,
         per,
@@ -1042,15 +1049,13 @@ def _compute_temperature_percentile_index(
     callback: Callable,
     xclim_index_fun: Callable,
 ) -> Tuple[DataArray, Optional[DataArray]]:
+    run_bootstrap = _can_run_bootstrap(cf_var)
     per = _compute_percentile_doy(
         cf_var.reference_da,
         tas_per_thresh,
         per_window,
         per_interpolation,
         callback,
-    )
-    run_bootstrap = _can_run_bootstrap(
-        cf_var, slice(*per.climatology_bounds), per_interpolation
     )
     result = xclim_index_fun(
         cf_var.study_da,

--- a/icclim/ecad_functions.py
+++ b/icclim/ecad_functions.py
@@ -756,12 +756,8 @@ def _can_run_bootstrap(cf_var: CfVariable) -> bool:
 
 
 def _get_ref_period_slice(da: DataArray) -> slice:
-    time_length = len(da.reference_da.time)
-    return (
-        da.reference_da.time[0 :: time_length - 1]
-        .dt.strftime("%Y-%m-%d")
-        .values.tolist()
-    )
+    time_length = len(da.time)
+    return slice(*(da.time[0 :: time_length - 1].dt.strftime("%Y-%m-%d").values))
 
 
 def _to_percent(da: DataArray, sampling_freq: Frequency) -> DataArray:

--- a/icclim/ecad_functions.py
+++ b/icclim/ecad_functions.py
@@ -1062,7 +1062,7 @@ def _compute_temperature_percentile_index(
         per_window,
         per_interpolation,
         callback,
-    )
+    ).compute()
     result = xclim_index_fun(
         cf_var.study_da,
         per,

--- a/icclim/icclim_logger.py
+++ b/icclim/icclim_logger.py
@@ -36,7 +36,7 @@ class IcclimLogger:
     verbosity: Verbosity = Verbosity.LOW
 
     @staticmethod
-    def get_instance(verbosity: Verbosity):
+    def get_instance(verbosity: Verbosity = Verbosity.LOW):
         if IcclimLogger.__instance is None:
             IcclimLogger(verbosity)
         return IcclimLogger.__instance
@@ -145,6 +145,9 @@ class IcclimLogger:
         logging.info(
             "   ********************************************************************************************"
         )
+
+    def info(*args):
+        logging.info(args)
 
     def deprecation_warning(self, old: str, new: str = None) -> None:
         if new:

--- a/icclim/main.py
+++ b/icclim/main.py
@@ -239,14 +239,6 @@ def index(
         index = None
     input_dataset, chunk_it = read_dataset(in_files, index, var_name)
     ds, reset_coords_dict = update_to_standard_coords(input_dataset)
-    if ds.chunks:
-        time_chunk_count = len(ds.chunks["time"])
-        if time_chunk_count > 1:
-            warn(
-                f"Your dataset has {time_chunk_count} chunks for time dimension."
-                f" You could significantly speed up your computations by rechunking it"
-                f" with `icclim.create_optimized_zarr_store`."
-            )
     config = IndexConfig(
         base_period_time_range=base_period_time_range,
         ds=ds,

--- a/icclim/tests/test_rechunk.py
+++ b/icclim/tests/test_rechunk.py
@@ -29,7 +29,6 @@ def test_create_optimized_zarr_store_success():
         in_files=ds,
         var_names="tas",
         target_zarr_store_name="yolo.zarr",
-        dim="time",
     ) as result:
         assert len(result.chunks["time"]) == 1
         np.testing.assert_array_equal(result.tas.values, ds.tas.values)
@@ -59,7 +58,6 @@ def test_create_optimized_zarr_store_error():
             in_files=ds,
             var_names="TATAYOYO!",
             target_zarr_store_name="yolo.zarr",
-            dim="time",
         ):
             pass
 
@@ -86,7 +84,6 @@ def test_create_optimized_zarr_store_no_rechunk(rechunk_mock: MagicMock):
         in_files=ds,
         var_names="tas",
         target_zarr_store_name="n/a",
-        dim="time",
     ) as result:
         xr.testing.assert_equal(ds, result)
         rechunk_mock.assert_not_called()

--- a/icclim/utils.py
+++ b/icclim/utils.py
@@ -1,0 +1,26 @@
+from xarray import DataArray, Dataset
+
+
+# FIXME To remove once minimal xarray version is v0.20.0 (use .chunksizes instead)
+def _da_chunksizes(da: DataArray) -> dict:
+    # Copied and adapted from xarray
+    if hasattr(da.data, "chunks"):
+        return {dim: c for dim, c in zip(da.dims, da.data.chunks)}
+    else:
+        return {}
+
+
+# FIXME To remove once minimal xarray version is v0.20.0 (use .chunksizes instead)
+def _get_chunksizes(ds: Dataset) -> dict:
+    # Copied and adapted from xarray
+    chunks = {}
+    for v in ds.variables.values():
+        if hasattr(v.data, "chunks"):
+            for dim, c in _da_chunksizes(v).items():
+                if dim in chunks and c != chunks[dim]:
+                    raise ValueError(
+                        f"Object has inconsistent chunks along dimension {dim}."
+                        " This can be fixed by calling unify_chunks()."
+                    )
+                chunks[dim] = c
+    return chunks


### PR DESCRIPTION
<!--
The following checklist points should all be checked before merging the PR.

Please replace xxx by your issue number (leave the prefixing '#').
-->

### Pull Request to resolve #xxx
- [x] Unit tests cover the changes.
- [x] These changes were tested on real data.
- [x] The relevant documentation has been added or updated.
- [x] A short description of the changes has been added to `doc/source/references/release_notes.rst`.

### Describe the changes you made
Following the discussion on S.O[0] it seems not so optimal to always use a chunking schema where a dimension is unchunked.

Now instead of passing a `dim` which will be unchunked, `create_optimized_zarr_store` accepts a `chunking` dictionary.
The default behavior is unchanged though, it will still create a zarr store unchunked on time.
This seems handy because the climate indices relying on daily percentiles will still be much faster if there is no chunk on "time" because of the `map_block` used in xclim bootstrapping.py.

[0] https://stackoverflow.com/questions/71570003/why-does-the-amount-of-dask-task-increase-with-an-optimized-chunking-compared