### PR TITLE
Enh/in between years season

### DIFF
--- a/doc/source/references/icclim_index_api.rst
+++ b/doc/source/references/icclim_index_api.rst
@@ -68,15 +68,15 @@ summer, autumn and monthly frequency:
 | The winter season (``DJF``) of 2000 is composed of December 2000, January 2001 and February 2001.
 | Likewise, the winter half-year (``ONDJFM``) of 2000 includes October 2000, November 2000, December 2000, January 2001, February 2001 and March 2001.
 
-Monthly time series with months selected by user:
-    >>> slice_mode = ['month',[4,5,11]] # index will be computed only for April, May and November
+Monthly time series with months selected by user (the keyword can be either "month" or "months"):
+    >>> slice_mode = ['month', [4,5,11]] # index will be computed only for April, May and November
     or
-    >>> slice_mode = ['month',[4]] # index will be computed only for April
+    >>> slice_mode = ['month', [4]] # index will be computed only for April
 
 User defined seasons:
-    >>> slice_mode = ['season',[4,5,6,7]]
+    >>> slice_mode = ['season', [4,5,6,7]]
     or
-    >>> slice_mode = ['season',([11, 12, 1])]
+    >>> slice_mode = ['season', ([11, 12, 1])]
 
 ``threshold``
 ~~~~~~~~~~~~~

--- a/icclim/ecad_functions.py
+++ b/icclim/ecad_functions.py
@@ -3,7 +3,7 @@ All ECA&D functions. Each function wraps its xclim equivalent functions adding i
 metadata to it.
 """
 import re
-from typing import Callable, Optional, Tuple
+from typing import Callable, Optional, Tuple, Any
 from warnings import warn
 
 import numpy as np
@@ -25,7 +25,7 @@ def gd4(config: IndexConfig) -> DataArray:
     return _compute_threshold_index(
         da=config.tas.study_da,
         threshold=4.0 if config.threshold is None else config.threshold,
-        freq=config.freq,
+        freq_config=_build_frequency_kwargs(config),
         xclim_index_fun=atmos.growing_degree_days,
     )
 
@@ -34,7 +34,7 @@ def cfd(config: IndexConfig) -> DataArray:
     return _compute_threshold_index(
         da=config.tasmin.study_da,
         threshold=0.0 if config.threshold is None else config.threshold,
-        freq=config.freq,
+        freq_config=_build_frequency_kwargs(config),
         xclim_index_fun=atmos.consecutive_frost_days,
     )
 
@@ -43,7 +43,7 @@ def fd(config: IndexConfig) -> DataArray:
     return _compute_threshold_index(
         da=config.tasmin.study_da,
         threshold=0.0 if config.threshold is None else config.threshold,
-        freq=config.freq,
+        freq_config=_build_frequency_kwargs(config),
         xclim_index_fun=atmos.frost_days,
     )
 
@@ -52,7 +52,7 @@ def hd17(config: IndexConfig) -> DataArray:
     return _compute_threshold_index(
         da=config.tas.study_da,
         threshold=17.0 if config.threshold is None else config.threshold,
-        freq=config.freq,
+        freq_config=_build_frequency_kwargs(config),
         xclim_index_fun=atmos.heating_degree_days,
     )
 
@@ -61,7 +61,7 @@ def id(config: IndexConfig) -> DataArray:
     return _compute_threshold_index(
         da=config.tasmax.study_da,
         threshold=0.0 if config.threshold is None else config.threshold,
-        freq=config.freq,
+        freq_config=_build_frequency_kwargs(config),
         xclim_index_fun=atmos.ice_days,
     )
 
@@ -70,7 +70,7 @@ def csdi(config: IndexConfig) -> Tuple[DataArray, Optional[DataArray]]:
     thresh = 10 if config.threshold is None else config.threshold
     return _compute_spell_duration(
         cf_var=config.tasmin,
-        freq=config.freq.panda_freq,
+        freq_config=_build_frequency_kwargs(config),
         per_thresh=thresh,
         per_window=config.window,
         per_interpolation=config.interpolation,
@@ -84,7 +84,7 @@ def csdi(config: IndexConfig) -> Tuple[DataArray, Optional[DataArray]]:
 def tg10p(config: IndexConfig) -> Tuple[DataArray, Optional[DataArray]]:
     return _compute_temperature_percentile_index(
         cf_var=config.tas,
-        freq=config.freq,
+        freq_config=_build_frequency_kwargs(config),
         tas_per_thresh=10,
         per_window=config.window,
         per_interpolation=config.interpolation,
@@ -98,7 +98,7 @@ def tg10p(config: IndexConfig) -> Tuple[DataArray, Optional[DataArray]]:
 def tn10p(config: IndexConfig) -> Tuple[DataArray, Optional[DataArray]]:
     return _compute_temperature_percentile_index(
         cf_var=config.tasmin,
-        freq=config.freq,
+        freq_config=_build_frequency_kwargs(config),
         tas_per_thresh=10,
         per_window=config.window,
         per_interpolation=config.interpolation,
@@ -112,7 +112,7 @@ def tn10p(config: IndexConfig) -> Tuple[DataArray, Optional[DataArray]]:
 def tx10p(config: IndexConfig) -> Tuple[DataArray, Optional[DataArray]]:
     return _compute_temperature_percentile_index(
         cf_var=config.tasmax,
-        freq=config.freq,
+        freq_config=_build_frequency_kwargs(config),
         tas_per_thresh=10,
         per_window=config.window,
         per_interpolation=config.interpolation,
@@ -124,20 +124,20 @@ def tx10p(config: IndexConfig) -> Tuple[DataArray, Optional[DataArray]]:
 
 
 def txn(config: IndexConfig) -> DataArray:
-    result = atmos.tx_min(config.tasmax.study_da, freq=config.freq.panda_freq)
+    result = atmos.tx_min(config.tasmax.study_da, **_build_frequency_kwargs(config))
     result = convert_units_to(result, "°C")
     return result
 
 
 def tnn(config: IndexConfig) -> DataArray:
-    result = atmos.tn_min(config.tasmin.study_da, freq=config.freq.panda_freq)
+    result = atmos.tn_min(config.tasmin.study_da, **_build_frequency_kwargs(config))
     result = convert_units_to(result, "°C")
     return result
 
 
 def cdd(config: IndexConfig) -> DataArray:
     result = atmos.maximum_consecutive_dry_days(
-        config.pr.study_da, thresh="1.0 mm/day", freq=config.freq.panda_freq
+        config.pr.study_da, thresh="1.0 mm/day", **_build_frequency_kwargs(config)
     )
     return result
 
@@ -146,7 +146,7 @@ def su(config: IndexConfig) -> DataArray:
     return _compute_threshold_index(
         da=config.tasmax.study_da,
         threshold=25.0 if config.threshold is None else config.threshold,
-        freq=config.freq,
+        freq_config=_build_frequency_kwargs(config),
         xclim_index_fun=atmos.tx_days_above,
     )
 
@@ -155,7 +155,7 @@ def tr(config: IndexConfig) -> DataArray:
     return _compute_threshold_index(
         da=config.tasmin.study_da,
         threshold=20.0 if config.threshold is None else config.threshold,
-        freq=config.freq,
+        freq_config=_build_frequency_kwargs(config),
         xclim_index_fun=atmos.tropical_nights,
     )
 
@@ -164,7 +164,7 @@ def wsdi(config: IndexConfig) -> Tuple[DataArray, Optional[DataArray]]:
     thresh = 90 if config.threshold is None else config.threshold
     return _compute_spell_duration(
         cf_var=config.tasmax,
-        freq=config.freq.panda_freq,
+        freq_config=_build_frequency_kwargs(config),
         per_thresh=thresh,
         per_window=config.window,
         per_interpolation=config.interpolation,
@@ -178,7 +178,7 @@ def wsdi(config: IndexConfig) -> Tuple[DataArray, Optional[DataArray]]:
 def tg90p(config: IndexConfig) -> Tuple[DataArray, Optional[DataArray]]:
     return _compute_temperature_percentile_index(
         cf_var=config.tas,
-        freq=config.freq,
+        freq_config=_build_frequency_kwargs(config),
         tas_per_thresh=90,
         per_window=config.window,
         per_interpolation=config.interpolation,
@@ -192,7 +192,7 @@ def tg90p(config: IndexConfig) -> Tuple[DataArray, Optional[DataArray]]:
 def tn90p(config: IndexConfig) -> Tuple[DataArray, Optional[DataArray]]:
     return _compute_temperature_percentile_index(
         cf_var=config.tasmin,
-        freq=config.freq,
+        freq_config=_build_frequency_kwargs(config),
         tas_per_thresh=90,
         per_window=config.window,
         per_interpolation=config.interpolation,
@@ -206,7 +206,7 @@ def tn90p(config: IndexConfig) -> Tuple[DataArray, Optional[DataArray]]:
 def tx90p(config: IndexConfig) -> Tuple[DataArray, Optional[DataArray]]:
     return _compute_temperature_percentile_index(
         cf_var=config.tasmax,
-        freq=config.freq,
+        freq_config=_build_frequency_kwargs(config),
         tas_per_thresh=90,
         per_window=config.window,
         per_interpolation=config.interpolation,
@@ -218,13 +218,13 @@ def tx90p(config: IndexConfig) -> Tuple[DataArray, Optional[DataArray]]:
 
 
 def txx(config: IndexConfig) -> DataArray:
-    result = atmos.tx_max(config.tasmax.study_da, freq=config.freq.panda_freq)
+    result = atmos.tx_max(config.tasmax.study_da, **_build_frequency_kwargs(config))
     result = convert_units_to(result, "°C")
     return result
 
 
 def tnx(config: IndexConfig) -> DataArray:
-    result = atmos.tn_max(config.tasmin.study_da, freq=config.freq.panda_freq)
+    result = atmos.tn_max(config.tasmin.study_da, **_build_frequency_kwargs(config))
     result = convert_units_to(result, "°C")
     return result
 
@@ -233,7 +233,7 @@ def csu(config: IndexConfig) -> DataArray:
     return _compute_threshold_index(
         da=config.tasmax.study_da,
         threshold=25.0 if config.threshold is None else config.threshold,
-        freq=config.freq,
+        freq_config=_build_frequency_kwargs(config),
         xclim_index_fun=atmos.maximum_consecutive_warm_days,
     )
 
@@ -241,56 +241,56 @@ def csu(config: IndexConfig) -> DataArray:
 def prcptot(config: IndexConfig) -> DataArray:
     result = atmos.precip_accumulation(
         _filter_in_wet_days(config.pr.study_da, dry_day_value=0),
-        freq=config.freq.panda_freq,
+        **_build_frequency_kwargs(config),
     )
     return result
 
 
 def rr1(config: IndexConfig) -> DataArray:
     result = atmos.wetdays(
-        config.pr.study_da, thresh="1.0 mm/day", freq=config.freq.panda_freq
+        config.pr.study_da, thresh="1.0 mm/day", **_build_frequency_kwargs(config)
     )
     return result
 
 
 def sdii(config: IndexConfig) -> DataArray:
     result = atmos.daily_pr_intensity(
-        config.pr.study_da, thresh="1.0 mm/day", freq=config.freq.panda_freq
+        config.pr.study_da, thresh="1.0 mm/day", **_build_frequency_kwargs(config)
     )
     return result
 
 
 def cwd(config: IndexConfig) -> DataArray:
     result = atmos.maximum_consecutive_wet_days(
-        config.pr.study_da, thresh="1.0 mm/day", freq=config.freq.panda_freq
+        config.pr.study_da, thresh="1.0 mm/day", **_build_frequency_kwargs(config)
     )
     return result
 
 
 def r10mm(config: IndexConfig) -> DataArray:
     result = atmos.wetdays(
-        config.pr.study_da, thresh="10 mm/day", freq=config.freq.panda_freq
+        config.pr.study_da, thresh="10 mm/day", **_build_frequency_kwargs(config)
     )
     return result
 
 
 def r20mm(config: IndexConfig) -> DataArray:
     result = atmos.wetdays(
-        config.pr.study_da, thresh="20 mm/day", freq=config.freq.panda_freq
+        config.pr.study_da, thresh="20 mm/day", **_build_frequency_kwargs(config)
     )
     return result
 
 
 def rx1day(config: IndexConfig) -> DataArray:
     result = atmos.max_1day_precipitation_amount(
-        config.pr.study_da, freq=config.freq.panda_freq
+        config.pr.study_da, **_build_frequency_kwargs(config)
     )
     return result
 
 
 def rx5day(config: IndexConfig) -> DataArray:
     result = atmos.max_n_day_precipitation_amount(
-        config.pr.study_da, window=5, freq=config.freq.panda_freq
+        config.pr.study_da, window=5, **_build_frequency_kwargs(config)
     )
     return result
 
@@ -298,7 +298,7 @@ def rx5day(config: IndexConfig) -> DataArray:
 def r75p(config: IndexConfig) -> Tuple[DataArray, Optional[DataArray]]:
     return _compute_rxxp(
         pr=config.pr,
-        freq=config.freq,
+        freq_config=_build_frequency_kwargs(config),
         pr_per_thresh=75.0,
         per_interpolation=config.interpolation,
         save_percentile=config.save_percentile,
@@ -309,7 +309,7 @@ def r75p(config: IndexConfig) -> Tuple[DataArray, Optional[DataArray]]:
 def r75ptot(config: IndexConfig) -> Tuple[DataArray, Optional[DataArray]]:
     return _compute_rxxptot(
         pr=config.pr,
-        freq=config.freq.panda_freq,
+        freq_config=_build_frequency_kwargs(config),
         pr_per_thresh=75.0,
         per_interpolation=config.interpolation,
         save_percentile=config.save_percentile,
@@ -319,7 +319,7 @@ def r75ptot(config: IndexConfig) -> Tuple[DataArray, Optional[DataArray]]:
 def r95p(config: IndexConfig) -> Tuple[DataArray, Optional[DataArray]]:
     return _compute_rxxp(
         pr=config.pr,
-        freq=config.freq,
+        freq_config=_build_frequency_kwargs(config),
         pr_per_thresh=95.0,
         per_interpolation=config.interpolation,
         save_percentile=config.save_percentile,
@@ -330,7 +330,7 @@ def r95p(config: IndexConfig) -> Tuple[DataArray, Optional[DataArray]]:
 def r95ptot(config: IndexConfig) -> Tuple[DataArray, Optional[DataArray]]:
     return _compute_rxxptot(
         pr=config.pr,
-        freq=config.freq.panda_freq,
+        freq_config=_build_frequency_kwargs(config),
         pr_per_thresh=95.0,
         per_interpolation=config.interpolation,
         save_percentile=config.save_percentile,
@@ -340,7 +340,7 @@ def r95ptot(config: IndexConfig) -> Tuple[DataArray, Optional[DataArray]]:
 def r99p(config: IndexConfig) -> Tuple[DataArray, Optional[DataArray]]:
     return _compute_rxxp(
         pr=config.pr,
-        freq=config.freq,
+        freq_config=_build_frequency_kwargs(config),
         pr_per_thresh=99.0,
         per_interpolation=config.interpolation,
         save_percentile=config.save_percentile,
@@ -351,7 +351,7 @@ def r99p(config: IndexConfig) -> Tuple[DataArray, Optional[DataArray]]:
 def r99ptot(config: IndexConfig) -> Tuple[DataArray, Optional[DataArray]]:
     return _compute_rxxptot(
         pr=config.pr,
-        freq=config.freq.panda_freq,
+        freq_config=_build_frequency_kwargs(config),
         pr_per_thresh=99.0,
         per_interpolation=config.interpolation,
         save_percentile=config.save_percentile,
@@ -377,7 +377,7 @@ def sd(config: IndexConfig) -> DataArray:
     -------
     returns DataArray of the resulting index
     """
-    result = land.snow_depth(config.pr.study_da, freq=config.freq.panda_freq)
+    result = land.snow_depth(config.pr.study_da, **_build_frequency_kwargs(config))
     return result
 
 
@@ -401,7 +401,7 @@ def sd1(config: IndexConfig) -> DataArray:
     returns DataArray of the resulting index
     """
     result = land.snow_cover_duration(
-        config.pr.study_da, thresh="1 cm", freq=config.freq.panda_freq
+        config.pr.study_da, thresh="1 cm", **_build_frequency_kwargs(config)
     )
     return result
 
@@ -426,7 +426,7 @@ def sd5cm(config: IndexConfig) -> DataArray:
     returns DataArray of the resulting index
     """
     result = land.snow_cover_duration(
-        config.pr.study_da, thresh="5 cm", freq=config.freq.panda_freq
+        config.pr.study_da, thresh="5 cm", **_build_frequency_kwargs(config)
     )
     return result
 
@@ -451,7 +451,7 @@ def sd50cm(config: IndexConfig) -> DataArray:
     returns DataArray of the resulting index
     """
     result = land.snow_cover_duration(
-        config.pr.study_da, thresh="50 cm", freq=config.freq.panda_freq
+        config.pr.study_da, thresh="50 cm", **_build_frequency_kwargs(config)
     )
     return result
 
@@ -475,7 +475,7 @@ def tg(config: IndexConfig) -> DataArray:
     -------
     returns DataArray of the resulting index
     """
-    result = atmos.tg_mean(config.tas.study_da, freq=config.freq.panda_freq)
+    result = atmos.tg_mean(config.tas.study_da, **_build_frequency_kwargs(config))
     result = convert_units_to(result, "°C")
     return result
 
@@ -499,7 +499,7 @@ def tn(config: IndexConfig) -> DataArray:
     -------
     returns DataArray of the resulting index
     """
-    result = atmos.tn_mean(config.tasmin.study_da, freq=config.freq.panda_freq)
+    result = atmos.tn_mean(config.tasmin.study_da, **_build_frequency_kwargs(config))
     result = convert_units_to(result, "°C")
     return result
 
@@ -523,7 +523,7 @@ def tx(config: IndexConfig) -> DataArray:
     -------
     returns DataArray of the resulting index
     """
-    result = atmos.tx_mean(config.tasmax.study_da, freq=config.freq.panda_freq)
+    result = atmos.tx_mean(config.tasmax.study_da, **_build_frequency_kwargs(config))
     result = convert_units_to(result, "°C")
     return result
 
@@ -551,7 +551,7 @@ def dtr(config: IndexConfig) -> DataArray:
     result = atmos.daily_temperature_range(
         tasmax=config.tasmax.study_da,
         tasmin=config.tasmin.study_da,
-        freq=config.freq.panda_freq,
+        **_build_frequency_kwargs(config),
     )
     result.attrs["units"] = "°C"
     return result
@@ -580,7 +580,7 @@ def etr(config: IndexConfig) -> DataArray:
     result = atmos.extreme_temperature_range(
         tasmax=config.tasmax.study_da,
         tasmin=config.tasmin.study_da,
-        freq=config.freq.panda_freq,
+        **_build_frequency_kwargs(config),
     )
     result.attrs["units"] = "°C"
     return result
@@ -610,7 +610,7 @@ def vdtr(config: IndexConfig) -> DataArray:
     result = atmos.daily_temperature_range_variability(
         tasmax=config.tasmax.study_da,
         tasmin=config.tasmin.study_da,
-        freq=config.freq.panda_freq,
+        **_build_frequency_kwargs(config),
     )
     result.attrs["units"] = "°C"
     return result
@@ -640,7 +640,7 @@ def cd(config: IndexConfig) -> DataArray:
     return compute_compound_index(
         tas=config.tas,
         pr=config.pr,
-        freq=config.freq.panda_freq,
+        freq_config=_build_frequency_kwargs(config),
         tas_per_thresh=25,
         pr_per_thresh=25,
         per_window=config.window,
@@ -675,7 +675,7 @@ def cw(config: IndexConfig) -> DataArray:
     return compute_compound_index(
         tas=config.tas,
         pr=config.pr,
-        freq=config.freq.panda_freq,
+        freq_config=_build_frequency_kwargs(config),
         tas_per_thresh=25,
         pr_per_thresh=75,
         per_window=config.window,
@@ -710,7 +710,7 @@ def wd(config: IndexConfig) -> DataArray:
     return compute_compound_index(
         tas=config.tas,
         pr=config.pr,
-        freq=config.freq.panda_freq,
+        freq_config=_build_frequency_kwargs(config),
         tas_per_thresh=75,
         pr_per_thresh=25,
         per_window=config.window,
@@ -733,7 +733,7 @@ def ww(config: IndexConfig) -> DataArray:
     return compute_compound_index(
         tas=config.tas,
         pr=config.pr,
-        freq=config.freq.panda_freq,
+        freq_config=_build_frequency_kwargs(config),
         tas_per_thresh=75,
         pr_per_thresh=75,
         per_window=config.window,
@@ -823,11 +823,7 @@ def _compute_percentile_doy(
     callback: Callable = None,
 ) -> DataArray:
     per = percentile_doy(
-        da,
-        window,
-        percentile,
-        alpha=interpolation.alpha,
-        beta=interpolation.beta,
+        da, window, percentile, alpha=interpolation.alpha, beta=interpolation.beta,
     )
     if callback is not None:
         callback(50)
@@ -863,18 +859,15 @@ def _filter_in_wet_days(da: DataArray, dry_day_value: float):
 
 
 def _compute_threshold_index(
-    da: DataArray,
-    threshold: float,
-    freq: Frequency,
-    xclim_index_fun: Callable,
+    da: DataArray, threshold: float, freq_config: dict, xclim_index_fun: Callable,
 ) -> DataArray:
-    result = xclim_index_fun(da, thresh=f"{threshold} °C", freq=freq.panda_freq)
+    result = xclim_index_fun(da, thresh=f"{threshold} °C", **freq_config)
     return result
 
 
 def _compute_spell_duration(
     cf_var: CfVariable,
-    freq: str,
+    freq_config: dict,
     per_window: int,
     per_thresh: float,
     per_interpolation: QuantileInterpolation,
@@ -884,18 +877,14 @@ def _compute_spell_duration(
     xclim_index_fun: Callable,
 ) -> Tuple[DataArray, Optional[DataArray]]:
     per = _compute_percentile_doy(
-        cf_var.reference_da,
-        per_thresh,
-        per_window,
-        per_interpolation,
-        callback,
+        cf_var.reference_da, per_thresh, per_window, per_interpolation, callback,
     )
     run_bootstrap = _can_run_bootstrap(cf_var)
     result = xclim_index_fun(
         cf_var.study_da,
         per,
         window=min_spell_duration,
-        freq=freq,
+        **freq_config,
         bootstrap=run_bootstrap,
     )
     result = result.squeeze(PERCENTILES_COORD, drop=True)
@@ -914,7 +903,7 @@ def _compute_spell_duration(
 def compute_compound_index(
     tas: CfVariable,
     pr: CfVariable,
-    freq: str,
+    freq_config: dict,
     tas_per_thresh: int,
     pr_per_thresh: int,
     per_window: int,
@@ -942,10 +931,9 @@ def compute_compound_index(
     window : int
         window in days used to computed each percentile.
         default is 5.
-    freq : str
-        pandas like frequency.
-        Used to determine the time slices of the output.
-        Default is "YS" as in Year Start.
+    freq_config : dict
+        pandas like frequency in "freq" key and either seasonal filtering in
+        "date_bounds" or month filtering in "month"
     save_percentile : bool
         Flag to include coordinate variable including the computed percentiles.
         Does not contain the bootstrapped percentiles.
@@ -962,24 +950,16 @@ def compute_compound_index(
         Otherwise, returns the index_result
     """
     tas_per = _compute_percentile_doy(
-        tas.reference_da,
-        tas_per_thresh,
-        per_window,
-        per_interpolation,
-        callback,
+        tas.reference_da, tas_per_thresh, per_window, per_interpolation, callback,
     )
     tas_per = tas_per.squeeze(PERCENTILES_COORD, drop=True)
     pr_in_base = _filter_in_wet_days(pr.reference_da, dry_day_value=np.NAN)
     pr_out_of_base = _filter_in_wet_days(pr.study_da, dry_day_value=0)
     pr_per = _compute_percentile_doy(
-        pr_in_base,
-        pr_per_thresh,
-        per_window,
-        per_interpolation,
-        callback,
+        pr_in_base, pr_per_thresh, per_window, per_interpolation, callback,
     )
     pr_per = pr_per.squeeze(PERCENTILES_COORD, drop=True)
-    result = xclim_index_fun(tas.study_da, tas_per, pr_out_of_base, pr_per, freq=freq)
+    result = xclim_index_fun(tas.study_da, tas_per, pr_out_of_base, pr_per, **freq_config)
     if save_percentile:
         # FIXME, not consistent with other percentile based indices
         #        We should probably return a Tuple (res, [tas_per, pr_per])
@@ -992,7 +972,7 @@ def compute_compound_index(
 
 def _compute_rxxptot(
     pr: CfVariable,
-    freq: str,
+    freq_config: dict,
     pr_per_thresh: float,
     per_interpolation: QuantileInterpolation,
     save_percentile: bool,
@@ -1002,11 +982,7 @@ def _compute_rxxptot(
         base_wet_days, per_interpolation, pr_per_thresh
     )
     result = atmos.fraction_over_precip_thresh(
-        pr.study_da,
-        per,
-        thresh="1 mm/day",
-        freq=freq,
-        bootstrap=False,
+        pr.study_da, per, thresh="1 mm/day", **freq_config, bootstrap=False,
     ).squeeze(PERCENTILES_COORD, drop=True)
     result = result * 100
     result.attrs["units"] = "%"
@@ -1017,7 +993,7 @@ def _compute_rxxptot(
 
 def _compute_rxxp(
     pr: CfVariable,
-    freq: Frequency,
+    freq_config: dict,
     pr_per_thresh: float,
     per_interpolation: QuantileInterpolation,
     save_percentile: bool,
@@ -1028,15 +1004,11 @@ def _compute_rxxp(
         base_wet_days, per_interpolation, pr_per_thresh
     )
     result = atmos.days_over_precip_thresh(
-        pr.study_da,
-        per,
-        thresh="1 mm/day",
-        freq=freq.panda_freq,
-        bootstrap=False,
+        pr.study_da, per, thresh="1 mm/day", **freq_config, bootstrap=False,
     )
     result = result.squeeze(PERCENTILES_COORD, drop=True)
     if is_percent:
-        result = _to_percent(result, freq)
+        result = _to_percent(result, freq_config["freq"])
     if save_percentile:
         return result, per
     return result, None
@@ -1044,7 +1016,7 @@ def _compute_rxxp(
 
 def _compute_temperature_percentile_index(
     cf_var: CfVariable,
-    freq: Frequency,
+    freq_config: dict,
     tas_per_thresh: int,
     per_window: int,
     per_interpolation: QuantileInterpolation,
@@ -1055,22 +1027,23 @@ def _compute_temperature_percentile_index(
 ) -> Tuple[DataArray, Optional[DataArray]]:
     run_bootstrap = _can_run_bootstrap(cf_var)
     per = _compute_percentile_doy(
-        cf_var.reference_da,
-        tas_per_thresh,
-        per_window,
-        per_interpolation,
-        callback,
+        cf_var.reference_da, tas_per_thresh, per_window, per_interpolation, callback,
     ).compute()
     result = xclim_index_fun(
-        cf_var.study_da,
-        per,
-        freq=freq.panda_freq,
-        bootstrap=run_bootstrap,
+        cf_var.study_da, per, **freq_config, bootstrap=run_bootstrap,
     ).squeeze(PERCENTILES_COORD, drop=True)
     if run_bootstrap:
         result = _add_bootstrap_meta(result, per)
     if is_percent:
-        result = _to_percent(result, freq)
+        result = _to_percent(result, freq_config["freq"])
     if save_percentile:
         return result, per
     return result, None
+
+
+def _build_frequency_kwargs(config) -> dict[str, Any]:
+    """Build kwargs with possible keys in {"freq", "month", "date_bounds"}"""
+    kwargs = dict(freq=config.freq.pandas_freq)
+    if config.freq.indexer is not None:
+        kwargs.update(config.freq.indexer)
+    return kwargs

--- a/icclim/main.py
+++ b/icclim/main.py
@@ -318,9 +318,6 @@ def _setup(callback, callback_start_value, logs_verbosity, slice_mode):
     # TODO: it might be safer to feed a context manager which will setup
     #       and teardown these confs
     xclim.set_options(data_validation="warn")
-    if Frequency.is_seasonal(slice_mode):
-        # for now seasonal slice_modes missing values cannot be checked
-        xclim.set_options(check_missing="skip")
     # keep attributes through xarray operations
     xr.set_options(keep_attrs=True)
     log.set_verbosity(logs_verbosity)

--- a/icclim/main.py
+++ b/icclim/main.py
@@ -113,13 +113,13 @@ def index(
     index_name: str | None = None,  # optional when computing user_indices
     var_name: str | list[str] | None = None,
     slice_mode: SliceMode = Frequency.YEAR,
-    time_range: list[datetime] = None,
+    time_range: list[datetime] = None, # TODO: use dateparser to accept strings
     out_file: str | None = None,
     threshold: float | list[float] | None = None,
     callback: Callable[[int], None] = log.callback,
     callback_percentage_start_value: int = 0,
     callback_percentage_total: int = 100,
-    base_period_time_range: list[datetime] | None = None,
+    base_period_time_range: list[datetime] | None = None,  # TODO: use dateparser to accept strings
     window_width: int = 5,
     only_leap_years: bool = False,
     ignore_Feb29th: bool = False,

--- a/icclim/models/constants.py
+++ b/icclim/models/constants.py
@@ -3,7 +3,7 @@
 
 ICCLIM_VERSION = "5.2.2-dev"
 
-# placeholder for user_indices
+# placeholder for user_index
 PERCENTILE_THRESHOLD_STAMP = "p"
 WET_DAY_THRESHOLD = 1  # 1mm
 PRECIPITATION = "p"
@@ -20,10 +20,10 @@ TAS = ["tas", "tavg", "ta", "tasadjust", "tmean", "tm", "tg", "meant", "TMEAN", 
 TAS_MAX = ["tasmax", "tasmaxadjust", "tmax", "tx", "maxt", "TMAX", "Tmax", "TX", "MAXT", "maxT"]
 TAS_MIN = ["tasmin", "tasminadjust", "tmin", "tn", "mint", "TMIN", "Tmin", "TN", "MINT", "minT"]
 
-# Source of index definition
+# Source of ECA&D indices definition
 ECAD_ATBD = "ECA&D, Algorithm Theoretical Basis Document (ATBD) v11"
 
-# Index qualifiers
+# Index qualifiers (needed to generate the API)
 QUANTILE_BASED = "QUANTILE_BASED"  # fields: QUANTILE_INDEX_FIELDS
 MODIFIABLE_UNIT = "MODIFIABLE_UNIT"  # fields: out_unit
 MODIFIABLE_THRESHOLD = "MODIFIABLE_THRESHOLD"  # fields: threshold

--- a/icclim/models/frequency.py
+++ b/icclim/models/frequency.py
@@ -1,6 +1,6 @@
 """
     `icclim.models.frequency` wraps the concept of pandas frequency in order to resample
-    time series.  `slice_mode` paramater of `icclim.index` is always converted to a
+    time series.  `slice_mode` parameter of `icclim.index` is always converted to a
     `Frequency`.
 """
 from __future__ import annotations
@@ -79,20 +79,19 @@ def get_seasonal_time_updater(
                         year_of_season_end,
                         end_month + 1,
                         1,
-                        calendar=first_time.calendar
-                    )
+                        calendar=first_time.calendar,
+                    )- timedelta(days=1)
                 else:
                     end = cftime.datetime(
                         year_of_season_end,
                         end_month,
                         end_day,
-                        calendar=first_time.calendar
+                        calendar=first_time.calendar,
                     )
             else:
                 start = pd.to_datetime(f"{year}-{start_month}-{start_day}")
                 if end_day is None:
-                    end = pd.to_datetime(f"{year_of_season_end}-{end_month + 1}")
-                    end = end - timedelta(days=1)
+                    end = pd.to_datetime(f"{year_of_season_end}-{end_month + 1}") - timedelta(days=1)
                 else:
                     end = pd.to_datetime(f"{year_of_season_end}-{end_month}-{end_day}")
             new_time_axis.append(start + (end - start) / 2)
@@ -316,7 +315,7 @@ def _get_frequency_from_string(slice_mode: str) -> Frequency:
     raise InvalidIcclimArgumentError(f"Unknown frequency {slice_mode}.")
 
 
-def _is_season_valid(months):
+def _is_season_valid(months: list[int]) -> bool:
     is_valid = True
     for i in range(0, len(months) - 1):
         is_valid = is_valid and months[i] > 0 and months[i] < 13

--- a/icclim/models/index_config.py
+++ b/icclim/models/index_config.py
@@ -117,7 +117,6 @@ class IndexConfig:
                 base_period_time_range=base_period_time_range,
                 only_leap_years=only_leap_years,
                 chunk_it=chunk_it,
-                pre_processing=self.freq.pre_processing,
             )
             for var_name in var_names
         ]
@@ -181,15 +180,12 @@ def _build_cf_variable(
     base_period_time_range: list[str] | None,
     only_leap_years: bool,
     chunk_it: bool,
-    pre_processing: Callable,
 ) -> CfVariable:
     if chunk_it:
         da = da.chunk("auto")  # noqa - typing fixed in futur xarray version
     study_da = _build_study_da(da, time_range, ignore_Feb29th)
-    study_da = pre_processing(study_da)
     if base_period_time_range is not None:
         reference_da = _build_reference_da(da, base_period_time_range, only_leap_years)
-        reference_da = pre_processing(reference_da)
     else:
         reference_da = study_da
     # TODO: all these operations should probably be added in history metadata

--- a/icclim/models/user_index_config.py
+++ b/icclim/models/user_index_config.py
@@ -133,7 +133,7 @@ class UserIndexConfig:
         var_type=None,
         is_percent=False,
         save_percentile=False,
-        ref_time_range: list[str] = None,
+        ref_time_range: list[str] = None,  # TODO: use dateparser to accept strings
     ) -> None:
         self.index_name = index_name
         self.calc_operation = calc_operation

--- a/icclim/models/user_index_config.py
+++ b/icclim/models/user_index_config.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Callable, Literal
 
+from xclim.core.calendar import select_time
 from xarray.core.dataarray import DataArray
 
 from icclim.icclim_exceptions import InvalidIcclimArgumentError
@@ -148,7 +149,10 @@ class UserIndexConfig:
         self.date_event = date_event
         self.var_type = var_type
         self.is_percent = is_percent
-        self.da_ref = cf_vars[0].reference_da
+        if freq.indexer is not None:
+            for cf_var in cf_vars:
+                cf_var.study_da = select_time(cf_var.study_da, **freq.indexer)
+                cf_var.reference_da = select_time(cf_var.reference_da, **freq.indexer)
         self.cf_vars = cf_vars
         if thresh is not None and logical_operation is not None:
             self.nb_event_config = get_nb_event_conf(

--- a/icclim/tests/test_frequency.py
+++ b/icclim/tests/test_frequency.py
@@ -3,7 +3,7 @@ import pandas as pd
 import pytest
 
 from icclim.icclim_exceptions import InvalidIcclimArgumentError
-from icclim.models.frequency import Frequency, filter_months, get_seasonal_time_updater
+from icclim.models.frequency import Frequency, get_seasonal_time_updater
 from icclim.tests.test_utils import stub_tas
 
 
@@ -31,21 +31,21 @@ class Test_build_frequency_over_list:
     def test_month(self):
         freq = Frequency.lookup(["month", [1, 4, 3]])
         assert freq == Frequency.CUSTOM
-        assert freq.panda_freq == "MS"
+        assert freq.pandas_freq == "MS"
         assert freq.accepted_values == []
         assert freq.post_processing is not None
 
     def test_season(self):
         freq = Frequency.lookup(["season", [1, 2, 3, 4]])
         assert freq == Frequency.CUSTOM
-        assert freq.panda_freq == "AS-JAN"
+        assert freq.pandas_freq == "AS-JAN"
         assert freq.accepted_values == []
         assert freq.post_processing is not None
 
     def test_winter__deprecated_tuple(self):
         freq = Frequency.lookup(["season", ([11, 12], [1, 2, 3, 4])])
         assert freq == Frequency.CUSTOM
-        assert freq.panda_freq == "AS-NOV"
+        assert freq.pandas_freq == "AS-NOV"
         assert freq.accepted_values == []
         assert freq.post_processing is not None
 
@@ -60,29 +60,16 @@ class Test_build_frequency_over_list:
     def test_winter(self):
         freq = Frequency.lookup(["season", [11, 12, 1, 2]])
         assert freq == Frequency.CUSTOM
-        assert freq.panda_freq == "AS-NOV"
+        assert freq.pandas_freq == "AS-NOV"
         assert freq.accepted_values == []
         assert freq.post_processing is not None
 
     def test_lookup_season_between_dates(self):
         freq = Frequency.lookup(["season",["07-19","08-14"]])
         assert freq == Frequency.CUSTOM
-        assert freq.panda_freq == "AS-JUL"
+        assert freq.pandas_freq == "AS-JUL"
         assert freq.accepted_values == []
         assert freq.post_processing is not None
-
-
-class Test_filter_months:
-    def test_simple(self):
-        # WHEN
-        da = filter_months(stub_tas(), [1, 2, 7])
-        # THEN
-        months = np.unique(da.time.dt.month)
-        assert len(months) == 3
-        assert months[0] == 1
-        assert months[1] == 2
-        assert months[2] == 7
-
 
 class Test_seasons_resampler:
     def test_simple(self):
@@ -125,3 +112,8 @@ class Test_seasons_resampler:
         np.testing.assert_array_equal(1, da_res) # data must be unchanged
         assert time_bds_res[0].data[0] == pd.to_datetime("2041-11-02")
         assert time_bds_res[0].data[1] == pd.to_datetime("2042-01-30")
+
+
+
+def filter_months(da, month_list: list[int]):
+    return da.sel(time=da.time.dt.month.isin(month_list))

--- a/icclim/tests/test_frequency.py
+++ b/icclim/tests/test_frequency.py
@@ -64,6 +64,13 @@ class Test_build_frequency_over_list:
         assert freq.accepted_values == []
         assert freq.post_processing is not None
 
+    def test_lookup_season_between_dates(self):
+        freq = Frequency.lookup(["season",["07-19","08-14"]])
+        assert freq == Frequency.CUSTOM
+        assert freq.panda_freq == "AS-JUL"
+        assert freq.accepted_values == []
+        assert freq.post_processing is not None
+
 
 class Test_filter_months:
     def test_simple(self):
@@ -106,3 +113,15 @@ class Test_seasons_resampler:
             time_bds_res[1].data[1]
             == pd.to_datetime("2043-02") - pd.tseries.offsets.Day()
         )
+
+    @pytest.mark.parametrize("use_cf", [True, False])
+    def test_between_dates(self, use_cf):
+        # WHEN
+        test_da = filter_months(stub_tas(use_cftime=use_cf), [11, 12, 1])\
+            .resample(time="AS-NOV")\
+            .mean()
+        da_res, time_bds_res = get_seasonal_time_updater(11, 1, 2, 30)(test_da)
+        # THEN
+        np.testing.assert_array_equal(1, da_res) # data must be unchanged
+        assert time_bds_res[0].data[0] == pd.to_datetime("2041-11-02")
+        assert time_bds_res[0].data[1] == pd.to_datetime("2042-01-30")

--- a/icclim/tests/test_generated_api.py
+++ b/icclim/tests/test_generated_api.py
@@ -95,11 +95,16 @@ def test_custom_index(index_fun_mock: MagicMock):
 
 # integration test
 def test_txx__season_slice_mode():
+    # GIVEN
     tas = stub_tas()
-    tas.loc[{"time": "2042-02-02"}] = 295
-    tas.loc[{"time": "2042-01-01"}] = 303.15  # 30ºC 273.15
+    tas.loc[{"time": "2043-02-02"}] = 295
+    tas.loc[{"time": "2043-01-01"}] = 303.15  # 30ºC 273.15
+    # WHEN
     res = icclim.txx(tas, slice_mode=["season", [11, 12, 1, 2]]).compute()
-    np.testing.assert_array_equal(res.TXx.isel(time=0), 30)
+    # THEN
+    # missing values for nov, dec of first period
+    np.testing.assert_array_equal(res.TXx.isel(time=0), np.NAN)
+    np.testing.assert_array_equal(res.TXx.isel(time=1), 30.)
     np.testing.assert_array_equal(
         res.time_bounds.isel(time=0),
         [np.datetime64("2041-11-01"), np.datetime64("2042-02-28")],
@@ -112,7 +117,8 @@ def test_txx__months_slice_mode():
     tas.loc[{"time": "2042-01-01"}] = 303.15  # 30ºC 273.15
     res = icclim.txx(tas, slice_mode=["months", [11, 1]]).compute()
     np.testing.assert_array_equal(res.TXx.isel(time=0), 30)
-    np.testing.assert_almost_equal(res.TXx.isel(time=1), 21.85)
+    np.testing.assert_array_equal(res.TXx.isel(time=1), np.NAN)
+    np.testing.assert_almost_equal(res.TXx.sel(time="2042-11"), 21.85)
     np.testing.assert_array_equal(
         res.time_bounds.isel(time=0),
         [np.datetime64("2042-01-01"), np.datetime64("2042-01-31")],

--- a/icclim/tests/test_generated_api.py
+++ b/icclim/tests/test_generated_api.py
@@ -121,7 +121,7 @@ def test_txx__months_slice_mode():
 
 # integration test
 @pytest.mark.parametrize(
-    "operator, exp_y1, exp_y2",
+    "operator, expectation_year_1, expectation_year_2",
     [
         (CalcOperation.MIN, 303.15, 280.15),
         (CalcOperation.MAX, 303.15, 280.15),
@@ -131,7 +131,7 @@ def test_txx__months_slice_mode():
         (CalcOperation.MAX_NUMBER_OF_CONSECUTIVE_EVENTS, 1, 1),
     ],
 )
-def test_custom_index__season_slice_mode(operator, exp_y1, exp_y2):
+def test_custom_index__season_slice_mode(operator, expectation_year_1, expectation_year_2):
     tas = stub_tas(2.0)
     tas.loc[{"time": "2042-01-01"}] = 303.15
     tas.loc[{"time": "2042-12-01"}] = 280.15
@@ -145,20 +145,20 @@ def test_custom_index__season_slice_mode(operator, exp_y1, exp_y2):
             "logical_operation": "gt",
             "thresh": 275,
         },
-    ).compute()
-    np.testing.assert_almost_equal(res.pouet.isel(time=0), exp_y1)
-    np.testing.assert_almost_equal(res.pouet.isel(time=1), exp_y2)
+    )
+    np.testing.assert_almost_equal(res.pouet.isel(time=0), expectation_year_1)
+    np.testing.assert_almost_equal(res.pouet.isel(time=1), expectation_year_2)
 
 
 # integration test
 @pytest.mark.parametrize(
-    "operator, exp_y1, exp_y2",
+    "operator, expectation_year_1, expectation_year_2",
     [
         (CalcOperation.RUN_MEAN, 2, 2),
         (CalcOperation.RUN_SUM, 14, 14),
     ],
 )
-def test_custom_index_run_algos__season_slice_mode(operator, exp_y1, exp_y2):
+def test_custom_index_run_algos__season_slice_mode(operator, expectation_year_1, expectation_year_2):
     tas = stub_tas(2.0)
     res = icclim.custom_index(
         in_files=tas,
@@ -170,9 +170,9 @@ def test_custom_index_run_algos__season_slice_mode(operator, exp_y1, exp_y2):
             "extreme_mode": "max",
             "window_width": 7,
         },
-    ).compute()
-    np.testing.assert_almost_equal(res.pouet.isel(time=0), exp_y1)
-    np.testing.assert_almost_equal(res.pouet.isel(time=1), exp_y2)
+    )
+    np.testing.assert_almost_equal(res.pouet.isel(time=0), expectation_year_1)
+    np.testing.assert_almost_equal(res.pouet.isel(time=1), expectation_year_2)
 
 
 def test_custom_index_anomaly__season_slice_mode():
@@ -187,5 +187,5 @@ def test_custom_index_anomaly__season_slice_mode():
             "calc_operation": CalcOperation.ANOMALY,
             "ref_time_range": [datetime(2042, 1, 1), datetime(2044, 12, 31)],
         },
-    ).compute()
+    )
     np.testing.assert_almost_equal(res.anomaly, 0.96129032)

--- a/icclim/tests/test_main.py
+++ b/icclim/tests/test_main.py
@@ -42,8 +42,8 @@ class Test_Integration:
     """
 
     OUTPUT_FILE = "out.nc"
-    CF_TIME_RANGE = pd.date_range(start="2042-01-01", end="2045-12-31", freq="D")
-    TIME_RANGE = xr.cftime_range("2042-01-01", end="2045-12-31", freq="D")
+    TIME_RANGE = pd.date_range(start="2042-01-01", end="2045-12-31", freq="D")
+    CF_TIME_RANGE = xr.cftime_range("2042-01-01", end="2045-12-31", freq="D")
     data = xr.DataArray(
         data=(np.full(len(TIME_RANGE), 20).reshape((len(TIME_RANGE), 1, 1))),
         dims=["time", "lat", "lon"],

--- a/icclim/tests/test_utils.py
+++ b/icclim/tests/test_utils.py
@@ -8,7 +8,9 @@ from icclim.models.frequency import Frequency
 from icclim.models.index_config import CfVariable
 from icclim.models.user_index_config import UserIndexConfig
 
-VALUE_COUNT = 365 * 5 + 1
+import xarray as xr
+
+VALUE_COUNT = 365 * 5 + 1 # 5 years of data (with 1 leap year)
 COORDS = dict(
     lat=[42],
     lon=[42],
@@ -16,6 +18,7 @@ COORDS = dict(
 )
 K2C = 273.15
 
+CF_TIME_RANGE = xr.cftime_range("2042-01-01", periods=VALUE_COUNT, freq="D")
 
 def stub_user_index(cf_vars: List[CfVariable]):
     return UserIndexConfig(
@@ -23,13 +26,15 @@ def stub_user_index(cf_vars: List[CfVariable]):
     )
 
 
-def stub_tas(tas_value: float = 1.0, use_dask=False):
+def stub_tas(tas_value: float = 1.0, use_dask=False, use_cftime=False):
     da = xarray.DataArray(
         data=(np.full(VALUE_COUNT, tas_value).reshape((VALUE_COUNT, 1, 1))),
         dims=["time", "lat", "lon"],
         coords=COORDS,
         attrs={"units": "K"},
     )
+    if use_cftime:
+        da["time"] = CF_TIME_RANGE
     if use_dask:
         da.chunk()
     return da

--- a/icclim/user_indices/calc_operation.py
+++ b/icclim/user_indices/calc_operation.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import Callable, Literal
 
+import xclim.core.calendar
 from xarray.core.dataarray import DataArray
 
 from icclim.icclim_exceptions import InvalidIcclimArgumentError, MissingIcclimInputError
@@ -54,7 +55,7 @@ def run_sum(config: UserIndexConfig):
         extreme_mode=config.extreme_mode,
         window_width=config.window_width,
         coef=config.coef,
-        freq=config.freq.panda_freq,
+        freq=config.freq.pandas_freq,
         date_event=config.date_event,
     )
 
@@ -69,7 +70,7 @@ def run_mean(config: UserIndexConfig):
         extreme_mode=config.extreme_mode,
         window_width=config.window_width,
         coef=config.coef,
-        freq=config.freq.panda_freq,
+        freq=config.freq.pandas_freq,
         date_event=config.date_event,
     )
 
@@ -90,7 +91,7 @@ def max_consecutive_event_count(config: UserIndexConfig):
         logical_operation=config.logical_operation,
         threshold=config.thresh,
         coef=config.coef,
-        freq=config.freq.panda_freq,
+        freq=config.freq.pandas_freq,
         date_event=config.date_event,
     )
 
@@ -108,7 +109,7 @@ def count_events(config: UserIndexConfig):
         link_logical_operations=config.nb_event_config.link_logical_operations,
         thresholds=config.nb_event_config.thresholds,
         coef=config.coef,
-        freq=config.freq.panda_freq,
+        freq=config.freq.pandas_freq,
         date_event=config.date_event,
     )
 
@@ -120,7 +121,7 @@ def sum(config: UserIndexConfig):
         coef=config.coef,
         logical_operation=config.logical_operation,
         threshold=_check_and_get_simple_threshold(config.thresh),
-        freq=config.freq.panda_freq,
+        freq=config.freq.pandas_freq,
     )
 
 
@@ -131,7 +132,7 @@ def mean(config: UserIndexConfig):
         coef=config.coef,
         logical_operation=config.logical_operation,
         threshold=_check_and_get_simple_threshold(config.thresh),
-        freq=config.freq.panda_freq,
+        freq=config.freq.pandas_freq,
     )
 
 
@@ -150,7 +151,7 @@ def _simple_reducer(op: Callable, config: UserIndexConfig):
         coef=config.coef,
         logical_operation=config.logical_operation,
         threshold=_check_and_get_simple_threshold(config.thresh),
-        freq=config.freq.panda_freq,
+        freq=config.freq.pandas_freq,
         date_event=config.date_event,
     )
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages, setup
 from icclim.models.constants import ICCLIM_VERSION
 
 MINIMAL_REQUIREMENTS = [
-    # todo: Unpin numpy 1.22 once numba works with it (numba comes with xclim)
+    # todo: Unpin numpy 1.22 once numba work with it (numba comes with xclim)
     #       https://github.com/numba/numba/issues/7754
     "numpy>=1.16,<1.22",
     "xarray>=0.17",
@@ -19,6 +19,7 @@ MINIMAL_REQUIREMENTS = [
     "zarr",
     "rechunker>=0.3, !=0.4",
     "fsspec",
+    "dateparser",
 ]
 
 setup(


### PR DESCRIPTION
<!--
The following checklist points should all be checked before merging the PR.

Please replace xxx by your issue number (leave the prefixing '#').
-->

### Pull Request to resolve #xxx
- [ ] Unit tests cover the changes.
- [ ] These changes were tested on real data.
- [ ] The relevant documentation has been added or updated.
- [ ] A short description of the changes has been added to `doc/source/references/release_notes.rst`.

### Describe the changes you made
Added the possibility to create a season between two dates using slice_mode.
```
slice_mode=["season", ["15 june", "25-08"] ]
```
Various date format are accepted thanks to dateparser library.
I think we should try to use it as well on `time_range` and `base_periode_time_range` parameters 

wip:
- wait for xclim PR to be merged
- List all indices where season cannot be computed on
- Forbid in icclim calling these indices with a season