### PR TITLE
Enh/percentile as input

### DIFF
--- a/doc/source/explanation/climate_indices.rst
+++ b/doc/source/explanation/climate_indices.rst
@@ -16,7 +16,7 @@ Climate indices allow a statistical study of variations of the dependent climato
     - `Climate Variability and Predictability (CLIVAR) <https://www.clivar.org/clivar-panels/etccdi/indices-data/indices-data>`_
     - `Expert Team on Climate Change Detection and Indices (ETCCDI) <https://etccdi.pacificclimate.org/>`_
     - `European Climate Assessment & Dataset (ECA&D) <https://www.ecad.eu>`_
-    - `ATBD ECA&D indices <https://www.ecad.eu/documents/atbd.pdf>`_
+    - `ATBD ECA&D indices <https://knmi-ecad-assets-prd.s3.amazonaws.com/documents/atbd.pdf>`_
     - `Article about percentile-based indices <http://etccdi.pacificclimate.org/docs/Zhangetal05JumpPaper.pdf>`_
     - `Sample quantiles in statistical packages <https://www.amherst.edu/media/view/129116/original/Sample+Quantiles.pdf>`_
 
@@ -35,7 +35,7 @@ air temperature and precipitation variables can be computed with icclim:
     - 6 temperature indices (TG, TN, TX, DTR, ETR, vDTR)
     - 4 compound indices (CD, CW, WD, WW)
 
-Detailed description of each indice is available at https://www.ecad.eu/documents/atbd.pdf.
+Detailed description of each indice is available at https://knmi-ecad-assets-prd.s3.amazonaws.com/documents/atbd.pdf.
 See table below for a short description of each indices.
 Most descriptions are extracted from clix-meta.
 Initially icclim was designed for online computing of climate indices through the `climate4impact portal <https://climate4impact.eu>`_.

--- a/doc/source/how_to/ocgis.rst
+++ b/doc/source/how_to/ocgis.rst
@@ -2,7 +2,7 @@
 
 icclim called from OpenClimateGIS - Examples
 ==============================================
-icclim indices (`ECA&D climate indices <https://www.ecad.eu/documents/atbd.pdf>`_) are implemented in the
+icclim indices (`ECA&D climate indices <https://knmi-ecad-assets-prd.s3.amazonaws.com/documents/atbd.pdf>`_) are implemented in the
 `OpenClimateGIS <https://github.com/NCPP/ocgis>`_ (Version 1.1.0) Python package.
 
 

--- a/doc/source/how_to/recipes_custom.rst
+++ b/doc/source/how_to/recipes_custom.rst
@@ -269,7 +269,7 @@ Number of days when tas < 25th pctl and precip. > 75th pctl
 
 .. note:: If 'calc_operation' is *'max_nb_consecutive_events'*, then max number of consecutive days for the same condition will be computed.
 
-4 compound indices defined in https://www.ecad.eu/documents/atbd.pdf (see the section 5.3.3 "Compound indices") are
+4 compound indices defined in https://knmi-ecad-assets-prd.s3.amazonaws.com/documents/atbd.pdf (see the section 5.3.3 "Compound indices") are
 based on daily precipitation (RR) and mean temperature (TG) variables:
 
     - CD (cold/dry days): (TG < 25th pctl) and (RR < 25th pctl)

--- a/doc/source/references/icclim_index_api.rst
+++ b/doc/source/references/icclim_index_api.rst
@@ -29,6 +29,7 @@ The ``in_files`` parameter can be
     - A *list of strings* to represent multiple netCDF files to combine
     - A *xarray.Dataset*
     - A *xarray.DataArray*
+    - A python dictionary (new in 5.3)
 
 +---------------------------------+----------------------------------------------------------+---------------------------------------------------------------------------------------------------------+
 |                                 | single input file per variable                           |  several input files per variable                                                                       |
@@ -41,6 +42,28 @@ The ``in_files`` parameter can be
 | (based on several variables)    +----------------------------------------------------------+---------------------------------------------------------------------------------------------------------+
 |                                 |  ``in_files`` = ['tas_1990-2010.nc', 'pr_1990-2010.nc']  |  ``in_files`` = ['tas_1990-2000.nc', 'tas_2000-2010.nc', 'pr_1990-2000.nc', 'pr_2000-2010.nc']          |
 +---------------------------------+----------------------------------------------------------+---------------------------------------------------------------------------------------------------------+
+
+New in 5.3
+++++++++++
+
+Starting with icclim 5.3, ``in_files`` can describe variable names, formerly set in ``var_name``, as dictionary format.
+The dictionary keys are variable names and values are the usual in_files types (netCDF, zarr, Dataset, DataArray).
+
+>>> in_files = {"tasmax" : "tasmax.nc", "pr": "precip.zarr"}
+
+Moreover, this new dictionary syntax can be used to specify a different set of files for percentiles.
+
+>>> in_files = {"tasmax" : "tasmax.nc", "thresholds": "tasmax-90p.zarr"}
+
+The ``thresholds`` input should contain percentile thresholds that will be used will be used in place of computing them.
+It allow to reuse percentiles computed and stored elsewhere easily.
+For the record, you can generate percentiles with ``save_percentile`` parameter of icclim.index.
+
+.. notes::
+        Be aware that percentiles will **not** be bootstrapped. Thus, the result could be biased if the period on which percentiles
+        were computed partially overlap the index studied period.
+        See `<Computing percentile thresholds>`_ for more information on this topic.
+
 
 .. _slice_mode:
 

--- a/doc/source/references/icclim_index_api.rst
+++ b/doc/source/references/icclim_index_api.rst
@@ -117,18 +117,19 @@ Additionally, you can define a season between two exact dates:
 
 ``threshold``
 ~~~~~~~~~~~~~
-It is possible to set a user define threshold for indices
-- SU (default threshold: 25ºC)
-- CSU (default threshold: 25ºC)
-- TR (default threshold: 20ºC)
-- CSDI (default 10th percentile)
-- WSDI (default 90th percentile)
-- TX90p (default 90th percentile)
-- TG90p (default 90th percentile)
-- TN90p (default 90th percentile)
-- TX10p (default 10th percentile)
-- TG10p (default 10th percentile)
-- TN10p (default 10th percentile)
+It is possible to set a user define threshold for the following indices:
+
+* SU (default threshold: 25ºC)
+* CSU (default threshold: 25ºC)
+* TR (default threshold: 20ºC)
+* CSDI (default 10th percentile)
+* WSDI (default 90th percentile)
+* TX90p (default 90th percentile)
+* TG90p (default 90th percentile)
+* TN90p (default 90th percentile)
+* TX10p (default 10th percentile)
+* TG10p (default 10th percentile)
+* TN10p (default 10th percentile)
 
 
 The threshold could be one value:
@@ -139,18 +140,18 @@ or a list of values:
 
 >>> threshold = [20,25,30]
 
-  .. note:: thresholds should be a float, the unit is expected to be in degrees Celsius or a unit-less for percentiles.
+.. note:: thresholds should be a float, the unit is expected to be in degrees Celsius or a unit-less for percentiles.
 
 ``transfer_limit_Mbytes``
 ~~~~~~~~~~~~~~~~~~~~~~~~~
-/!\ Deprecated
+!Deprecated
 
 ``transfer_limit_Mbytes`` is now ignored and will be deleted in a futur version.
 See :ref:`how to chunk data and parallelize computation <dask>` to configure dask chunking.
 
 ``callback``
-~~~~~~~~~~~~~
-/!\ Deprecated
+~~~~~~~~~~~~
+!Deprecated
 
 Callback can used to output a estimated progress of the calculus.
 However, when using dask, the calculus are done lazily at the very end of icclim's process.

--- a/doc/source/references/output_metadata.rst
+++ b/doc/source/references/output_metadata.rst
@@ -171,7 +171,7 @@ Example:
         :title = "ECA cold index FD" ;
         :institution = "Climate impact portal (https://climate4impact.eu)" ;
         :source =  ;
-        :references = "ATBD of the ECA indices calculation (https://www.ecad.eu/documents/atbd.pdf)" ;
+        :references = "ATBD of the ECA indices calculation (https://knmi-ecad-assets-prd.s3.amazonaws.com/documents/atbd.pdf)" ;
         :comment = " " ;
         :history = "2011-04-07T06:39:36Z CMOR rewrote data to comply with CF standards and CMIP5 requirements. \n",
                         "2014-04-01 12:16:03 Calculation of FD index (monthly time series) from 1950-1-1 to 1955-12-31." ;

--- a/doc/source/references/release_notes.rst
+++ b/doc/source/references/release_notes.rst
@@ -4,31 +4,35 @@ Release history
 5.3.0
 -----
 * [enh] Add icclim version to history in outputted metadata.
-* [maint] **breaking change** Pin minimal pandas version to 1.3 to fix: https://github.com/pandas-dev/pandas/issues/24539
-* [enh] `slice_mode`: seasons can now be defined to be between two exact dates.
-* [enh] `slice_mode`: a tuple[str, list] can now be used as long as the usual list in input of seasons.
-* [enh] `slice_mode`: Added `clipped_season` keyword which ignores event starting before the season bounds (original behavior of ``season``).
-* [maint] `slice_mode`: Modified `season` keyword to take into account events (such as in CDD) starting before the season bounds.
-   This should improve the scientific validity of these seasonal computations. Plus it is in accordance to xclim way of doing this.
+* [maint] **breaking change** Pin minimal pandas version to 1.3 to have the fix for https://github.com/pandas-dev/pandas/issues/24539
+* [enh] ``slice_mode``: seasons can now be defined to be between two exact dates.
+* [enh] ``slice_mode`` type can now be tuple[str, list], it works similarly to the list in input of seasons but, it enforces a length of 2.
+* [enh] ``slice_mode``: Added `clipped_season` keyword which ignores events starting before the season bounds (original behavior of ``season``).
+* [maint] ``slice_mode``: Modified `season` keyword to take into account events (such as in CDD) starting before the season bounds.
+This should improve the scientific validity of these seasonal computations. Plus it is in accordance to xclim way of doing this.
 * [maint] Added dataclass ClimateIndex to ease the introduction of new indices not in the ECAD standard.
 * [maint] Made use the new typing syntax thanks to ``from __future__ import annotations``.
 * [maint] Add docstring validation into flake8 checks.
 * [enh] Improve API for date related parameters ``{time_range, base_period_time_range, ref_time_range}``
-  They can still be filled with a datetime object but additionally various string format are now available.
-  This comes with dateparser library.
-* [doc] Update callback doc as it is very inaccurate when using dask.
-* [enh] T(X/N/G)(10/90)p indices' threshold is now configurable with `threshold` parameter.
-  Example of use: `icclim.tx90p(in_files=data, threshold=[42, 99])`
+They can still be filled with a datetime object but additionally various string format are now available.
+This comes with dateparser library.
+* [doc] Update callback doc as its outputted value is very inaccurate when dask is enable.
+* [enh] T(X/N/G)(10/90)p indices threshold is now configurable with `threshold` parameter.
+Example of use: `icclim.tx90p(in_files=data, threshold=[42, 99])`
 * [enh|maint] threshold, history and source metadata have been updated to better describe what happens during icclim process.
 * [fix/doc] The documentation of the generated API for T(X/N/G)(10/90)p indices now properly use thier ECAD definitions instead of those from ETCCDI.
-* [enh/doc] Add [WSDI, CSDI, rxxp, rxxpTOT, CW, CD, WW, WD] indices in yaml definition. We no longer strictly follow the yaml given by clix-meta.
+* [enh/doc] Add [WSDI, CSDI, rxxp, rxxpTOT, CW, CD, WW, WD] indices in yaml definition.
+Note: We no longer strictly follow the yaml given by clix-meta.
 * [fix] custom seasonal slice_mode was broken when it ended in december. It's now fixed and unit tested.
+* [enh] Make ``in_file`` accept a dictionary merging together ``var_name`` and ``in_file`` features.
+* [enh] ``in_file`` dictionary can now be used to pass percentiles thresholds. These thresholds will be used instead of computing them on relevant indices.
+* [maint/internal] Refactored IndexConfig and moved all the logic to input_parsing.
 
 5.2.1
 -----
 * [maint] Made Frequency part of SliceMode union.
 * [fix] slice_mode seasonal samplings was giving wrong results for quite a few indices. This has been fixed and the performances should also be improved by the fix.
-  However, now seasonal slice_mode does not allow to use xclim missing values mechanisms.
+        However, now seasonal slice_mode does not allow to use xclim missing values mechanisms.
 * [fix] user_index ExtremeMode config was not properly parsed when a string was used.
 * [fix] user_index Anomaly operator was not properly using the `ref_time_range` to setup a reference period as it should.
 * [fix] user_index Sum and Mean operators were broken due to a previous refactoring and a lack of unit tests, it is now fixed and tested.
@@ -121,8 +125,8 @@ For spatial stats, Xarray provides a `DataArrayWeighted <https://xarray.pydata.o
     improvements of version 5.0.0.
 
 
-Release candidates (rc1, rc2, rc3) change logs
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Release candidates for 5.0 change logs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * [fix] Make HD17 expect tas instead of tas_min.
 * [fix] Fix performance issue with indices computed on consecutive days such as CDD.
 * [maint] Add Github action CI to run unit tests.

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
 # Core dependencies
  - python>=3.8
- - xclim>=0.34
+ - xclim>=0.37
  - numpy==1.21.5
  - xarray>=0.19
  - dask[array]

--- a/icclim/_generated_api.py
+++ b/icclim/_generated_api.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import datetime
 
-from xarray.core.dataarray import DataArray
 from xarray.core.dataset import Dataset
 
 import icclim
@@ -16,6 +15,7 @@ from icclim.models.frequency import Frequency, SliceMode
 from icclim.models.netcdf_version import NetcdfVersion
 from icclim.models.quantile_interpolation import QuantileInterpolation
 from icclim.models.user_index_dict import UserIndexDict
+from icclim.pre_processing.input_parsing import InFileType
 
 __all__ = [
     "tg",
@@ -72,7 +72,7 @@ __all__ = [
 
 
 def tg(
-    in_files: str | list[str] | Dataset | DataArray,
+    in_files: InFileType,
     var_name: str | list[str] | None = None,
     slice_mode: SliceMode = Frequency.YEAR,
     time_range: list[datetime] | list[str] | tuple[str, str] | None = None,
@@ -88,7 +88,7 @@ def tg(
 
     Parameters
     ----------
-    in_files : str | list[str] | Dataset | DataArray,
+    in_files : str | list[str] | Dataset | DataArray | InputDictionary,
         Absolute path(s) to NetCDF dataset(s), including OPeNDAP URLs,
         or path to zarr store, or xarray.Dataset or xarray.DataArray.
     var_name : str | list[str] | None
@@ -144,7 +144,7 @@ def tg(
 
 
 def tn(
-    in_files: str | list[str] | Dataset | DataArray,
+    in_files: InFileType,
     var_name: str | list[str] | None = None,
     slice_mode: SliceMode = Frequency.YEAR,
     time_range: list[datetime] | list[str] | tuple[str, str] | None = None,
@@ -160,7 +160,7 @@ def tn(
 
     Parameters
     ----------
-    in_files : str | list[str] | Dataset | DataArray,
+    in_files : str | list[str] | Dataset | DataArray | InputDictionary,
         Absolute path(s) to NetCDF dataset(s), including OPeNDAP URLs,
         or path to zarr store, or xarray.Dataset or xarray.DataArray.
     var_name : str | list[str] | None
@@ -216,7 +216,7 @@ def tn(
 
 
 def tx(
-    in_files: str | list[str] | Dataset | DataArray,
+    in_files: InFileType,
     var_name: str | list[str] | None = None,
     slice_mode: SliceMode = Frequency.YEAR,
     time_range: list[datetime] | list[str] | tuple[str, str] | None = None,
@@ -232,7 +232,7 @@ def tx(
 
     Parameters
     ----------
-    in_files : str | list[str] | Dataset | DataArray,
+    in_files : str | list[str] | Dataset | DataArray | InputDictionary,
         Absolute path(s) to NetCDF dataset(s), including OPeNDAP URLs,
         or path to zarr store, or xarray.Dataset or xarray.DataArray.
     var_name : str | list[str] | None
@@ -288,7 +288,7 @@ def tx(
 
 
 def dtr(
-    in_files: str | list[str] | Dataset | DataArray,
+    in_files: InFileType,
     var_name: str | list[str] | None = None,
     slice_mode: SliceMode = Frequency.YEAR,
     time_range: list[datetime] | list[str] | tuple[str, str] | None = None,
@@ -304,7 +304,7 @@ def dtr(
 
     Parameters
     ----------
-    in_files : str | list[str] | Dataset | DataArray,
+    in_files : str | list[str] | Dataset | DataArray | InputDictionary,
         Absolute path(s) to NetCDF dataset(s), including OPeNDAP URLs,
         or path to zarr store, or xarray.Dataset or xarray.DataArray.
     var_name : str | list[str] | None
@@ -360,7 +360,7 @@ def dtr(
 
 
 def etr(
-    in_files: str | list[str] | Dataset | DataArray,
+    in_files: InFileType,
     var_name: str | list[str] | None = None,
     slice_mode: SliceMode = Frequency.YEAR,
     time_range: list[datetime] | list[str] | tuple[str, str] | None = None,
@@ -376,7 +376,7 @@ def etr(
 
     Parameters
     ----------
-    in_files : str | list[str] | Dataset | DataArray,
+    in_files : str | list[str] | Dataset | DataArray | InputDictionary,
         Absolute path(s) to NetCDF dataset(s), including OPeNDAP URLs,
         or path to zarr store, or xarray.Dataset or xarray.DataArray.
     var_name : str | list[str] | None
@@ -432,7 +432,7 @@ def etr(
 
 
 def vdtr(
-    in_files: str | list[str] | Dataset | DataArray,
+    in_files: InFileType,
     var_name: str | list[str] | None = None,
     slice_mode: SliceMode = Frequency.YEAR,
     time_range: list[datetime] | list[str] | tuple[str, str] | None = None,
@@ -448,7 +448,7 @@ def vdtr(
 
     Parameters
     ----------
-    in_files : str | list[str] | Dataset | DataArray,
+    in_files : str | list[str] | Dataset | DataArray | InputDictionary,
         Absolute path(s) to NetCDF dataset(s), including OPeNDAP URLs,
         or path to zarr store, or xarray.Dataset or xarray.DataArray.
     var_name : str | list[str] | None
@@ -504,7 +504,7 @@ def vdtr(
 
 
 def su(
-    in_files: str | list[str] | Dataset | DataArray,
+    in_files: InFileType,
     var_name: str | list[str] | None = None,
     slice_mode: SliceMode = Frequency.YEAR,
     time_range: list[datetime] | list[str] | tuple[str, str] | None = None,
@@ -521,7 +521,7 @@ def su(
 
     Parameters
     ----------
-    in_files : str | list[str] | Dataset | DataArray,
+    in_files : str | list[str] | Dataset | DataArray | InputDictionary,
         Absolute path(s) to NetCDF dataset(s), including OPeNDAP URLs,
         or path to zarr store, or xarray.Dataset or xarray.DataArray.
     var_name : str | list[str] | None
@@ -583,7 +583,7 @@ def su(
 
 
 def tr(
-    in_files: str | list[str] | Dataset | DataArray,
+    in_files: InFileType,
     var_name: str | list[str] | None = None,
     slice_mode: SliceMode = Frequency.YEAR,
     time_range: list[datetime] | list[str] | tuple[str, str] | None = None,
@@ -600,7 +600,7 @@ def tr(
 
     Parameters
     ----------
-    in_files : str | list[str] | Dataset | DataArray,
+    in_files : str | list[str] | Dataset | DataArray | InputDictionary,
         Absolute path(s) to NetCDF dataset(s), including OPeNDAP URLs,
         or path to zarr store, or xarray.Dataset or xarray.DataArray.
     var_name : str | list[str] | None
@@ -662,7 +662,7 @@ def tr(
 
 
 def wsdi(
-    in_files: str | list[str] | Dataset | DataArray,
+    in_files: InFileType,
     var_name: str | list[str] | None = None,
     slice_mode: SliceMode = Frequency.YEAR,
     time_range: list[datetime] | list[str] | tuple[str, str] | None = None,
@@ -686,7 +686,7 @@ def wsdi(
 
     Parameters
     ----------
-    in_files : str | list[str] | Dataset | DataArray,
+    in_files : str | list[str] | Dataset | DataArray | InputDictionary,
         Absolute path(s) to NetCDF dataset(s), including OPeNDAP URLs,
         or path to zarr store, or xarray.Dataset or xarray.DataArray.
     var_name : str | list[str] | None
@@ -779,7 +779,7 @@ def wsdi(
 
 
 def tg90p(
-    in_files: str | list[str] | Dataset | DataArray,
+    in_files: InFileType,
     var_name: str | list[str] | None = None,
     slice_mode: SliceMode = Frequency.YEAR,
     time_range: list[datetime] | list[str] | tuple[str, str] | None = None,
@@ -804,7 +804,7 @@ def tg90p(
 
     Parameters
     ----------
-    in_files : str | list[str] | Dataset | DataArray,
+    in_files : str | list[str] | Dataset | DataArray | InputDictionary,
         Absolute path(s) to NetCDF dataset(s), including OPeNDAP URLs,
         or path to zarr store, or xarray.Dataset or xarray.DataArray.
     var_name : str | list[str] | None
@@ -900,7 +900,7 @@ def tg90p(
 
 
 def tn90p(
-    in_files: str | list[str] | Dataset | DataArray,
+    in_files: InFileType,
     var_name: str | list[str] | None = None,
     slice_mode: SliceMode = Frequency.YEAR,
     time_range: list[datetime] | list[str] | tuple[str, str] | None = None,
@@ -925,7 +925,7 @@ def tn90p(
 
     Parameters
     ----------
-    in_files : str | list[str] | Dataset | DataArray,
+    in_files : str | list[str] | Dataset | DataArray | InputDictionary,
         Absolute path(s) to NetCDF dataset(s), including OPeNDAP URLs,
         or path to zarr store, or xarray.Dataset or xarray.DataArray.
     var_name : str | list[str] | None
@@ -1021,7 +1021,7 @@ def tn90p(
 
 
 def tx90p(
-    in_files: str | list[str] | Dataset | DataArray,
+    in_files: InFileType,
     var_name: str | list[str] | None = None,
     slice_mode: SliceMode = Frequency.YEAR,
     time_range: list[datetime] | list[str] | tuple[str, str] | None = None,
@@ -1046,7 +1046,7 @@ def tx90p(
 
     Parameters
     ----------
-    in_files : str | list[str] | Dataset | DataArray,
+    in_files : str | list[str] | Dataset | DataArray | InputDictionary,
         Absolute path(s) to NetCDF dataset(s), including OPeNDAP URLs,
         or path to zarr store, or xarray.Dataset or xarray.DataArray.
     var_name : str | list[str] | None
@@ -1142,7 +1142,7 @@ def tx90p(
 
 
 def txx(
-    in_files: str | list[str] | Dataset | DataArray,
+    in_files: InFileType,
     var_name: str | list[str] | None = None,
     slice_mode: SliceMode = Frequency.YEAR,
     time_range: list[datetime] | list[str] | tuple[str, str] | None = None,
@@ -1158,7 +1158,7 @@ def txx(
 
     Parameters
     ----------
-    in_files : str | list[str] | Dataset | DataArray,
+    in_files : str | list[str] | Dataset | DataArray | InputDictionary,
         Absolute path(s) to NetCDF dataset(s), including OPeNDAP URLs,
         or path to zarr store, or xarray.Dataset or xarray.DataArray.
     var_name : str | list[str] | None
@@ -1214,7 +1214,7 @@ def txx(
 
 
 def tnx(
-    in_files: str | list[str] | Dataset | DataArray,
+    in_files: InFileType,
     var_name: str | list[str] | None = None,
     slice_mode: SliceMode = Frequency.YEAR,
     time_range: list[datetime] | list[str] | tuple[str, str] | None = None,
@@ -1230,7 +1230,7 @@ def tnx(
 
     Parameters
     ----------
-    in_files : str | list[str] | Dataset | DataArray,
+    in_files : str | list[str] | Dataset | DataArray | InputDictionary,
         Absolute path(s) to NetCDF dataset(s), including OPeNDAP URLs,
         or path to zarr store, or xarray.Dataset or xarray.DataArray.
     var_name : str | list[str] | None
@@ -1286,7 +1286,7 @@ def tnx(
 
 
 def csu(
-    in_files: str | list[str] | Dataset | DataArray,
+    in_files: InFileType,
     var_name: str | list[str] | None = None,
     slice_mode: SliceMode = Frequency.YEAR,
     time_range: list[datetime] | list[str] | tuple[str, str] | None = None,
@@ -1303,7 +1303,7 @@ def csu(
 
     Parameters
     ----------
-    in_files : str | list[str] | Dataset | DataArray,
+    in_files : str | list[str] | Dataset | DataArray | InputDictionary,
         Absolute path(s) to NetCDF dataset(s), including OPeNDAP URLs,
         or path to zarr store, or xarray.Dataset or xarray.DataArray.
     var_name : str | list[str] | None
@@ -1365,7 +1365,7 @@ def csu(
 
 
 def gd4(
-    in_files: str | list[str] | Dataset | DataArray,
+    in_files: InFileType,
     var_name: str | list[str] | None = None,
     slice_mode: SliceMode = Frequency.YEAR,
     time_range: list[datetime] | list[str] | tuple[str, str] | None = None,
@@ -1382,7 +1382,7 @@ def gd4(
 
     Parameters
     ----------
-    in_files : str | list[str] | Dataset | DataArray,
+    in_files : str | list[str] | Dataset | DataArray | InputDictionary,
         Absolute path(s) to NetCDF dataset(s), including OPeNDAP URLs,
         or path to zarr store, or xarray.Dataset or xarray.DataArray.
     var_name : str | list[str] | None
@@ -1444,7 +1444,7 @@ def gd4(
 
 
 def fd(
-    in_files: str | list[str] | Dataset | DataArray,
+    in_files: InFileType,
     var_name: str | list[str] | None = None,
     slice_mode: SliceMode = Frequency.YEAR,
     time_range: list[datetime] | list[str] | tuple[str, str] | None = None,
@@ -1461,7 +1461,7 @@ def fd(
 
     Parameters
     ----------
-    in_files : str | list[str] | Dataset | DataArray,
+    in_files : str | list[str] | Dataset | DataArray | InputDictionary,
         Absolute path(s) to NetCDF dataset(s), including OPeNDAP URLs,
         or path to zarr store, or xarray.Dataset or xarray.DataArray.
     var_name : str | list[str] | None
@@ -1523,7 +1523,7 @@ def fd(
 
 
 def cfd(
-    in_files: str | list[str] | Dataset | DataArray,
+    in_files: InFileType,
     var_name: str | list[str] | None = None,
     slice_mode: SliceMode = Frequency.YEAR,
     time_range: list[datetime] | list[str] | tuple[str, str] | None = None,
@@ -1540,7 +1540,7 @@ def cfd(
 
     Parameters
     ----------
-    in_files : str | list[str] | Dataset | DataArray,
+    in_files : str | list[str] | Dataset | DataArray | InputDictionary,
         Absolute path(s) to NetCDF dataset(s), including OPeNDAP URLs,
         or path to zarr store, or xarray.Dataset or xarray.DataArray.
     var_name : str | list[str] | None
@@ -1602,7 +1602,7 @@ def cfd(
 
 
 def hd17(
-    in_files: str | list[str] | Dataset | DataArray,
+    in_files: InFileType,
     var_name: str | list[str] | None = None,
     slice_mode: SliceMode = Frequency.YEAR,
     time_range: list[datetime] | list[str] | tuple[str, str] | None = None,
@@ -1619,7 +1619,7 @@ def hd17(
 
     Parameters
     ----------
-    in_files : str | list[str] | Dataset | DataArray,
+    in_files : str | list[str] | Dataset | DataArray | InputDictionary,
         Absolute path(s) to NetCDF dataset(s), including OPeNDAP URLs,
         or path to zarr store, or xarray.Dataset or xarray.DataArray.
     var_name : str | list[str] | None
@@ -1681,7 +1681,7 @@ def hd17(
 
 
 def id(
-    in_files: str | list[str] | Dataset | DataArray,
+    in_files: InFileType,
     var_name: str | list[str] | None = None,
     slice_mode: SliceMode = Frequency.YEAR,
     time_range: list[datetime] | list[str] | tuple[str, str] | None = None,
@@ -1698,7 +1698,7 @@ def id(
 
     Parameters
     ----------
-    in_files : str | list[str] | Dataset | DataArray,
+    in_files : str | list[str] | Dataset | DataArray | InputDictionary,
         Absolute path(s) to NetCDF dataset(s), including OPeNDAP URLs,
         or path to zarr store, or xarray.Dataset or xarray.DataArray.
     var_name : str | list[str] | None
@@ -1760,7 +1760,7 @@ def id(
 
 
 def tg10p(
-    in_files: str | list[str] | Dataset | DataArray,
+    in_files: InFileType,
     var_name: str | list[str] | None = None,
     slice_mode: SliceMode = Frequency.YEAR,
     time_range: list[datetime] | list[str] | tuple[str, str] | None = None,
@@ -1785,7 +1785,7 @@ def tg10p(
 
     Parameters
     ----------
-    in_files : str | list[str] | Dataset | DataArray,
+    in_files : str | list[str] | Dataset | DataArray | InputDictionary,
         Absolute path(s) to NetCDF dataset(s), including OPeNDAP URLs,
         or path to zarr store, or xarray.Dataset or xarray.DataArray.
     var_name : str | list[str] | None
@@ -1881,7 +1881,7 @@ def tg10p(
 
 
 def tn10p(
-    in_files: str | list[str] | Dataset | DataArray,
+    in_files: InFileType,
     var_name: str | list[str] | None = None,
     slice_mode: SliceMode = Frequency.YEAR,
     time_range: list[datetime] | list[str] | tuple[str, str] | None = None,
@@ -1906,7 +1906,7 @@ def tn10p(
 
     Parameters
     ----------
-    in_files : str | list[str] | Dataset | DataArray,
+    in_files : str | list[str] | Dataset | DataArray | InputDictionary,
         Absolute path(s) to NetCDF dataset(s), including OPeNDAP URLs,
         or path to zarr store, or xarray.Dataset or xarray.DataArray.
     var_name : str | list[str] | None
@@ -2002,7 +2002,7 @@ def tn10p(
 
 
 def tx10p(
-    in_files: str | list[str] | Dataset | DataArray,
+    in_files: InFileType,
     var_name: str | list[str] | None = None,
     slice_mode: SliceMode = Frequency.YEAR,
     time_range: list[datetime] | list[str] | tuple[str, str] | None = None,
@@ -2027,7 +2027,7 @@ def tx10p(
 
     Parameters
     ----------
-    in_files : str | list[str] | Dataset | DataArray,
+    in_files : str | list[str] | Dataset | DataArray | InputDictionary,
         Absolute path(s) to NetCDF dataset(s), including OPeNDAP URLs,
         or path to zarr store, or xarray.Dataset or xarray.DataArray.
     var_name : str | list[str] | None
@@ -2123,7 +2123,7 @@ def tx10p(
 
 
 def txn(
-    in_files: str | list[str] | Dataset | DataArray,
+    in_files: InFileType,
     var_name: str | list[str] | None = None,
     slice_mode: SliceMode = Frequency.YEAR,
     time_range: list[datetime] | list[str] | tuple[str, str] | None = None,
@@ -2139,7 +2139,7 @@ def txn(
 
     Parameters
     ----------
-    in_files : str | list[str] | Dataset | DataArray,
+    in_files : str | list[str] | Dataset | DataArray | InputDictionary,
         Absolute path(s) to NetCDF dataset(s), including OPeNDAP URLs,
         or path to zarr store, or xarray.Dataset or xarray.DataArray.
     var_name : str | list[str] | None
@@ -2195,7 +2195,7 @@ def txn(
 
 
 def tnn(
-    in_files: str | list[str] | Dataset | DataArray,
+    in_files: InFileType,
     var_name: str | list[str] | None = None,
     slice_mode: SliceMode = Frequency.YEAR,
     time_range: list[datetime] | list[str] | tuple[str, str] | None = None,
@@ -2211,7 +2211,7 @@ def tnn(
 
     Parameters
     ----------
-    in_files : str | list[str] | Dataset | DataArray,
+    in_files : str | list[str] | Dataset | DataArray | InputDictionary,
         Absolute path(s) to NetCDF dataset(s), including OPeNDAP URLs,
         or path to zarr store, or xarray.Dataset or xarray.DataArray.
     var_name : str | list[str] | None
@@ -2267,7 +2267,7 @@ def tnn(
 
 
 def csdi(
-    in_files: str | list[str] | Dataset | DataArray,
+    in_files: InFileType,
     var_name: str | list[str] | None = None,
     slice_mode: SliceMode = Frequency.YEAR,
     time_range: list[datetime] | list[str] | tuple[str, str] | None = None,
@@ -2291,7 +2291,7 @@ def csdi(
 
     Parameters
     ----------
-    in_files : str | list[str] | Dataset | DataArray,
+    in_files : str | list[str] | Dataset | DataArray | InputDictionary,
         Absolute path(s) to NetCDF dataset(s), including OPeNDAP URLs,
         or path to zarr store, or xarray.Dataset or xarray.DataArray.
     var_name : str | list[str] | None
@@ -2384,7 +2384,7 @@ def csdi(
 
 
 def cdd(
-    in_files: str | list[str] | Dataset | DataArray,
+    in_files: InFileType,
     var_name: str | list[str] | None = None,
     slice_mode: SliceMode = Frequency.YEAR,
     time_range: list[datetime] | list[str] | tuple[str, str] | None = None,
@@ -2400,7 +2400,7 @@ def cdd(
 
     Parameters
     ----------
-    in_files : str | list[str] | Dataset | DataArray,
+    in_files : str | list[str] | Dataset | DataArray | InputDictionary,
         Absolute path(s) to NetCDF dataset(s), including OPeNDAP URLs,
         or path to zarr store, or xarray.Dataset or xarray.DataArray.
     var_name : str | list[str] | None
@@ -2456,7 +2456,7 @@ def cdd(
 
 
 def prcptot(
-    in_files: str | list[str] | Dataset | DataArray,
+    in_files: InFileType,
     var_name: str | list[str] | None = None,
     slice_mode: SliceMode = Frequency.YEAR,
     time_range: list[datetime] | list[str] | tuple[str, str] | None = None,
@@ -2472,7 +2472,7 @@ def prcptot(
 
     Parameters
     ----------
-    in_files : str | list[str] | Dataset | DataArray,
+    in_files : str | list[str] | Dataset | DataArray | InputDictionary,
         Absolute path(s) to NetCDF dataset(s), including OPeNDAP URLs,
         or path to zarr store, or xarray.Dataset or xarray.DataArray.
     var_name : str | list[str] | None
@@ -2528,7 +2528,7 @@ def prcptot(
 
 
 def rr1(
-    in_files: str | list[str] | Dataset | DataArray,
+    in_files: InFileType,
     var_name: str | list[str] | None = None,
     slice_mode: SliceMode = Frequency.YEAR,
     time_range: list[datetime] | list[str] | tuple[str, str] | None = None,
@@ -2544,7 +2544,7 @@ def rr1(
 
     Parameters
     ----------
-    in_files : str | list[str] | Dataset | DataArray,
+    in_files : str | list[str] | Dataset | DataArray | InputDictionary,
         Absolute path(s) to NetCDF dataset(s), including OPeNDAP URLs,
         or path to zarr store, or xarray.Dataset or xarray.DataArray.
     var_name : str | list[str] | None
@@ -2600,7 +2600,7 @@ def rr1(
 
 
 def sdii(
-    in_files: str | list[str] | Dataset | DataArray,
+    in_files: InFileType,
     var_name: str | list[str] | None = None,
     slice_mode: SliceMode = Frequency.YEAR,
     time_range: list[datetime] | list[str] | tuple[str, str] | None = None,
@@ -2616,7 +2616,7 @@ def sdii(
 
     Parameters
     ----------
-    in_files : str | list[str] | Dataset | DataArray,
+    in_files : str | list[str] | Dataset | DataArray | InputDictionary,
         Absolute path(s) to NetCDF dataset(s), including OPeNDAP URLs,
         or path to zarr store, or xarray.Dataset or xarray.DataArray.
     var_name : str | list[str] | None
@@ -2672,7 +2672,7 @@ def sdii(
 
 
 def cwd(
-    in_files: str | list[str] | Dataset | DataArray,
+    in_files: InFileType,
     var_name: str | list[str] | None = None,
     slice_mode: SliceMode = Frequency.YEAR,
     time_range: list[datetime] | list[str] | tuple[str, str] | None = None,
@@ -2688,7 +2688,7 @@ def cwd(
 
     Parameters
     ----------
-    in_files : str | list[str] | Dataset | DataArray,
+    in_files : str | list[str] | Dataset | DataArray | InputDictionary,
         Absolute path(s) to NetCDF dataset(s), including OPeNDAP URLs,
         or path to zarr store, or xarray.Dataset or xarray.DataArray.
     var_name : str | list[str] | None
@@ -2744,7 +2744,7 @@ def cwd(
 
 
 def r10mm(
-    in_files: str | list[str] | Dataset | DataArray,
+    in_files: InFileType,
     var_name: str | list[str] | None = None,
     slice_mode: SliceMode = Frequency.YEAR,
     time_range: list[datetime] | list[str] | tuple[str, str] | None = None,
@@ -2760,7 +2760,7 @@ def r10mm(
 
     Parameters
     ----------
-    in_files : str | list[str] | Dataset | DataArray,
+    in_files : str | list[str] | Dataset | DataArray | InputDictionary,
         Absolute path(s) to NetCDF dataset(s), including OPeNDAP URLs,
         or path to zarr store, or xarray.Dataset or xarray.DataArray.
     var_name : str | list[str] | None
@@ -2816,7 +2816,7 @@ def r10mm(
 
 
 def r20mm(
-    in_files: str | list[str] | Dataset | DataArray,
+    in_files: InFileType,
     var_name: str | list[str] | None = None,
     slice_mode: SliceMode = Frequency.YEAR,
     time_range: list[datetime] | list[str] | tuple[str, str] | None = None,
@@ -2832,7 +2832,7 @@ def r20mm(
 
     Parameters
     ----------
-    in_files : str | list[str] | Dataset | DataArray,
+    in_files : str | list[str] | Dataset | DataArray | InputDictionary,
         Absolute path(s) to NetCDF dataset(s), including OPeNDAP URLs,
         or path to zarr store, or xarray.Dataset or xarray.DataArray.
     var_name : str | list[str] | None
@@ -2888,7 +2888,7 @@ def r20mm(
 
 
 def rx1day(
-    in_files: str | list[str] | Dataset | DataArray,
+    in_files: InFileType,
     var_name: str | list[str] | None = None,
     slice_mode: SliceMode = Frequency.YEAR,
     time_range: list[datetime] | list[str] | tuple[str, str] | None = None,
@@ -2904,7 +2904,7 @@ def rx1day(
 
     Parameters
     ----------
-    in_files : str | list[str] | Dataset | DataArray,
+    in_files : str | list[str] | Dataset | DataArray | InputDictionary,
         Absolute path(s) to NetCDF dataset(s), including OPeNDAP URLs,
         or path to zarr store, or xarray.Dataset or xarray.DataArray.
     var_name : str | list[str] | None
@@ -2960,7 +2960,7 @@ def rx1day(
 
 
 def rx5day(
-    in_files: str | list[str] | Dataset | DataArray,
+    in_files: InFileType,
     var_name: str | list[str] | None = None,
     slice_mode: SliceMode = Frequency.YEAR,
     time_range: list[datetime] | list[str] | tuple[str, str] | None = None,
@@ -2976,7 +2976,7 @@ def rx5day(
 
     Parameters
     ----------
-    in_files : str | list[str] | Dataset | DataArray,
+    in_files : str | list[str] | Dataset | DataArray | InputDictionary,
         Absolute path(s) to NetCDF dataset(s), including OPeNDAP URLs,
         or path to zarr store, or xarray.Dataset or xarray.DataArray.
     var_name : str | list[str] | None
@@ -3032,7 +3032,7 @@ def rx5day(
 
 
 def r75p(
-    in_files: str | list[str] | Dataset | DataArray,
+    in_files: InFileType,
     var_name: str | list[str] | None = None,
     slice_mode: SliceMode = Frequency.YEAR,
     time_range: list[datetime] | list[str] | tuple[str, str] | None = None,
@@ -3055,7 +3055,7 @@ def r75p(
 
     Parameters
     ----------
-    in_files : str | list[str] | Dataset | DataArray,
+    in_files : str | list[str] | Dataset | DataArray | InputDictionary,
         Absolute path(s) to NetCDF dataset(s), including OPeNDAP URLs,
         or path to zarr store, or xarray.Dataset or xarray.DataArray.
     var_name : str | list[str] | None
@@ -3141,7 +3141,7 @@ def r75p(
 
 
 def r75ptot(
-    in_files: str | list[str] | Dataset | DataArray,
+    in_files: InFileType,
     var_name: str | list[str] | None = None,
     slice_mode: SliceMode = Frequency.YEAR,
     time_range: list[datetime] | list[str] | tuple[str, str] | None = None,
@@ -3163,7 +3163,7 @@ def r75ptot(
 
     Parameters
     ----------
-    in_files : str | list[str] | Dataset | DataArray,
+    in_files : str | list[str] | Dataset | DataArray | InputDictionary,
         Absolute path(s) to NetCDF dataset(s), including OPeNDAP URLs,
         or path to zarr store, or xarray.Dataset or xarray.DataArray.
     var_name : str | list[str] | None
@@ -3246,7 +3246,7 @@ def r75ptot(
 
 
 def r95p(
-    in_files: str | list[str] | Dataset | DataArray,
+    in_files: InFileType,
     var_name: str | list[str] | None = None,
     slice_mode: SliceMode = Frequency.YEAR,
     time_range: list[datetime] | list[str] | tuple[str, str] | None = None,
@@ -3269,7 +3269,7 @@ def r95p(
 
     Parameters
     ----------
-    in_files : str | list[str] | Dataset | DataArray,
+    in_files : str | list[str] | Dataset | DataArray | InputDictionary,
         Absolute path(s) to NetCDF dataset(s), including OPeNDAP URLs,
         or path to zarr store, or xarray.Dataset or xarray.DataArray.
     var_name : str | list[str] | None
@@ -3355,7 +3355,7 @@ def r95p(
 
 
 def r95ptot(
-    in_files: str | list[str] | Dataset | DataArray,
+    in_files: InFileType,
     var_name: str | list[str] | None = None,
     slice_mode: SliceMode = Frequency.YEAR,
     time_range: list[datetime] | list[str] | tuple[str, str] | None = None,
@@ -3377,7 +3377,7 @@ def r95ptot(
 
     Parameters
     ----------
-    in_files : str | list[str] | Dataset | DataArray,
+    in_files : str | list[str] | Dataset | DataArray | InputDictionary,
         Absolute path(s) to NetCDF dataset(s), including OPeNDAP URLs,
         or path to zarr store, or xarray.Dataset or xarray.DataArray.
     var_name : str | list[str] | None
@@ -3460,7 +3460,7 @@ def r95ptot(
 
 
 def r99p(
-    in_files: str | list[str] | Dataset | DataArray,
+    in_files: InFileType,
     var_name: str | list[str] | None = None,
     slice_mode: SliceMode = Frequency.YEAR,
     time_range: list[datetime] | list[str] | tuple[str, str] | None = None,
@@ -3483,7 +3483,7 @@ def r99p(
 
     Parameters
     ----------
-    in_files : str | list[str] | Dataset | DataArray,
+    in_files : str | list[str] | Dataset | DataArray | InputDictionary,
         Absolute path(s) to NetCDF dataset(s), including OPeNDAP URLs,
         or path to zarr store, or xarray.Dataset or xarray.DataArray.
     var_name : str | list[str] | None
@@ -3569,7 +3569,7 @@ def r99p(
 
 
 def r99ptot(
-    in_files: str | list[str] | Dataset | DataArray,
+    in_files: InFileType,
     var_name: str | list[str] | None = None,
     slice_mode: SliceMode = Frequency.YEAR,
     time_range: list[datetime] | list[str] | tuple[str, str] | None = None,
@@ -3591,7 +3591,7 @@ def r99ptot(
 
     Parameters
     ----------
-    in_files : str | list[str] | Dataset | DataArray,
+    in_files : str | list[str] | Dataset | DataArray | InputDictionary,
         Absolute path(s) to NetCDF dataset(s), including OPeNDAP URLs,
         or path to zarr store, or xarray.Dataset or xarray.DataArray.
     var_name : str | list[str] | None
@@ -3674,7 +3674,7 @@ def r99ptot(
 
 
 def sd(
-    in_files: str | list[str] | Dataset | DataArray,
+    in_files: InFileType,
     var_name: str | list[str] | None = None,
     slice_mode: SliceMode = Frequency.YEAR,
     time_range: list[datetime] | list[str] | tuple[str, str] | None = None,
@@ -3690,7 +3690,7 @@ def sd(
 
     Parameters
     ----------
-    in_files : str | list[str] | Dataset | DataArray,
+    in_files : str | list[str] | Dataset | DataArray | InputDictionary,
         Absolute path(s) to NetCDF dataset(s), including OPeNDAP URLs,
         or path to zarr store, or xarray.Dataset or xarray.DataArray.
     var_name : str | list[str] | None
@@ -3746,7 +3746,7 @@ def sd(
 
 
 def sd1(
-    in_files: str | list[str] | Dataset | DataArray,
+    in_files: InFileType,
     var_name: str | list[str] | None = None,
     slice_mode: SliceMode = Frequency.YEAR,
     time_range: list[datetime] | list[str] | tuple[str, str] | None = None,
@@ -3762,7 +3762,7 @@ def sd1(
 
     Parameters
     ----------
-    in_files : str | list[str] | Dataset | DataArray,
+    in_files : str | list[str] | Dataset | DataArray | InputDictionary,
         Absolute path(s) to NetCDF dataset(s), including OPeNDAP URLs,
         or path to zarr store, or xarray.Dataset or xarray.DataArray.
     var_name : str | list[str] | None
@@ -3818,7 +3818,7 @@ def sd1(
 
 
 def sd5cm(
-    in_files: str | list[str] | Dataset | DataArray,
+    in_files: InFileType,
     var_name: str | list[str] | None = None,
     slice_mode: SliceMode = Frequency.YEAR,
     time_range: list[datetime] | list[str] | tuple[str, str] | None = None,
@@ -3834,7 +3834,7 @@ def sd5cm(
 
     Parameters
     ----------
-    in_files : str | list[str] | Dataset | DataArray,
+    in_files : str | list[str] | Dataset | DataArray | InputDictionary,
         Absolute path(s) to NetCDF dataset(s), including OPeNDAP URLs,
         or path to zarr store, or xarray.Dataset or xarray.DataArray.
     var_name : str | list[str] | None
@@ -3890,7 +3890,7 @@ def sd5cm(
 
 
 def sd50cm(
-    in_files: str | list[str] | Dataset | DataArray,
+    in_files: InFileType,
     var_name: str | list[str] | None = None,
     slice_mode: SliceMode = Frequency.YEAR,
     time_range: list[datetime] | list[str] | tuple[str, str] | None = None,
@@ -3906,7 +3906,7 @@ def sd50cm(
 
     Parameters
     ----------
-    in_files : str | list[str] | Dataset | DataArray,
+    in_files : str | list[str] | Dataset | DataArray | InputDictionary,
         Absolute path(s) to NetCDF dataset(s), including OPeNDAP URLs,
         or path to zarr store, or xarray.Dataset or xarray.DataArray.
     var_name : str | list[str] | None
@@ -3962,7 +3962,7 @@ def sd50cm(
 
 
 def cd(
-    in_files: str | list[str] | Dataset | DataArray,
+    in_files: InFileType,
     var_name: str | list[str] | None = None,
     slice_mode: SliceMode = Frequency.YEAR,
     time_range: list[datetime] | list[str] | tuple[str, str] | None = None,
@@ -3986,7 +3986,7 @@ def cd(
 
     Parameters
     ----------
-    in_files : str | list[str] | Dataset | DataArray,
+    in_files : str | list[str] | Dataset | DataArray | InputDictionary,
         Absolute path(s) to NetCDF dataset(s), including OPeNDAP URLs,
         or path to zarr store, or xarray.Dataset or xarray.DataArray.
     var_name : str | list[str] | None
@@ -4073,7 +4073,7 @@ def cd(
 
 
 def cw(
-    in_files: str | list[str] | Dataset | DataArray,
+    in_files: InFileType,
     var_name: str | list[str] | None = None,
     slice_mode: SliceMode = Frequency.YEAR,
     time_range: list[datetime] | list[str] | tuple[str, str] | None = None,
@@ -4097,7 +4097,7 @@ def cw(
 
     Parameters
     ----------
-    in_files : str | list[str] | Dataset | DataArray,
+    in_files : str | list[str] | Dataset | DataArray | InputDictionary,
         Absolute path(s) to NetCDF dataset(s), including OPeNDAP URLs,
         or path to zarr store, or xarray.Dataset or xarray.DataArray.
     var_name : str | list[str] | None
@@ -4184,7 +4184,7 @@ def cw(
 
 
 def wd(
-    in_files: str | list[str] | Dataset | DataArray,
+    in_files: InFileType,
     var_name: str | list[str] | None = None,
     slice_mode: SliceMode = Frequency.YEAR,
     time_range: list[datetime] | list[str] | tuple[str, str] | None = None,
@@ -4208,7 +4208,7 @@ def wd(
 
     Parameters
     ----------
-    in_files : str | list[str] | Dataset | DataArray,
+    in_files : str | list[str] | Dataset | DataArray | InputDictionary,
         Absolute path(s) to NetCDF dataset(s), including OPeNDAP URLs,
         or path to zarr store, or xarray.Dataset or xarray.DataArray.
     var_name : str | list[str] | None
@@ -4295,7 +4295,7 @@ def wd(
 
 
 def ww(
-    in_files: str | list[str] | Dataset | DataArray,
+    in_files: InFileType,
     var_name: str | list[str] | None = None,
     slice_mode: SliceMode = Frequency.YEAR,
     time_range: list[datetime] | list[str] | tuple[str, str] | None = None,
@@ -4319,7 +4319,7 @@ def ww(
 
     Parameters
     ----------
-    in_files : str | list[str] | Dataset | DataArray,
+    in_files : str | list[str] | Dataset | DataArray | InputDictionary,
         Absolute path(s) to NetCDF dataset(s), including OPeNDAP URLs,
         or path to zarr store, or xarray.Dataset or xarray.DataArray.
     var_name : str | list[str] | None
@@ -4407,7 +4407,7 @@ def ww(
 
 def custom_index(
     user_index: UserIndexDict,
-    in_files: str | list[str] | Dataset | DataArray,
+    in_files: InFileType,
     var_name: str | list[str] | None = None,
     slice_mode: SliceMode = Frequency.YEAR,
     time_range: list[datetime] | list[str] | tuple[str, str] | None = None,
@@ -4427,7 +4427,7 @@ def custom_index(
 
     Parameters
     ----------
-    in_files : str | list[str] | Dataset | DataArray,
+    in_files : str | list[str] | Dataset | DataArray | InputDictionary,
         Absolute path(s) to NetCDF dataset(s), including OPeNDAP URLs,
         or path to zarr store, or xarray.Dataset or xarray.DataArray.
     var_name : str | list[str] | None

--- a/icclim/ecad/ecad_functions.py
+++ b/icclim/ecad/ecad_functions.py
@@ -16,9 +16,10 @@ from xclim.core.calendar import percentile_doy, resample_doy
 from xclim.core.units import convert_units_to
 
 from icclim.models.cf_calendar import CfCalendar
+from icclim.models.cf_variable import CfVariable
 from icclim.models.constants import IN_BASE_IDENTIFIER, PERCENTILES_COORD
 from icclim.models.frequency import Frequency
-from icclim.models.index_config import CfVariable, IndexConfig
+from icclim.models.index_config import IndexConfig
 from icclim.models.quantile_interpolation import QuantileInterpolation
 
 
@@ -26,7 +27,7 @@ def gd4(config: IndexConfig) -> DataArray:
     return _compute_threshold_index(
         da=config.tas.study_da,
         threshold=4.0 if config.threshold is None else config.threshold,
-        freq=config.freq,
+        freq=config.frequency,
         xclim_index_fun=atmos.growing_degree_days,
     )
 
@@ -35,7 +36,7 @@ def cfd(config: IndexConfig) -> DataArray:
     return _compute_threshold_index(
         da=config.tasmin.study_da,
         threshold=0.0 if config.threshold is None else config.threshold,
-        freq=config.freq,
+        freq=config.frequency,
         xclim_index_fun=atmos.consecutive_frost_days,
     )
 
@@ -44,7 +45,7 @@ def fd(config: IndexConfig) -> DataArray:
     return _compute_threshold_index(
         da=config.tasmin.study_da,
         threshold=0.0 if config.threshold is None else config.threshold,
-        freq=config.freq,
+        freq=config.frequency,
         xclim_index_fun=atmos.frost_days,
     )
 
@@ -53,7 +54,7 @@ def hd17(config: IndexConfig) -> DataArray:
     return _compute_threshold_index(
         da=config.tas.study_da,
         threshold=17.0 if config.threshold is None else config.threshold,
-        freq=config.freq,
+        freq=config.frequency,
         xclim_index_fun=atmos.heating_degree_days,
     )
 
@@ -62,7 +63,7 @@ def id(config: IndexConfig) -> DataArray:
     return _compute_threshold_index(
         da=config.tasmax.study_da,
         threshold=0.0 if config.threshold is None else config.threshold,
-        freq=config.freq,
+        freq=config.frequency,
         xclim_index_fun=atmos.ice_days,
     )
 
@@ -71,7 +72,7 @@ def csdi(config: IndexConfig) -> tuple[DataArray, DataArray | None]:
     thresh = 10 if config.threshold is None else config.threshold
     return _compute_spell_duration(
         cf_var=config.tasmin,
-        freq=config.freq,
+        freq=config.frequency,
         per_thresh=thresh,
         per_window=config.window,
         per_interpolation=config.interpolation,
@@ -86,7 +87,7 @@ def tg10p(config: IndexConfig) -> tuple[DataArray, DataArray | None]:
     thresh = 10 if config.threshold is None else config.threshold
     return _compute_temperature_percentile_index(
         cf_var=config.tas,
-        freq=config.freq,
+        freq=config.frequency,
         tas_per_thresh=thresh,
         per_window=config.window,
         per_interpolation=config.interpolation,
@@ -101,7 +102,7 @@ def tn10p(config: IndexConfig) -> tuple[DataArray, DataArray | None]:
     thresh = 10 if config.threshold is None else config.threshold
     return _compute_temperature_percentile_index(
         cf_var=config.tasmin,
-        freq=config.freq,
+        freq=config.frequency,
         tas_per_thresh=thresh,
         per_window=config.window,
         per_interpolation=config.interpolation,
@@ -116,7 +117,7 @@ def tx10p(config: IndexConfig) -> tuple[DataArray, DataArray | None]:
     thresh = 10 if config.threshold is None else config.threshold
     return _compute_temperature_percentile_index(
         cf_var=config.tasmax,
-        freq=config.freq,
+        freq=config.frequency,
         tas_per_thresh=thresh,
         per_window=config.window,
         per_interpolation=config.interpolation,
@@ -129,7 +130,7 @@ def tx10p(config: IndexConfig) -> tuple[DataArray, DataArray | None]:
 
 def txn(config: IndexConfig) -> DataArray:
     result = atmos.tx_min(
-        config.tasmax.study_da, **config.freq.build_frequency_kwargs()
+        config.tasmax.study_da, **config.frequency.build_frequency_kwargs()
     )
     result = convert_units_to(result, "°C")
     return result
@@ -137,7 +138,7 @@ def txn(config: IndexConfig) -> DataArray:
 
 def tnn(config: IndexConfig) -> DataArray:
     result = atmos.tn_min(
-        config.tasmin.study_da, **config.freq.build_frequency_kwargs()
+        config.tasmin.study_da, **config.frequency.build_frequency_kwargs()
     )
     result = convert_units_to(result, "°C")
     return result
@@ -145,7 +146,9 @@ def tnn(config: IndexConfig) -> DataArray:
 
 def cdd(config: IndexConfig) -> DataArray:
     result = atmos.maximum_consecutive_dry_days(
-        config.pr.study_da, thresh="1.0 mm/day", **config.freq.build_frequency_kwargs()
+        config.pr.study_da,
+        thresh="1.0 mm/day",
+        **config.frequency.build_frequency_kwargs(),
     )
     return result
 
@@ -154,7 +157,7 @@ def su(config: IndexConfig) -> DataArray:
     return _compute_threshold_index(
         da=config.tasmax.study_da,
         threshold=25.0 if config.threshold is None else config.threshold,
-        freq=config.freq,
+        freq=config.frequency,
         xclim_index_fun=atmos.tx_days_above,
     )
 
@@ -163,7 +166,7 @@ def tr(config: IndexConfig) -> DataArray:
     return _compute_threshold_index(
         da=config.tasmin.study_da,
         threshold=20.0 if config.threshold is None else config.threshold,
-        freq=config.freq,
+        freq=config.frequency,
         xclim_index_fun=atmos.tropical_nights,
     )
 
@@ -172,7 +175,7 @@ def wsdi(config: IndexConfig) -> tuple[DataArray, DataArray | None]:
     thresh = 90 if config.threshold is None else config.threshold
     return _compute_spell_duration(
         cf_var=config.tasmax,
-        freq=config.freq,
+        freq=config.frequency,
         per_thresh=thresh,
         per_window=config.window,
         per_interpolation=config.interpolation,
@@ -187,7 +190,7 @@ def tg90p(config: IndexConfig) -> tuple[DataArray, DataArray | None]:
     thresh = 90 if config.threshold is None else config.threshold
     return _compute_temperature_percentile_index(
         cf_var=config.tas,
-        freq=config.freq,
+        freq=config.frequency,
         tas_per_thresh=thresh,
         per_window=config.window,
         per_interpolation=config.interpolation,
@@ -202,7 +205,7 @@ def tn90p(config: IndexConfig) -> tuple[DataArray, DataArray | None]:
     thresh = 90 if config.threshold is None else config.threshold
     return _compute_temperature_percentile_index(
         cf_var=config.tasmin,
-        freq=config.freq,
+        freq=config.frequency,
         tas_per_thresh=thresh,
         per_window=config.window,
         per_interpolation=config.interpolation,
@@ -217,7 +220,7 @@ def tx90p(config: IndexConfig) -> tuple[DataArray, DataArray | None]:
     thresh = 90 if config.threshold is None else config.threshold
     return _compute_temperature_percentile_index(
         cf_var=config.tasmax,
-        freq=config.freq,
+        freq=config.frequency,
         tas_per_thresh=thresh,
         per_window=config.window,
         per_interpolation=config.interpolation,
@@ -230,7 +233,7 @@ def tx90p(config: IndexConfig) -> tuple[DataArray, DataArray | None]:
 
 def txx(config: IndexConfig) -> DataArray:
     result = atmos.tx_max(
-        config.tasmax.study_da, **config.freq.build_frequency_kwargs()
+        config.tasmax.study_da, **config.frequency.build_frequency_kwargs()
     )
     result = convert_units_to(result, "°C")
     return result
@@ -238,7 +241,7 @@ def txx(config: IndexConfig) -> DataArray:
 
 def tnx(config: IndexConfig) -> DataArray:
     result = atmos.tn_max(
-        config.tasmin.study_da, **config.freq.build_frequency_kwargs()
+        config.tasmin.study_da, **config.frequency.build_frequency_kwargs()
     )
     result = convert_units_to(result, "°C")
     return result
@@ -248,7 +251,7 @@ def csu(config: IndexConfig) -> DataArray:
     return _compute_threshold_index(
         da=config.tasmax.study_da,
         threshold=25.0 if config.threshold is None else config.threshold,
-        freq=config.freq,
+        freq=config.frequency,
         xclim_index_fun=atmos.maximum_consecutive_warm_days,
     )
 
@@ -256,56 +259,66 @@ def csu(config: IndexConfig) -> DataArray:
 def prcptot(config: IndexConfig) -> DataArray:
     result = atmos.precip_accumulation(
         _filter_in_wet_days(config.pr.study_da, dry_day_value=0),
-        **config.freq.build_frequency_kwargs(),
+        **config.frequency.build_frequency_kwargs(),
     )
     return result
 
 
 def rr1(config: IndexConfig) -> DataArray:
     result = atmos.wetdays(
-        config.pr.study_da, thresh="1.0 mm/day", **config.freq.build_frequency_kwargs()
+        config.pr.study_da,
+        thresh="1.0 mm/day",
+        **config.frequency.build_frequency_kwargs(),
     )
     return result
 
 
 def sdii(config: IndexConfig) -> DataArray:
     result = atmos.daily_pr_intensity(
-        config.pr.study_da, thresh="1.0 mm/day", **config.freq.build_frequency_kwargs()
+        config.pr.study_da,
+        thresh="1.0 mm/day",
+        **config.frequency.build_frequency_kwargs(),
     )
     return result
 
 
 def cwd(config: IndexConfig) -> DataArray:
     result = atmos.maximum_consecutive_wet_days(
-        config.pr.study_da, thresh="1.0 mm/day", **config.freq.build_frequency_kwargs()
+        config.pr.study_da,
+        thresh="1.0 mm/day",
+        **config.frequency.build_frequency_kwargs(),
     )
     return result
 
 
 def r10mm(config: IndexConfig) -> DataArray:
     result = atmos.wetdays(
-        config.pr.study_da, thresh="10 mm/day", **config.freq.build_frequency_kwargs()
+        config.pr.study_da,
+        thresh="10 mm/day",
+        **config.frequency.build_frequency_kwargs(),
     )
     return result
 
 
 def r20mm(config: IndexConfig) -> DataArray:
     result = atmos.wetdays(
-        config.pr.study_da, thresh="20 mm/day", **config.freq.build_frequency_kwargs()
+        config.pr.study_da,
+        thresh="20 mm/day",
+        **config.frequency.build_frequency_kwargs(),
     )
     return result
 
 
 def rx1day(config: IndexConfig) -> DataArray:
     result = atmos.max_1day_precipitation_amount(
-        config.pr.study_da, **config.freq.build_frequency_kwargs()
+        config.pr.study_da, **config.frequency.build_frequency_kwargs()
     )
     return result
 
 
 def rx5day(config: IndexConfig) -> DataArray:
     result = atmos.max_n_day_precipitation_amount(
-        config.pr.study_da, window=5, **config.freq.build_frequency_kwargs()
+        config.pr.study_da, window=5, **config.frequency.build_frequency_kwargs()
     )
     return result
 
@@ -313,7 +326,7 @@ def rx5day(config: IndexConfig) -> DataArray:
 def r75p(config: IndexConfig) -> tuple[DataArray, DataArray | None]:
     return _compute_rxxp(
         pr=config.pr,
-        freq=config.freq,
+        freq=config.frequency,
         pr_per_thresh=75.0,
         per_interpolation=config.interpolation,
         save_percentile=config.save_percentile,
@@ -324,7 +337,7 @@ def r75p(config: IndexConfig) -> tuple[DataArray, DataArray | None]:
 def r75ptot(config: IndexConfig) -> tuple[DataArray, DataArray | None]:
     return _compute_rxxptot(
         pr=config.pr,
-        freq=config.freq,
+        freq=config.frequency,
         pr_per_thresh=75.0,
         per_interpolation=config.interpolation,
         save_percentile=config.save_percentile,
@@ -334,7 +347,7 @@ def r75ptot(config: IndexConfig) -> tuple[DataArray, DataArray | None]:
 def r95p(config: IndexConfig) -> tuple[DataArray, DataArray | None]:
     return _compute_rxxp(
         pr=config.pr,
-        freq=config.freq,
+        freq=config.frequency,
         pr_per_thresh=95.0,
         per_interpolation=config.interpolation,
         save_percentile=config.save_percentile,
@@ -345,7 +358,7 @@ def r95p(config: IndexConfig) -> tuple[DataArray, DataArray | None]:
 def r95ptot(config: IndexConfig) -> tuple[DataArray, DataArray | None]:
     return _compute_rxxptot(
         pr=config.pr,
-        freq=config.freq,
+        freq=config.frequency,
         pr_per_thresh=95.0,
         per_interpolation=config.interpolation,
         save_percentile=config.save_percentile,
@@ -355,7 +368,7 @@ def r95ptot(config: IndexConfig) -> tuple[DataArray, DataArray | None]:
 def r99p(config: IndexConfig) -> tuple[DataArray, DataArray | None]:
     return _compute_rxxp(
         pr=config.pr,
-        freq=config.freq,
+        freq=config.frequency,
         pr_per_thresh=99.0,
         per_interpolation=config.interpolation,
         save_percentile=config.save_percentile,
@@ -366,7 +379,7 @@ def r99p(config: IndexConfig) -> tuple[DataArray, DataArray | None]:
 def r99ptot(config: IndexConfig) -> tuple[DataArray, DataArray | None]:
     return _compute_rxxptot(
         pr=config.pr,
-        freq=config.freq,
+        freq=config.frequency,
         pr_per_thresh=99.0,
         per_interpolation=config.interpolation,
         save_percentile=config.save_percentile,
@@ -374,40 +387,44 @@ def r99ptot(config: IndexConfig) -> tuple[DataArray, DataArray | None]:
 
 
 def sd(config: IndexConfig) -> DataArray:
-    result = land.snow_depth(config.pr.study_da, **config.freq.build_frequency_kwargs())
+    result = land.snow_depth(
+        config.pr.study_da, **config.frequency.build_frequency_kwargs()
+    )
     return result
 
 
 def sd1(config: IndexConfig) -> DataArray:
     result = land.snow_cover_duration(
-        config.pr.study_da, thresh="1 cm", **config.freq.build_frequency_kwargs()
+        config.pr.study_da, thresh="1 cm", **config.frequency.build_frequency_kwargs()
     )
     return result
 
 
 def sd5cm(config: IndexConfig) -> DataArray:
     result = land.snow_cover_duration(
-        config.pr.study_da, thresh="5 cm", **config.freq.build_frequency_kwargs()
+        config.pr.study_da, thresh="5 cm", **config.frequency.build_frequency_kwargs()
     )
     return result
 
 
 def sd50cm(config: IndexConfig) -> DataArray:
     result = land.snow_cover_duration(
-        config.pr.study_da, thresh="50 cm", **config.freq.build_frequency_kwargs()
+        config.pr.study_da, thresh="50 cm", **config.frequency.build_frequency_kwargs()
     )
     return result
 
 
 def tg(config: IndexConfig) -> DataArray:
-    result = atmos.tg_mean(config.tas.study_da, **config.freq.build_frequency_kwargs())
+    result = atmos.tg_mean(
+        config.tas.study_da, **config.frequency.build_frequency_kwargs()
+    )
     result = convert_units_to(result, "°C")
     return result
 
 
 def tn(config: IndexConfig) -> DataArray:
     result = atmos.tn_mean(
-        config.tasmin.study_da, **config.freq.build_frequency_kwargs()
+        config.tasmin.study_da, **config.frequency.build_frequency_kwargs()
     )
     result = convert_units_to(result, "°C")
     return result
@@ -415,7 +432,7 @@ def tn(config: IndexConfig) -> DataArray:
 
 def tx(config: IndexConfig) -> DataArray:
     result = atmos.tx_mean(
-        config.tasmax.study_da, **config.freq.build_frequency_kwargs()
+        config.tasmax.study_da, **config.frequency.build_frequency_kwargs()
     )
     result = convert_units_to(result, "°C")
     return result
@@ -425,7 +442,7 @@ def dtr(config: IndexConfig) -> DataArray:
     result = atmos.daily_temperature_range(
         tasmax=config.tasmax.study_da,
         tasmin=config.tasmin.study_da,
-        **config.freq.build_frequency_kwargs(),
+        **config.frequency.build_frequency_kwargs(),
     )
     result.attrs["units"] = "°C"
     return result
@@ -435,7 +452,7 @@ def etr(config: IndexConfig) -> DataArray:
     result = atmos.extreme_temperature_range(
         tasmax=config.tasmax.study_da,
         tasmin=config.tasmin.study_da,
-        **config.freq.build_frequency_kwargs(),
+        **config.frequency.build_frequency_kwargs(),
     )
     result.attrs["units"] = "°C"
     return result
@@ -445,7 +462,7 @@ def vdtr(config: IndexConfig) -> DataArray:
     result = atmos.daily_temperature_range_variability(
         tasmax=config.tasmax.study_da,
         tasmin=config.tasmin.study_da,
-        **config.freq.build_frequency_kwargs(),
+        **config.frequency.build_frequency_kwargs(),
     )
     result.attrs["units"] = "°C"
     return result
@@ -455,7 +472,7 @@ def cd(config: IndexConfig) -> DataArray:
     return compute_compound_index(
         tas=config.tas,
         pr=config.pr,
-        freq=config.freq,
+        freq=config.frequency,
         tas_per_thresh=25,
         pr_per_thresh=25,
         per_window=config.window,
@@ -470,7 +487,7 @@ def cw(config: IndexConfig) -> DataArray:
     return compute_compound_index(
         tas=config.tas,
         pr=config.pr,
-        freq=config.freq,
+        freq=config.frequency,
         tas_per_thresh=25,
         pr_per_thresh=75,
         per_window=config.window,
@@ -485,7 +502,7 @@ def wd(config: IndexConfig) -> DataArray:
     return compute_compound_index(
         tas=config.tas,
         pr=config.pr,
-        freq=config.freq,
+        freq=config.frequency,
         tas_per_thresh=75,
         pr_per_thresh=25,
         per_window=config.window,
@@ -500,7 +517,7 @@ def ww(config: IndexConfig) -> DataArray:
     return compute_compound_index(
         tas=config.tas,
         pr=config.pr,
-        freq=config.freq,
+        freq=config.frequency,
         tas_per_thresh=75,
         pr_per_thresh=75,
         per_window=config.window,

--- a/icclim/ecad/ecad_functions.py
+++ b/icclim/ecad/ecad_functions.py
@@ -743,10 +743,10 @@ def compute_compound_index(
         callback,
     )
     tas_per = tas_per.squeeze(PERCENTILES_COORD, drop=True)
-    pr_in_base = _filter_in_wet_days(pr.reference_da, dry_day_value=np.NAN)
-    pr_out_of_base = _filter_in_wet_days(pr.study_da, dry_day_value=0)
+    pr.reference_da = _filter_in_wet_days(pr.reference_da, dry_day_value=np.NAN)
+    pr.study_da = _filter_in_wet_days(pr.study_da, dry_day_value=0)
     pr_per, _ = _compute_percentile_doy(
-        pr_in_base,
+        pr,
         pr_per_thresh,
         per_window,
         per_interpolation,
@@ -754,7 +754,7 @@ def compute_compound_index(
     )
     pr_per = pr_per.squeeze(PERCENTILES_COORD, drop=True)
     result = xclim_index_fun(
-        tas.study_da, pr_out_of_base, tas_per, pr_per, **freq.build_frequency_kwargs()
+        tas.study_da, pr.study_da, tas_per, pr_per, **freq.build_frequency_kwargs()
     )
     if save_percentile:
         # FIXME, not consistent with other percentile based indices

--- a/icclim/main.py
+++ b/icclim/main.py
@@ -475,7 +475,7 @@ def _add_ecad_index_metadata(
         dict(
             title=_build_title(computed_index, config),
             references="ATBD of the ECA&D indices calculation"
-            " (https://www.ecad.eu/documents/atbd.pdf)",
+            " (https://knmi-ecad-assets-prd.s3.amazonaws.com/documents/atbd.pdf)",
             institution="Climate impact portal (https://climate4impact.eu)",
             history=history,
             source=initial_source if initial_source is not None else "",

--- a/icclim/main.py
+++ b/icclim/main.py
@@ -34,7 +34,7 @@ from icclim.pre_processing.input_parsing import (
     InFileType,
     build_cf_variables,
     guess_var_names,
-    read_multiple,
+    read_dataset,
     update_to_standard_coords,
 )
 from icclim.user_indices.calc_operation import CalcOperation, compute_user_index
@@ -259,9 +259,7 @@ def index(
         index = EcadIndex.lookup(index_name)
     else:
         index = None
-
-    # input_dataset = read_multiple(in_files, index, var_name)
-    input_dataset = read_multiple(in_files, index, var_name)
+    input_dataset = read_dataset(in_files, index, var_name)
     input_dataset, reset_coords_dict = update_to_standard_coords(input_dataset)
     sampling_frequency = Frequency.lookup(slice_mode)
     input_dataset = input_dataset.chunk("auto")

--- a/icclim/main.py
+++ b/icclim/main.py
@@ -264,8 +264,9 @@ def index(
     input_dataset = read_multiple(in_files, index, var_name)
     input_dataset, reset_coords_dict = update_to_standard_coords(input_dataset)
     sampling_frequency = Frequency.lookup(slice_mode)
+    input_dataset = input_dataset.chunk("auto")
     cf_vars = build_cf_variables(
-        var_names=guess_var_names(in_files, input_dataset, index, var_name),
+        var_names=guess_var_names(input_dataset, in_files, index, var_name),
         ds=input_dataset,
         time_range=time_range,
         ignore_Feb29th=ignore_Feb29th,

--- a/icclim/main.py
+++ b/icclim/main.py
@@ -31,9 +31,10 @@ from icclim.models.quantile_interpolation import QuantileInterpolation
 from icclim.models.user_index_config import UserIndexConfig
 from icclim.models.user_index_dict import UserIndexDict
 from icclim.pre_processing.input_parsing import (
-    InFileBaseType,
+    InFileType,
     build_cf_variables,
-    read_dataset,
+    guess_var_names,
+    read_multiple,
     update_to_standard_coords,
 )
 from icclim.user_indices.calc_operation import CalcOperation, compute_user_index
@@ -119,7 +120,7 @@ def indice(*args, **kwargs):
 
 
 def index(
-    in_files: InFileBaseType,  # | InputDictionary,
+    in_files: InFileType,
     index_name: str | None = None,  # optional when computing user_indices
     var_name: str | list[str] | None = None,
     slice_mode: SliceMode = Frequency.YEAR,
@@ -260,18 +261,17 @@ def index(
         index = None
 
     # input_dataset = read_multiple(in_files, index, var_name)
-    input_dataset = read_dataset(in_files, index, var_name)
+    input_dataset = read_multiple(in_files, index, var_name)
     input_dataset, reset_coords_dict = update_to_standard_coords(input_dataset)
     sampling_frequency = Frequency.lookup(slice_mode)
     cf_vars = build_cf_variables(
-        var_name,
-        index,
-        input_dataset,
-        time_range,
-        ignore_Feb29th,
-        base_period_time_range,
-        only_leap_years,
-        sampling_frequency,
+        var_names=guess_var_names(in_files, input_dataset, index, var_name),
+        ds=input_dataset,
+        time_range=time_range,
+        ignore_Feb29th=ignore_Feb29th,
+        base_period_time_range=base_period_time_range,
+        only_leap_years=only_leap_years,
+        freq=sampling_frequency,
     )
     config = IndexConfig(
         save_percentile=save_percentile,

--- a/icclim/models/cf_variable.py
+++ b/icclim/models/cf_variable.py
@@ -1,0 +1,27 @@
+from dataclasses import dataclass
+
+from xarray import DataArray
+
+
+@dataclass()
+class CfVariable:
+    """CfVariable groups together two xarray DataArray for the same variable.
+    One represent the whole studied period. The other is only the in base period used by
+    percentile based indices to compute percentiles.
+
+    # todo: maybe we should supercharge xr.Dataset
+
+    Parameters
+    ----------
+    name: str
+        Name of the variable.
+    study_da: DataArray
+        The variable studied.
+    reference_da: DataArray
+        The variable studied limited to the in base period.
+    """
+
+    name: str
+    study_da: DataArray
+    reference_da: DataArray = None
+    # percentiles: PercentileDataArray = None

--- a/icclim/models/cf_variable.py
+++ b/icclim/models/cf_variable.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 
 from xarray import DataArray
+from xclim.core.utils import PercentileDataArray
 
 
 @dataclass()
@@ -8,8 +11,7 @@ class CfVariable:
     """CfVariable groups together two xarray DataArray for the same variable.
     One represent the whole studied period. The other is only the in base period used by
     percentile based indices to compute percentiles.
-
-    # todo: maybe we should supercharge xr.Dataset
+    This is an internal icclim structure.
 
     Parameters
     ----------
@@ -23,5 +25,4 @@ class CfVariable:
 
     name: str
     study_da: DataArray
-    reference_da: DataArray = None
-    # percentiles: PercentileDataArray = None
+    reference_da: DataArray | PercentileDataArray

--- a/icclim/models/cf_variable.py
+++ b/icclim/models/cf_variable.py
@@ -25,4 +25,4 @@ class CfVariable:
 
     name: str
     study_da: DataArray
-    reference_da: DataArray | PercentileDataArray
+    reference_da: DataArray | PercentileDataArray | None = None

--- a/icclim/models/climate_index.py
+++ b/icclim/models/climate_index.py
@@ -1,15 +1,14 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Callable, Optional, Tuple, Union
+from typing import Any, Callable, Optional, Tuple, Union
 
 from xarray import DataArray
 
-from icclim.models.index_config import IndexConfig
 from icclim.models.index_group import IndexGroup
 
 ComputeIndexFun = Callable[
-    [IndexConfig], Union[DataArray, Tuple[DataArray, Optional[DataArray]]]
+    [Any], Union[DataArray, Tuple[DataArray, Optional[DataArray]]]
 ]
 
 

--- a/icclim/models/constants.py
+++ b/icclim/models/constants.py
@@ -16,11 +16,16 @@ PERCENTILES_COORD = "percentiles"
 # attribut holding the in_base time bounds
 IN_BASE_IDENTIFIER = "reference_epoch"
 
-# Aliases of input variables names. Source: clix-meta
+# Aliases of input variables names.
+# Source: clix-meta
 PR = ["pr", "pradjust", "prec", "rr", "precip", "PREC", "Prec", "RR", "PRECIP", "Precip"]
 TAS = ["tas", "tavg", "ta", "tasadjust", "tmean", "tm", "tg", "meant", "TMEAN", "Tmean", "TM", "TG", "MEANT", "meanT", "tasmidpoint"]
 TAS_MAX = ["tasmax", "tasmaxadjust", "tmax", "tx", "maxt", "TMAX", "Tmax", "TX", "MAXT", "maxT"]
 TAS_MIN = ["tasmin", "tasminadjust", "tmin", "tn", "mint", "TMIN", "Tmin", "TN", "MINT", "minT"]
+
+# Aliases of input percentiles variables names
+# Source icclim dev
+VALID_PERCENTILE_DIMENSION = ["quantile", "percentile", "per", "centile"]
 
 # Source of ECA&D indices definition
 ECAD_ATBD = "ECA&D, Algorithm Theoretical Basis Document (ATBD) v11"

--- a/icclim/models/index_config.py
+++ b/icclim/models/index_config.py
@@ -1,50 +1,22 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-from datetime import datetime
-from typing import Any, Callable
+from typing import Callable
 
-import xarray
-from xarray import DataArray, Dataset
-from xclim.core import calendar
-
-from icclim.icclim_exceptions import InvalidIcclimArgumentError
-from icclim.models.cf_calendar import CfCalendar
+from icclim.models.cf_variable import CfVariable
+from icclim.models.climate_index import ClimateIndex
 from icclim.models.constants import PR, TAS, TAS_MAX, TAS_MIN
-from icclim.models.frequency import Frequency, SliceMode
+from icclim.models.frequency import Frequency
 from icclim.models.netcdf_version import NetcdfVersion
 from icclim.models.quantile_interpolation import QuantileInterpolation
-from icclim.utils import get_date_to_iso_format
-
-
-@dataclass
-class CfVariable:
-    """CfVariable groups together two xarray DataArray for the same variable.
-    One represent the whole studied period. The other is only the in base period used by
-    percentile based indices to compute percentiles.
-
-    Parameters
-    ----------
-    name: str
-        Name of the variable.
-    study_da: DataArray
-        The variable studied.
-    reference_da: DataArray
-        The variable studied limited to the in base period.
-    """
-
-    name: str
-    study_da: DataArray
-    reference_da: DataArray
 
 
 class IndexConfig:
     """
-    Configuration class for ECA&D indices.
+    Configuration class for standard indices.
 
     Parameters
     ----------
-    freq: Frequency
+    frequency: Frequency
         The expected resampling frequency of the output.
     cf_variables:
         List of CfVariable necessary to compute the index.
@@ -69,8 +41,8 @@ class IndexConfig:
         A callable to produce a progress bar
     """
 
-    freq: Frequency
-    _cf_variables: list[CfVariable]
+    frequency: Frequency
+    cf_variables: list[CfVariable]
     save_percentile: bool = False
     is_percent: bool = False
     netcdf_version: NetcdfVersion
@@ -82,52 +54,24 @@ class IndexConfig:
 
     def __init__(
         self,
-        ds: Dataset,
-        slice_mode: SliceMode,
-        var_names: list[str],
+        frequency: Frequency,
         netcdf_version: str | NetcdfVersion,
-        index: Any | None,  # EcadIndex proper typing causes circular dependency
+        index: ClimateIndex | None,
+        cf_variables: list[CfVariable],
         save_percentile: bool = False,
-        only_leap_years: bool = False,
-        ignore_Feb29th: bool = False,
         window_width: int | None = 5,
-        time_range: list[datetime] | None | tuple[str] = None,
-        base_period_time_range: list[datetime] | None | tuple[str] = None,
         threshold: float | None = None,
         out_unit: str | None = None,
-        interpolation: QuantileInterpolation
-        | None = QuantileInterpolation.MEDIAN_UNBIASED,
+        interpolation=QuantileInterpolation.MEDIAN_UNBIASED,
         callback: Callable[[int], None] | None = None,
-        chunk_it: bool = False,
     ):
-        self.freq = Frequency.lookup(slice_mode)
-        if time_range is not None:
-            time_range = [get_date_to_iso_format(x) for x in time_range]
-        if base_period_time_range is not None:
-            base_period_time_range = [
-                get_date_to_iso_format(x) for x in base_period_time_range
-            ]
-        self._cf_variables = [
-            _build_cf_variable(
-                da=ds[var_name],
-                name=var_name,
-                time_range=time_range,
-                ignore_Feb29th=ignore_Feb29th,
-                base_period_time_range=base_period_time_range,
-                only_leap_years=only_leap_years,
-                chunk_it=chunk_it,
-                time_clipping=self.freq.time_clipping,
-            )
-            for var_name in var_names
-        ]
+        self.frequency = frequency
+        self.cf_variables = cf_variables
         self.window = window_width
         self.save_percentile = save_percentile
         self.is_percent = out_unit == "%"
         self.out_unit = out_unit
-        if isinstance(netcdf_version, str):
-            self.netcdf_version = NetcdfVersion.lookup(netcdf_version)
-        else:
-            self.netcdf_version = netcdf_version
+        self.netcdf_version = NetcdfVersion.lookup(netcdf_version)
         self.interpolation = interpolation
         self.threshold = threshold
         self.callback = callback
@@ -135,128 +79,38 @@ class IndexConfig:
 
     @property
     def tas(self) -> CfVariable:
-        tas_vars = list(filter(lambda v: v.name in TAS, self._cf_variables))
+        tas_vars = list(filter(lambda v: v.name in TAS, self.cf_variables))
         if len(tas_vars) == 1:
             return tas_vars[0]
         # Otherwise rely on positional guess
-        return self._cf_variables[0]
+        return self.cf_variables[0]
 
     @property
     def tasmax(self) -> CfVariable:
-        tas_max_vars = list(filter(lambda v: v.name in TAS_MAX, self._cf_variables))
+        tas_max_vars = list(filter(lambda v: v.name in TAS_MAX, self.cf_variables))
         if len(tas_max_vars) == 1:
             return tas_max_vars[0]
         # Otherwise rely on positional guess
-        return self._cf_variables[0]
+        return self.cf_variables[0]
 
     @property
     def tasmin(self) -> CfVariable:
-        tas_min_vars = list(filter(lambda v: v.name in TAS_MIN, self._cf_variables))
+        tas_min_vars = list(filter(lambda v: v.name in TAS_MIN, self.cf_variables))
         if len(tas_min_vars) == 1:
             return tas_min_vars[0]
         # Otherwise rely on positional guess
-        if len(self._cf_variables) > 1:
+        if len(self.cf_variables) > 1:
             # compound indices case
-            return self._cf_variables[1]
-        return self._cf_variables[0]
+            return self.cf_variables[1]
+        return self.cf_variables[0]
 
     @property
     def pr(self) -> CfVariable:
-        pr_vars = list(filter(lambda v: v.name in PR, self._cf_variables))
+        pr_vars = list(filter(lambda v: v.name in PR, self.cf_variables))
         if len(pr_vars) == 1:
             return pr_vars[0]
         # Otherwise rely on positional guess
-        if len(self._cf_variables) > 1:
+        if len(self.cf_variables) > 1:
             # compound indices case
-            return self._cf_variables[1]
-        return self._cf_variables[0]
-
-
-def _build_cf_variable(
-    da: DataArray,
-    name: str,
-    time_range: list[str] | None,
-    ignore_Feb29th: bool,
-    base_period_time_range: list[str] | None,
-    only_leap_years: bool,
-    chunk_it: bool,
-    time_clipping: Callable | None,
-) -> CfVariable:
-    if chunk_it:
-        da = da.chunk("auto")  # noqa - typing fixed in futur xarray version
-    study_da = _build_study_da(da, time_range, ignore_Feb29th)
-    if base_period_time_range is not None:
-        reference_da = _build_reference_da(da, base_period_time_range, only_leap_years)
-    else:
-        reference_da = study_da
-    if time_clipping is not None:
-        study_da = time_clipping(study_da)
-        reference_da = time_clipping(reference_da)
-    # TODO: all these operations should probably be added in history metadata or
-    #       provenance it could be a property in CfVariable which will be reused when we
-    #       update the metadata of the index, at the end.
-    return CfVariable(name, study_da, reference_da)
-
-
-def _build_study_da(
-    original_da: DataArray, time_range: list[str] | None, ignore_Feb29th: bool
-) -> DataArray:
-    if time_range is not None:
-        if len(time_range) != 2:
-            raise InvalidIcclimArgumentError(
-                f"The given `time_range` {time_range}"
-                f" has {len(time_range)} elements."
-                f" It must have exactly 2 dates."
-            )
-        da = original_da.sel(time=slice(time_range[0], time_range[1]))
-        if len(da.time) == 0:
-            raise InvalidIcclimArgumentError(
-                f"The given `time_range` {time_range} "
-                f"is out of the dataset time period: "
-                f"{original_da.time.min().dt.floor('D').values} "
-                f"- {original_da.time.max().dt.floor('D').values}."
-            )
-    else:
-        da = original_da
-    if ignore_Feb29th:
-        da = calendar.convert_calendar(da, CfCalendar.NO_LEAP.get_name())  # type:ignore
-    return da
-
-
-def _build_reference_da(
-    original_da: DataArray,
-    base_period_time_range: list[str],
-    only_leap_years: bool,
-) -> DataArray:
-    # TODO merge with _build_data_array ?
-    if len(base_period_time_range) != 2:
-        raise InvalidIcclimArgumentError(
-            f"The given `base_period_time_range` {base_period_time_range}"
-            f" has {len(base_period_time_range)} elements."
-            f" It must have exactly 2 dates."
-        )
-    da = original_da.sel(
-        time=slice(base_period_time_range[0], base_period_time_range[1])
-    )
-    if len(da.time) == 0:
-        raise InvalidIcclimArgumentError(
-            f"The given `base_period_time_range` {base_period_time_range}"
-            f" is out of the sample time bounds: "
-            f"{original_da.time.min().dt.floor('D').values} "
-            f"- {original_da.time.max().dt.floor('D').values}."
-        )
-    if only_leap_years:
-        da = _reduce_only_leap_years(original_da)
-    return da
-
-
-def _reduce_only_leap_years(da: DataArray) -> DataArray:
-    reduced_list: list[DataArray] = []
-    for _, val in da.groupby(da.time.dt.year):
-        if val.time.dt.dayofyear.max() == 366:
-            reduced_list.append(val)
-    if not reduced_list:
-        raise InvalidIcclimArgumentError(
-            "No leap year in current dataset. Do not use only_leap_years parameter."
-        )
-    return xarray.concat(reduced_list, "time")
+            return self.cf_variables[1]
+        return self.cf_variables[0]

--- a/icclim/models/index_config.py
+++ b/icclim/models/index_config.py
@@ -47,7 +47,7 @@ class IndexConfig:
     is_percent: bool = False
     netcdf_version: NetcdfVersion
     window: int | None
-    threshold: float | None
+    threshold: list[float] | float | None
     transfer_limit_Mbytes: int | None
     out_unit: str | None
     callback: Callable[[int], None] | None
@@ -60,7 +60,7 @@ class IndexConfig:
         cf_variables: list[CfVariable],
         save_percentile: bool = False,
         window_width: int | None = 5,
-        threshold: float | None = None,
+        threshold: list[float] | float | None = None,
         out_unit: str | None = None,
         interpolation=QuantileInterpolation.MEDIAN_UNBIASED,
         callback: Callable[[int], None] | None = None,

--- a/icclim/models/netcdf_version.py
+++ b/icclim/models/netcdf_version.py
@@ -12,8 +12,10 @@ class NetcdfVersion(Enum):
     NETCDF3_64BIT = "NETCDF3_64BIT"
 
     @staticmethod
-    def lookup(s: str):
+    def lookup(query: str | NetcdfVersion):
+        if isinstance(query, NetcdfVersion):
+            return query
         for version in NetcdfVersion:
-            if version.name.upper() == s.upper():
+            if version.name.upper() == query.upper():
                 return version
-        raise InvalidIcclimArgumentError(f"Unknown netcdf version {s}")
+        raise InvalidIcclimArgumentError(f"Unknown netcdf version {query}")

--- a/icclim/pre_processing/input_parsing.py
+++ b/icclim/pre_processing/input_parsing.py
@@ -1,60 +1,93 @@
 from __future__ import annotations
 
+from typing import Callable, List, Union
+
 import xarray as xr
+import xclim
 from xarray.core.dataarray import DataArray
 from xarray.core.dataset import Dataset
 
 from icclim.ecad.ecad_indices import EcadIndex
 from icclim.icclim_exceptions import InvalidIcclimArgumentError
+from icclim.models.cf_calendar import CfCalendar
+from icclim.models.cf_variable import CfVariable
+from icclim.models.climate_index import ClimateIndex
+from icclim.models.index_group import IndexGroup
+from icclim.utils import get_date_to_iso_format
+
+InFileBaseType = Union[str, List[str], Dataset, DataArray]
+
+# # todo valid input to handle:
+# in_files = {
+#     "tasmax": {"study": "tasmax-store.zarr", "reference": ["per-1.nc", "per-2.nc"]},
+#     "pr":     {"study": xr.open_dataset("pr").pr, },
+# }
+#
+#
+# class InputDictionary(TypedDict):
+#     study: InFileBaseType
+#     reference: InFileBaseType
+#
+#
+# def read_multiple(
+#         dudul: dict[str, InputDictionary] | InFileBaseType,
+#         index: EcadIndex | None = None,
+#         var_names: str | list[str] | None = None,
+# ) -> Dataset:
+#     if isinstance(dudul, dict):
+#         data = read_dataset(dudul["study"], index, var_names)
+#         percentiles = read_dataset(
+#             dudul["reference"], index=None, var_names="percentiles",
+#         )
+#         return xr.merge([data[0], percentiles[0]])
+#     return read_dataset(dudul)
 
 
 def read_dataset(
-    data: str | list[str] | Dataset | DataArray,
+    data: InFileBaseType,
     index: EcadIndex | None = None,
     var_names: str | list[str] | None = None,
-) -> tuple[Dataset, bool, bool]:
-    is_zarr = False
+) -> Dataset:
     if isinstance(data, Dataset):
-        input_dataset = data
-        chunk_da = False
+        return data
     elif isinstance(data, DataArray):
-        if index is None:
-            # user index case
-            if var_names is None or (
-                isinstance(var_names, list) and len(var_names) > 1
-            ):
-                raise InvalidIcclimArgumentError(
-                    "When the input is a DataArray, var_names must be a string."
-                )
-            if isinstance(var_names, list):
-                var_names = var_names[0]
-            data_name = var_names
-        else:
-            if len(index.input_variables) > 1:
-                raise InvalidIcclimArgumentError(
-                    f"Index {index.name} needs {len(index.input_variables)} variables."
-                    f" Please provide them with an xarray.Dataset, a netCDF file or a"
-                    f" zarr store."
-                )
-            data_name = index.input_variables[0][
-                0
-            ]  # first alias of the unique variable
-        input_dataset = data.to_dataset(name=data_name, promote_attrs=True)
-        chunk_da = False
+        return _read_dataarray(data, index, var_names)
     elif isinstance(data, list):
-        input_dataset = xr.open_mfdataset(data, parallel=True)
-        chunk_da = True
-    elif isinstance(data, str):
-        if ".nc" in data:
-            input_dataset = xr.open_dataset(data)
-            chunk_da = True
-        else:  # assume it's a zarr store
-            input_dataset = xr.open_zarr(data)
-            chunk_da = True
-            is_zarr = True
+        # we assumes it's a list of netCDF files
+        return xr.open_mfdataset(data, parallel=True)
+    elif is_netcdf(data):
+        return xr.open_dataset(data)
+    elif is_zarr(data):
+        return xr.open_zarr(data)
     else:
         raise NotImplementedError("`in_files` format was not recognized.")
-    return input_dataset, chunk_da, is_zarr
+
+
+def _read_dataarray(
+    data: InFileBaseType,
+    index: EcadIndex | None = None,
+    var_names: str | list[str] | None = None,
+) -> Dataset:
+    if index is None:
+        # user index case
+        if var_names is None or (isinstance(var_names, list) and len(var_names) > 1):
+            raise InvalidIcclimArgumentError(
+                "When the input is a DataArray, var_names must be a string."
+            )
+        if isinstance(var_names, list):
+            data_name = var_names[0]
+        else:
+            data_name = var_names
+    else:
+        if len(index.input_variables) > 1:
+            raise InvalidIcclimArgumentError(
+                f"Index {index.name} needs {len(index.input_variables)} variables."
+                f" Please provide them with an xarray.Dataset, netCDF file(s) or a"
+                f" zarr store."
+            )
+        # first alias of the unique variable
+        data_name = index.input_variables[0][0]
+    return data.to_dataset(name=data_name, promote_attrs=True)
 
 
 def update_to_standard_coords(ds: Dataset) -> tuple[Dataset, dict]:
@@ -73,3 +106,191 @@ def update_to_standard_coords(ds: Dataset) -> tuple[Dataset, dict]:
         ds = ds.rename({"t": "time"})
         revert.update({"time": "t"})
     return ds, revert
+
+
+def is_zarr(data: InFileBaseType):
+    return isinstance(data, str) and ".nc" not in data
+
+
+def is_netcdf(data: InFileBaseType):
+    return isinstance(data, str) and ".nc" in data
+
+
+def _guess_variable_names(
+    in_var_name: str | list[str], index: ClimateIndex, ds: Dataset
+) -> list[str]:
+    """Try to guess the variable names using the expected kind of variable for
+    the index.
+    """
+    if isinstance(in_var_name, str):
+        return [in_var_name]
+    elif isinstance(in_var_name, list):
+        return in_var_name
+    variable_names = []
+    index_variables = index.input_variables
+    for indice_var in index_variables:
+        for alias in indice_var:
+            # check if dataset contains this alias
+            if is_alias_valid(ds, index, alias):
+                variable_names.append(alias)
+                break
+    if len(variable_names) < len(index_variables):
+        main_aliases = ", ".join(map(lambda v: v[0], index_variables))
+        raise InvalidIcclimArgumentError(
+            f"Index {index.short_name} needs the following variable(s)"
+            f" [{main_aliases}], some of them were not recognized in the input."
+            f" Use `var_name` parameter to explicitly use data variable names"
+            f" from your input dataset: {list(ds.data_vars)}."
+        )
+    return variable_names
+
+
+def build_cf_variables(
+    var_name,
+    index,
+    ds,
+    time_range,
+    ignore_Feb29th,
+    base_period_time_range,
+    only_leap_years,
+    freq,
+) -> list[CfVariable]:
+    # TODO:
+    #     1. read variables var_names, in_files, guess_variable_name
+    #     2. reduce variables (time_range, base_period_time_range, in_files(dict))
+    #     Il faut que la partie qui associe quels nom pour quels variables (
+    #     var_names, in_files(dict), guess_variable_name,
+    #     ignore_Feb29th, only_leap_years)
+    # todo move `_guess_variable_names` to `read_dataset` and build a dictionnary of
+    #  {var_name: {in_da, in_ref_da, in_per}}
+    #     then, and only then, apply time_range, base_period_time_range etc
+    var_names = _guess_variable_names(var_name, index, ds)
+    return [
+        _build_cf_variable(
+            da=ds[var_name],
+            name=var_name,
+            time_range=time_range,
+            ignore_Feb29th=ignore_Feb29th,
+            base_period_time_range=base_period_time_range,
+            only_leap_years=only_leap_years,
+            time_clipping=freq.time_clipping,
+        )
+        for var_name in var_names
+    ]
+
+
+def _build_cf_variable(
+    da: DataArray,
+    # ref_da: DataArray,
+    name: str,
+    time_range: list[str] | None,
+    ignore_Feb29th: bool,
+    base_period_time_range: list[str] | None,
+    only_leap_years: bool,
+    time_clipping: Callable,
+) -> CfVariable:
+    da = da.chunk("auto")
+    study_da = _build_study_da(da, time_range, ignore_Feb29th)
+    if base_period_time_range is not None:  # and ref_da is not None:
+        raise InvalidIcclimArgumentError(
+            "Cannot determine the reference data to compute percentiles."
+        )
+    elif base_period_time_range is not None:
+        reference_da = _build_reference_da(da, base_period_time_range, only_leap_years)
+    else:
+        reference_da = study_da
+    if time_clipping is not None:
+        study_da = time_clipping(study_da)
+        reference_da = time_clipping(reference_da)
+    # TODO: all these pre-processing operations should probably be added in history
+    #       metadata or
+    #       provenance it could be a property in CfVariable which will be reused when we
+    #       update the metadata of the index, at the end.
+    #       We could have a singleton "taking notes" of each operation that must be
+    #       logged into the output netcdf/provenance/metadata
+    return CfVariable(name, study_da, reference_da)
+
+
+def _build_study_da(
+    original_da: DataArray, time_range: list[str] | None, ignore_Feb29th: bool
+) -> DataArray:
+    if time_range is not None:
+        check_time_range_pre_validity("time_range", time_range)
+        time_range = [get_date_to_iso_format(x) for x in time_range]
+        da = original_da.sel(time=slice(time_range[0], time_range[1]))
+        check_time_range_post_validity(da, original_da, "time_range", time_range)
+        if len(da.time) == 0:
+            raise InvalidIcclimArgumentError(
+                f"The given `time_range` {time_range} "
+                f"is out of the dataset time period: "
+                f"{original_da.time.min().dt.floor('D').values} "
+                f"- {original_da.time.max().dt.floor('D').values}."
+            )
+    else:
+        da = original_da
+    if ignore_Feb29th:
+        da = xclim.core.calendar.convert_calendar(
+            da, CfCalendar.NO_LEAP.get_name()
+        )  # type:ignore
+    return da
+
+
+def _build_reference_da(
+    original_da: DataArray,
+    base_time_range: list[str],
+    only_leap_years: bool,
+) -> DataArray:
+    check_time_range_pre_validity("base_period_time_range", base_time_range)
+    base_time_range = [get_date_to_iso_format(x) for x in base_time_range]
+    da = original_da.sel(time=slice(base_time_range[0], base_time_range[1]))
+    check_time_range_post_validity(
+        da, original_da, "base_period_time_range", base_time_range
+    )
+    if only_leap_years:
+        da = _reduce_only_leap_years(original_da)
+    return da
+
+
+def _reduce_only_leap_years(da: DataArray) -> DataArray:
+    reduced_list = []
+    for _, val in da.groupby(da.time.dt.year):
+        if val.time.dt.dayofyear.max() == 366:
+            reduced_list.append(val)
+    if not reduced_list:
+        raise InvalidIcclimArgumentError(
+            "No leap year in current dataset. Do not use `only_leap_years` parameter."
+        )
+    return xr.concat(reduced_list, "time")
+
+
+def check_time_range_pre_validity(key: str, tr: list) -> None:
+    if len(tr) != 2:
+        raise InvalidIcclimArgumentError(
+            f"The given `{key}` {tr}"
+            f" has {len(tr)} elements."
+            f" It must have exactly 2 dates."
+        )
+
+
+def check_time_range_post_validity(da, original_da, key: str, tr: list) -> None:
+    if len(da.time) == 0:
+        raise InvalidIcclimArgumentError(
+            f"The given `{key}` {tr} is out of the sample time bounds:"
+            f" {original_da.time.min().dt.floor('D').values}"
+            f" - {original_da.time.max().dt.floor('D').values}."
+        )
+
+
+def is_alias_valid(ds, index, alias):
+    return ds.get(alias, None) is not None and _has_valid_unit(index.group, ds[alias])
+
+
+def _has_valid_unit(group: IndexGroup, da: DataArray) -> bool:
+    if group == IndexGroup.SNOW:
+        try:
+            # todo: unit check might be replaced by cf-xarray
+            xclim.core.units.check_units.__wrapped__(da, "[length]")
+        except xclim.core.utils.ValidationError:
+            return False
+    # We delegate to xclim other unit checks
+    return True

--- a/icclim/pre_processing/input_parsing.py
+++ b/icclim/pre_processing/input_parsing.py
@@ -1,46 +1,105 @@
 from __future__ import annotations
 
-from typing import Callable, List, Union
+from typing import Callable, Dict, Hashable, List, TypedDict, Union
 
 import xarray as xr
 import xclim
 from xarray.core.dataarray import DataArray
 from xarray.core.dataset import Dataset
+from xclim.core.utils import PercentileDataArray
 
 from icclim.ecad.ecad_indices import EcadIndex
 from icclim.icclim_exceptions import InvalidIcclimArgumentError
 from icclim.models.cf_calendar import CfCalendar
 from icclim.models.cf_variable import CfVariable
 from icclim.models.climate_index import ClimateIndex
+from icclim.models.constants import VALID_PERCENTILE_DIMENSION
+from icclim.models.frequency import Frequency
 from icclim.models.index_group import IndexGroup
 from icclim.utils import get_date_to_iso_format
 
+# zarr or netcdf, or list of netcdf or xarray struct
 InFileBaseType = Union[str, List[str], Dataset, DataArray]
 
-# # todo valid input to handle:
-# in_files = {
-#     "tasmax": {"study": "tasmax-store.zarr", "reference": ["per-1.nc", "per-2.nc"]},
-#     "pr":     {"study": xr.open_dataset("pr").pr, },
-# }
-#
-#
-# class InputDictionary(TypedDict):
-#     study: InFileBaseType
-#     reference: InFileBaseType
-#
-#
-# def read_multiple(
-#         dudul: dict[str, InputDictionary] | InFileBaseType,
-#         index: EcadIndex | None = None,
-#         var_names: str | list[str] | None = None,
-# ) -> Dataset:
-#     if isinstance(dudul, dict):
-#         data = read_dataset(dudul["study"], index, var_names)
-#         percentiles = read_dataset(
-#             dudul["reference"], index=None, var_names="percentiles",
-#         )
-#         return xr.merge([data[0], percentiles[0]])
-#     return read_dataset(dudul)
+
+class InFileDictionary(TypedDict, total=False):
+    """Dictionary grouping in_files and var_name functionnalities.
+    It also allows to use a different input for percentiles.
+
+    Examples
+    --------
+
+    >>> in_files = {
+    ...    "tasmax": { "study": "tasmax-store.zarr",
+    ...                "percentiles": ["per-1.nc", "per-2.nc"],
+    ...                "climatology_bounds":['1990-01-01', '1991-12-31'],
+    ...                "per_var_name":"tas_max_per" },
+    ...    "pr": "pr.nc"
+    ...     }
+    """
+
+    study: InFileBaseType
+    percentiles: InFileBaseType | None
+    climatology_bounds: tuple[str, str] | list[str] | None
+    per_var_name: str | None
+
+
+InFileType = Union[Dict[str, Union[InFileDictionary, InFileBaseType]], InFileBaseType]
+
+
+def guess_var_names(
+    in_data: dict[str, InFileDictionary | InFileBaseType] | InFileBaseType,
+    ds: Dataset,
+    index: ClimateIndex | None = None,
+    var_names: str | list[str] | None = None,
+) -> list[str]:
+    if isinstance(in_data, dict):
+        if var_names is not None:
+            raise InvalidIcclimArgumentError(
+                "When `in_files` is a dictionary, `var_name` must be empty."
+                " The dictionary's keys are the expected variable names."
+            )
+        return list(in_data.keys())
+    elif var_names is None:
+        return _guess_variable_names(index, ds)
+    elif isinstance(var_names, str):
+        return [var_names]
+    elif isinstance(var_names, list):
+        return var_names
+
+
+def read_multiple(
+    in_data: InFileType,
+    index: EcadIndex | None = None,
+    var_names: str | list[str] | None = None,
+) -> Dataset:
+    if isinstance(in_data, dict):
+        ds_acc = []
+        for climate_var, data in in_data.items():
+            if isinstance(in_data, dict):
+                data: InFileDictionary
+                ds_acc.append(read_dataset(data["study"], index, climate_var))
+                if data.get("percentiles", None) is not None:
+                    per_ds = read_dataset(
+                        data["percentiles"],
+                        index=None,
+                        var_names=f"{climate_var}_percentiles",
+                    )
+                    per_da = per_ds[_get_percentile_var_name(per_ds, data, climate_var)]
+                    # TODO: Maybe we should construct the CfVariable here
+                    #       to avoid relying on a string to retrieve the percentiles
+                    #       later.
+                    per_da = per_da.rename(f"{climate_var}_percentiles")
+                    per_da = _standardize_percentile_dim_name(per_da)
+                    per_da = PercentileDataArray.from_da(
+                        per_da, climatology_bounds=_read_clim_bounds(data, per_da)
+                    )
+                    ds_acc.append(per_da)  # todo make sure it works to merge da and ds
+            else:
+                data: InFileBaseType
+                ds_acc.append(read_dataset(data, index, climate_var))
+        return xr.merge(ds_acc)
+    return read_dataset(in_data, index, var_names)
 
 
 def read_dataset(
@@ -63,31 +122,27 @@ def read_dataset(
         raise NotImplementedError("`in_files` format was not recognized.")
 
 
-def _read_dataarray(
-    data: InFileBaseType,
-    index: EcadIndex | None = None,
-    var_names: str | list[str] | None = None,
-) -> Dataset:
-    if index is None:
-        # user index case
-        if var_names is None or (isinstance(var_names, list) and len(var_names) > 1):
-            raise InvalidIcclimArgumentError(
-                "When the input is a DataArray, var_names must be a string."
-            )
-        if isinstance(var_names, list):
-            data_name = var_names[0]
-        else:
-            data_name = var_names
-    else:
-        if len(index.input_variables) > 1:
-            raise InvalidIcclimArgumentError(
-                f"Index {index.name} needs {len(index.input_variables)} variables."
-                f" Please provide them with an xarray.Dataset, netCDF file(s) or a"
-                f" zarr store."
-            )
-        # first alias of the unique variable
-        data_name = index.input_variables[0][0]
-    return data.to_dataset(name=data_name, promote_attrs=True)
+def build_cf_variables(
+    var_names: list[str],
+    ds: Dataset,
+    time_range: list[str] | None,
+    ignore_Feb29th: bool,
+    base_period_time_range: list[str] | None,
+    only_leap_years: bool,
+    freq: Frequency,
+) -> list[CfVariable]:
+    return [
+        _build_cf_variable(
+            ds=ds,
+            name=var_name,
+            time_range=time_range,
+            ignore_Feb29th=ignore_Feb29th,
+            base_period_time_range=base_period_time_range,
+            only_leap_years=only_leap_years,
+            time_clipping=freq.time_clipping,
+        )
+        for var_name in var_names
+    ]
 
 
 def update_to_standard_coords(ds: Dataset) -> tuple[Dataset, dict]:
@@ -116,72 +171,117 @@ def is_netcdf(data: InFileBaseType):
     return isinstance(data, str) and ".nc" in data
 
 
-def _guess_variable_names(
-    in_var_name: str | list[str], index: ClimateIndex, ds: Dataset
-) -> list[str]:
+def _standardize_percentile_dim_name(per_da: DataArray) -> DataArray:
+    # This function could probably be backported to xclim PercentileDataArray
+    per_dim_name = None
+    for d in VALID_PERCENTILE_DIMENSION:
+        if d in per_da.dims:
+            per_dim_name = d
+        elif f"{d}s" in per_da.dims:
+            # plural handling
+            per_dim_name = f"{d}s"
+    if per_dim_name is None:
+        raise InvalidIcclimArgumentError(
+            "Percentile data must contain a recognizable"
+            " percentiles dimension such as 'percentiles',"
+            " 'quantile', 'per' or 'centile'."
+        )
+    per_da = per_da.rename({per_dim_name: "percentiles"})
+    if "quantile" in per_dim_name:
+        per_da.coords["percentiles"] = per_da.coords["percentiles"] * 100
+    return per_da
+
+
+def _read_clim_bounds(input_dict: InFileDictionary, per_da: DataArray) -> list[str]:
+    bds = input_dict.get("climatology_bounds", None) or per_da.attrs.get(
+        "climatology_bounds", None
+    )
+    if len(bds) != 2:
+        raise InvalidIcclimArgumentError(
+            "climatology_bounds must be a iterable of length 2."
+        )
+    return [d for d in map(lambda bd: get_date_to_iso_format(bd), bds)]
+
+
+def _read_dataarray(
+    data: InFileBaseType,
+    index: EcadIndex | None = None,
+    var_names: str | list[str] | None = None,
+) -> Dataset:
+    if isinstance(var_names, list) and len(var_names) > 1:
+        raise InvalidIcclimArgumentError(
+            "When the input is a DataArray, var_name must be a string."
+        )
+    if var_names is None:
+        if index is not None and len(index.input_variables) > 1:
+            raise InvalidIcclimArgumentError(
+                f"Index {index.name} needs {len(index.input_variables)} variables."
+                f" Please provide them with an xarray.Dataset, netCDF file(s) or a"
+                f" zarr store."
+            )
+        # first alias of the unique variable
+        data_name = index.input_variables[0][0]
+    elif isinstance(var_names, list):
+        data_name = var_names[0]
+    else:
+        data_name = var_names
+    return data.to_dataset(name=data_name, promote_attrs=True)
+
+
+def _guess_variable_names(index: ClimateIndex, ds: Dataset) -> list[str]:
     """Try to guess the variable names using the expected kind of variable for
     the index.
     """
-    if isinstance(in_var_name, str):
-        return [in_var_name]
-    elif isinstance(in_var_name, list):
-        return in_var_name
-    variable_names = []
-    index_variables = index.input_variables
-    for indice_var in index_variables:
-        for alias in indice_var:
-            # check if dataset contains this alias
-            if is_alias_valid(ds, index, alias):
-                variable_names.append(alias)
-                break
-    if len(variable_names) < len(index_variables):
-        main_aliases = ", ".join(map(lambda v: v[0], index_variables))
-        raise InvalidIcclimArgumentError(
+
+    def get_error() -> Exception:
+        main_aliases = ", ".join(map(lambda v: v[0], index_expected_vars))
+        return InvalidIcclimArgumentError(
             f"Index {index.short_name} needs the following variable(s)"
             f" [{main_aliases}], some of them were not recognized in the input."
             f" Use `var_name` parameter to explicitly use data variable names"
             f" from your input dataset: {list(ds.data_vars)}."
         )
-    return variable_names
+
+    index_expected_vars = index.input_variables
+    if len(ds.data_vars) == 1:
+        if len(index_expected_vars) != 1:
+            raise get_error()
+        return [str(ds.data_vars[0].name)]
+    climate_var_names = []
+    for indice_var in index_expected_vars:
+        for alias in indice_var:
+            # check if dataset contains this alias
+            if _is_alias_valid(ds, index, alias):
+                climate_var_names.append(alias)
+                break
+    if len(climate_var_names) < len(index_expected_vars):
+        raise get_error()
+    return climate_var_names
 
 
-def build_cf_variables(
-    var_name,
-    index,
-    ds,
-    time_range,
-    ignore_Feb29th,
-    base_period_time_range,
-    only_leap_years,
-    freq,
-) -> list[CfVariable]:
-    # TODO:
-    #     1. read variables var_names, in_files, guess_variable_name
-    #     2. reduce variables (time_range, base_period_time_range, in_files(dict))
-    #     Il faut que la partie qui associe quels nom pour quels variables (
-    #     var_names, in_files(dict), guess_variable_name,
-    #     ignore_Feb29th, only_leap_years)
-    # todo move `_guess_variable_names` to `read_dataset` and build a dictionnary of
-    #  {var_name: {in_da, in_ref_da, in_per}}
-    #     then, and only then, apply time_range, base_period_time_range etc
-    var_names = _guess_variable_names(var_name, index, ds)
-    return [
-        _build_cf_variable(
-            da=ds[var_name],
-            name=var_name,
-            time_range=time_range,
-            ignore_Feb29th=ignore_Feb29th,
-            base_period_time_range=base_period_time_range,
-            only_leap_years=only_leap_years,
-            time_clipping=freq.time_clipping,
-        )
-        for var_name in var_names
-    ]
+def _guess_per_var_name(climate_var_name: str, per_ds: Dataset) -> Hashable:
+    for x in map(lambda v: str(v.name), per_ds.data_vars):
+        if climate_var_name in x:
+            return x
+    raise InvalidIcclimArgumentError(
+        "Could not guess the variable name for percentiles"
+        f" of {climate_var_name}. Please, provide the"
+        f" explicite name using per_var_name like so:"
+        f" \u007bf'{climate_var_name}':"
+        f" \u007b'study': 'x.nc',"
+        f" 'percentiles': 'y.nc',"
+        f" per_var_name='{climate_var_name}_percentiles'"
+        f" \u007d\u007d"
+    )
+
+
+def _has_percentile_variable(ds: Dataset, name: str) -> bool:
+    # fixme: Not the best to use a string (the name) to identify percentiles data
+    return f"{name}_percentiles" in ds.data_vars
 
 
 def _build_cf_variable(
-    da: DataArray,
-    # ref_da: DataArray,
+    ds: Dataset,
     name: str,
     time_range: list[str] | None,
     ignore_Feb29th: bool,
@@ -189,12 +289,15 @@ def _build_cf_variable(
     only_leap_years: bool,
     time_clipping: Callable,
 ) -> CfVariable:
-    da = da.chunk("auto")
+    ds = ds.chunk("auto")
+    da = ds[name]
     study_da = _build_study_da(da, time_range, ignore_Feb29th)
-    if base_period_time_range is not None:  # and ref_da is not None:
-        raise InvalidIcclimArgumentError(
-            "Cannot determine the reference data to compute percentiles."
-        )
+    if _has_percentile_variable(ds, name):
+        if base_period_time_range is not None:
+            raise InvalidIcclimArgumentError(
+                "Cannot determine the reference data to compute percentiles."
+            )
+        reference_da = PercentileDataArray.from_da(ds[f"{name}_percentiles"])
     elif base_period_time_range is not None:
         reference_da = _build_reference_da(da, base_period_time_range, only_leap_years)
     else:
@@ -215,10 +318,10 @@ def _build_study_da(
     original_da: DataArray, time_range: list[str] | None, ignore_Feb29th: bool
 ) -> DataArray:
     if time_range is not None:
-        check_time_range_pre_validity("time_range", time_range)
+        _check_time_range_pre_validity("time_range", time_range)
         time_range = [get_date_to_iso_format(x) for x in time_range]
         da = original_da.sel(time=slice(time_range[0], time_range[1]))
-        check_time_range_post_validity(da, original_da, "time_range", time_range)
+        _check_time_range_post_validity(da, original_da, "time_range", time_range)
         if len(da.time) == 0:
             raise InvalidIcclimArgumentError(
                 f"The given `time_range` {time_range} "
@@ -229,9 +332,7 @@ def _build_study_da(
     else:
         da = original_da
     if ignore_Feb29th:
-        da = xclim.core.calendar.convert_calendar(
-            da, CfCalendar.NO_LEAP.get_name()
-        )  # type:ignore
+        da = xclim.core.calendar.convert_calendar(da, CfCalendar.NO_LEAP.get_name())
     return da
 
 
@@ -240,10 +341,10 @@ def _build_reference_da(
     base_time_range: list[str],
     only_leap_years: bool,
 ) -> DataArray:
-    check_time_range_pre_validity("base_period_time_range", base_time_range)
+    _check_time_range_pre_validity("base_period_time_range", base_time_range)
     base_time_range = [get_date_to_iso_format(x) for x in base_time_range]
     da = original_da.sel(time=slice(base_time_range[0], base_time_range[1]))
-    check_time_range_post_validity(
+    _check_time_range_post_validity(
         da, original_da, "base_period_time_range", base_time_range
     )
     if only_leap_years:
@@ -263,7 +364,7 @@ def _reduce_only_leap_years(da: DataArray) -> DataArray:
     return xr.concat(reduced_list, "time")
 
 
-def check_time_range_pre_validity(key: str, tr: list) -> None:
+def _check_time_range_pre_validity(key: str, tr: list) -> None:
     if len(tr) != 2:
         raise InvalidIcclimArgumentError(
             f"The given `{key}` {tr}"
@@ -272,7 +373,7 @@ def check_time_range_pre_validity(key: str, tr: list) -> None:
         )
 
 
-def check_time_range_post_validity(da, original_da, key: str, tr: list) -> None:
+def _check_time_range_post_validity(da, original_da, key: str, tr: list) -> None:
     if len(da.time) == 0:
         raise InvalidIcclimArgumentError(
             f"The given `{key}` {tr} is out of the sample time bounds:"
@@ -281,7 +382,7 @@ def check_time_range_post_validity(da, original_da, key: str, tr: list) -> None:
         )
 
 
-def is_alias_valid(ds, index, alias):
+def _is_alias_valid(ds, index, alias):
     return ds.get(alias, None) is not None and _has_valid_unit(index.group, ds[alias])
 
 
@@ -294,3 +395,14 @@ def _has_valid_unit(group: IndexGroup, da: DataArray) -> bool:
             return False
     # We delegate to xclim other unit checks
     return True
+
+
+def _get_percentile_var_name(
+    per_ds: Dataset, in_dict: InFileDictionary, climate_var_name: str
+) -> Hashable:
+    if per_var_name := in_dict.get("per_var_name", None):
+        return per_var_name
+    elif len(per_ds.data_vars) == 1:
+        return per_ds.data_vars[list(per_ds.data_vars.keys())[0]].name
+    else:
+        return _guess_per_var_name(climate_var_name, per_ds)

--- a/icclim/pre_processing/rechunk.py
+++ b/icclim/pre_processing/rechunk.py
@@ -155,7 +155,7 @@ def _remove_stores(*stores, filesystem):
 
 def _unsafe_create_optimized_zarr_store(
     in_files: str | list[str] | Dataset | DataArray,
-    var_names: str | list[str],
+    var_name: str | list[str],
     zarr_store_name: str,
     chunking: dict[str, int] | None,
     max_mem: int,
@@ -164,12 +164,12 @@ def _unsafe_create_optimized_zarr_store(
     with dask.config.set(DEFAULT_DASK_CONF):
         logger.info("Rechunking in progress, this will take some time.")
         is_ds_zarr = is_zarr(in_files)
-        ds = read_dataset(in_files, index=None, var_names=var_names)
+        ds = read_dataset(in_files, index=None, var_name=var_name)
         # drop all non essential data variables
-        ds = ds.drop_vars(filter(lambda v: v not in var_names, ds.data_vars.keys()))
+        ds = ds.drop_vars(filter(lambda v: v not in var_name, ds.data_vars.keys()))
         if len(ds.data_vars.keys()) == 0:
             raise InvalidIcclimArgumentError(
-                f"The variable(s) {var_names} were not found in the dataset."
+                f"The variable(s) {var_name} were not found in the dataset."
             )
         if _is_rechunking_unnecessary(ds, chunking):
             raise InvalidIcclimArgumentError(

--- a/icclim/tests/test_calc_operation.py
+++ b/icclim/tests/test_calc_operation.py
@@ -29,7 +29,7 @@ class Test_compute:
         cf_var = CfVariable("tas", stub_tas(), stub_tas())
         user_index = stub_user_index([cf_var])
         user_index.calc_operation = "pouet pouet"
-        user_index.freq = Frequency.MONTH
+        user_index.frequency = Frequency.MONTH
         # WHEN
         with pytest.raises(InvalidIcclimArgumentError):
             compute_user_index(user_index)
@@ -39,7 +39,7 @@ class Test_compute:
         cf_var = CfVariable("tas", stub_tas(), stub_tas())
         user_index = stub_user_index([cf_var])
         user_index.calc_operation = "max"
-        user_index.freq = Frequency.MONTH
+        user_index.frequency = Frequency.MONTH
         # WHEN
         result = compute_user_index(user_index)
         # THEN
@@ -58,7 +58,7 @@ class Test_compute:
         user_index.thresh = "90p"
         user_index.logical_operation = LogicalOperation.GREATER_OR_EQUAL_THAN
         user_index.var_type = PRECIPITATION
-        user_index.freq = Frequency.YEAR
+        user_index.frequency = Frequency.YEAR
         # WHEN
         result = compute_user_index(user_index)
         # THEN
@@ -75,7 +75,7 @@ class Test_compute:
         user_index.thresh = "10p"
         user_index.logical_operation = LogicalOperation.LOWER_OR_EQUAL_THAN
         user_index.var_type = TEMPERATURE
-        user_index.freq = Frequency.MONTH
+        user_index.frequency = Frequency.MONTH
         # WHEN
         result = compute_user_index(user_index)
         # THEN

--- a/icclim/tests/test_input_parsing.py
+++ b/icclim/tests/test_input_parsing.py
@@ -103,10 +103,8 @@ class Test_ReadDataset:
             name="pr",
             attrs={"units": "kg m-2 d-1"},
         )
-        ds_res, chunk_it, is_zarr = read_dataset(da, EcadIndex.TX90P)
+        ds_res = read_dataset(da, EcadIndex.TX90P)
         xr.testing.assert_equal(ds_res.tasmax, da)
-        assert chunk_it is False
-        assert is_zarr is False
 
     def test_read_dataset_xr_da_user_index_success(self):
         da = xr.DataArray(
@@ -120,10 +118,8 @@ class Test_ReadDataset:
             name="pr",
             attrs={"units": "kg m-2 d-1"},
         )
-        ds_res, chunk_it, is_zarr = read_dataset(da, None, "doto")
+        ds_res = read_dataset(da, None, "doto")
         xr.testing.assert_equal(ds_res.doto, da)
-        assert chunk_it is False
-        assert is_zarr is False
 
     def test_read_dataset_xr_ds_success(self):
         ds = xr.Dataset(
@@ -141,10 +137,8 @@ class Test_ReadDataset:
                 )
             }
         )
-        ds_res, chunk_it, is_zarr = read_dataset(ds)
+        ds_res = read_dataset(ds)
         xr.testing.assert_equal(ds_res.pouet, ds.pouet)
-        assert chunk_it is False
-        assert is_zarr is False
 
     def test_read_dataset_netcdf_success(self):
         ds = xr.Dataset(
@@ -163,10 +157,8 @@ class Test_ReadDataset:
             }
         )
         ds.to_netcdf(self.OUTPUT_NC_FILE)
-        ds_res, chunk_it, is_zarr = read_dataset(self.OUTPUT_NC_FILE)
+        ds_res = read_dataset(self.OUTPUT_NC_FILE)
         xr.testing.assert_equal(ds_res.pouet, ds.pouet)
-        assert chunk_it is True
-        assert is_zarr is False
 
     def test_read_dataset_multi_netcdf_success(self):
         ds = xr.Dataset(
@@ -187,14 +179,10 @@ class Test_ReadDataset:
         ds.to_netcdf(self.OUTPUT_NC_FILE)
         ds.rename({"pouet": "patapouet"}).to_netcdf(self.OUTPUT_NC_FILE_2)
         # WHEN
-        ds_res, chunk_it, is_zarr = read_dataset(
-            [self.OUTPUT_NC_FILE, self.OUTPUT_NC_FILE_2]
-        )
+        ds_res = read_dataset([self.OUTPUT_NC_FILE, self.OUTPUT_NC_FILE_2])
         # THEN
         xr.testing.assert_equal(ds_res.pouet, ds.pouet)
         xr.testing.assert_equal(ds_res.patapouet, ds.pouet)
-        assert chunk_it is True
-        assert is_zarr is False
 
     def test_read_dataset_zarr_store_success(self):
         ds = xr.Dataset(
@@ -214,11 +202,9 @@ class Test_ReadDataset:
         )
         ds.to_zarr(self.OUTPUT_ZARR_STORE)
         # WHEN
-        ds_res, chunk_it, is_zarr = read_dataset(self.OUTPUT_ZARR_STORE)
+        ds_res = read_dataset(self.OUTPUT_ZARR_STORE)
         # THEN
         xr.testing.assert_equal(ds_res.pouet, ds.pouet)
-        assert chunk_it is True
-        assert is_zarr is True
 
     def test_read_dataset_not_implemented_error(self):
         # WHEN

--- a/icclim/tests/test_input_parsing.py
+++ b/icclim/tests/test_input_parsing.py
@@ -10,7 +10,12 @@ import xarray as xr
 
 from icclim.ecad.ecad_indices import EcadIndex
 from icclim.icclim_exceptions import InvalidIcclimArgumentError
-from icclim.pre_processing.input_parsing import read_dataset, update_to_standard_coords
+from icclim.pre_processing.input_parsing import (
+    guess_var_names,
+    read_dataset,
+    read_multiple,
+    update_to_standard_coords,
+)
 
 
 def test_update_to_standard_coords():
@@ -207,6 +212,15 @@ class Test_ReadDataset:
         xr.testing.assert_equal(ds_res.pouet, ds.pouet)
 
     def test_read_dataset_not_implemented_error(self):
-        # WHEN
+        # THEN
         with pytest.raises(NotImplementedError):
+            # WHEN
             read_dataset(42)  # noqa
+
+    def test_read_multiple(self):
+        # TODO
+        read_multiple()
+
+    def test_guess_variables(self):
+        # TODO
+        guess_var_names()

--- a/icclim/tests/test_input_parsing.py
+++ b/icclim/tests/test_input_parsing.py
@@ -2,15 +2,18 @@ from __future__ import annotations
 
 import os
 import shutil
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
+from xclim.core.utils import PercentileDataArray
 
 from icclim.ecad.ecad_indices import EcadIndex
 from icclim.icclim_exceptions import InvalidIcclimArgumentError
 from icclim.pre_processing.input_parsing import (
+    InFileDictionary,
     guess_var_names,
     read_dataset,
     read_multiple,
@@ -49,12 +52,36 @@ class Test_ReadDataset:
     OUTPUT_NC_FILE_2 = "tmp-2.nc"
     OUTPUT_ZARR_STORE = "tmp.zarr"
     OUTPUT_UNKNOWN_FORMAT = "tmp.cacahuete"
+    pr_da = None
+    tas_da = None
 
     @pytest.fixture(autouse=True)
     def cleanup(self):
-        # setup
+        # -- setup
+        self.pr_da = xr.DataArray(
+            data=np.full(10, 42).reshape((10, 1, 1)),
+            coords=dict(
+                latitude=[42],
+                longitude=[42],
+                t=pd.date_range("2042-01-01", periods=10, freq="D"),
+            ),
+            dims=["t", "latitude", "longitude"],
+            name="pr",
+            attrs={"units": "kg m-2 d-1"},
+        )
+        self.tas_da = xr.DataArray(
+            data=np.full(10, 42).reshape((10, 1, 1)),
+            coords=dict(
+                latitude=[42],
+                longitude=[42],
+                t=pd.date_range("2042-01-01", periods=10, freq="D"),
+            ),
+            dims=["t", "latitude", "longitude"],
+            name="tas",
+            attrs={"units": "degC"},
+        )
         yield
-        # teardown
+        # -- teardown
         shutil.rmtree(self.OUTPUT_ZARR_STORE, ignore_errors=True)
         for f in [
             self.OUTPUT_NC_FILE,
@@ -66,121 +93,50 @@ class Test_ReadDataset:
             except FileNotFoundError:
                 pass
 
-    def test_read_dataset_xr_da_user_index_error(self):
-        da = xr.DataArray(
-            data=np.full(10, 42).reshape((10, 1, 1)),
-            coords=dict(
-                latitude=[42],
-                longitude=[42],
-                t=pd.date_range("2042-01-01", periods=10, freq="D"),
-            ),
-            dims=["t", "latitude", "longitude"],
-            name="pr",
-            attrs={"units": "kg m-2 d-1"},
-        )
-        with pytest.raises(InvalidIcclimArgumentError):
-            read_dataset(da)
+    def test_read_dataset_xr_DataArray__simple(self):
+        # WHEN
+        res = read_dataset(self.pr_da)
+        # THEN
+        assert "pr" in res.data_vars
 
-    def test_read_dataset_xr_da_ecad_index_error(self):
-        da = xr.DataArray(
-            data=np.full(10, 42).reshape((10, 1, 1)),
-            coords=dict(
-                latitude=[42],
-                longitude=[42],
-                t=pd.date_range("2042-01-01", periods=10, freq="D"),
-            ),
-            dims=["t", "latitude", "longitude"],
-            name="pr",
-            attrs={"units": "kg m-2 d-1"},
-        )
+    def test_read_dataset_xr_DataArray__error_1_var_when_2_needed(self):
+        # THEN
         with pytest.raises(InvalidIcclimArgumentError):
-            read_dataset(da, EcadIndex.WW)
+            # WHEN
+            read_dataset(self.pr_da, EcadIndex.WW)
 
-    def test_read_dataset_xr_da_ecad_index_success(self):
-        da = xr.DataArray(
-            data=np.full(10, 42).reshape((10, 1, 1)),
-            coords=dict(
-                latitude=[42],
-                longitude=[42],
-                t=pd.date_range("2042-01-01", periods=10, freq="D"),
-            ),
-            dims=["t", "latitude", "longitude"],
-            name="pr",
-            attrs={"units": "kg m-2 d-1"},
-        )
-        ds_res = read_dataset(da, EcadIndex.TX90P)
-        xr.testing.assert_equal(ds_res.tasmax, da)
+    def test_read_dataset_xr_DataArray__rename_var(self):
+        # WHEN
+        ds_res = read_dataset(self.pr_da, EcadIndex.TX90P)
+        # THEN
+        xr.testing.assert_equal(ds_res.tasmax, self.pr_da)
 
     def test_read_dataset_xr_da_user_index_success(self):
-        da = xr.DataArray(
-            data=np.full(10, 42).reshape((10, 1, 1)),
-            coords=dict(
-                latitude=[42],
-                longitude=[42],
-                t=pd.date_range("2042-01-01", periods=10, freq="D"),
-            ),
-            dims=["t", "latitude", "longitude"],
-            name="pr",
-            attrs={"units": "kg m-2 d-1"},
-        )
-        ds_res = read_dataset(da, None, "doto")
-        xr.testing.assert_equal(ds_res.doto, da)
+        # WHEN
+        ds_res = read_dataset(self.pr_da, None)
+        # THEN
+        xr.testing.assert_equal(ds_res.pr, self.pr_da)
 
-    def test_read_dataset_xr_ds_success(self):
-        ds = xr.Dataset(
-            {
-                "pouet": xr.DataArray(
-                    data=np.full(10, 42).reshape((10, 1, 1)),
-                    coords=dict(
-                        latitude=[42],
-                        longitude=[42],
-                        t=pd.date_range("2042-01-01", periods=10, freq="D"),
-                    ),
-                    dims=["t", "latitude", "longitude"],
-                    name="pr",
-                    attrs={"units": "kg m-2 d-1"},
-                )
-            }
-        )
+    def test_read_dataset_xr_ds__simple(self):
+        # GIVEN
+        ds = xr.Dataset({"pouet": self.pr_da})
+        # WHEN
         ds_res = read_dataset(ds)
+        # THEN
         xr.testing.assert_equal(ds_res.pouet, ds.pouet)
 
     def test_read_dataset_netcdf_success(self):
-        ds = xr.Dataset(
-            {
-                "pouet": xr.DataArray(
-                    data=np.full(10, 42).reshape((10, 1, 1)),
-                    coords=dict(
-                        latitude=[42],
-                        longitude=[42],
-                        t=pd.date_range("2042-01-01", periods=10, freq="D"),
-                    ),
-                    dims=["t", "latitude", "longitude"],
-                    name="pr",
-                    attrs={"units": "kg m-2 d-1"},
-                )
-            }
-        )
+        # GIVEN
+        ds = xr.Dataset({"pouet": self.pr_da})
         ds.to_netcdf(self.OUTPUT_NC_FILE)
+        # WHEN
         ds_res = read_dataset(self.OUTPUT_NC_FILE)
+        # THEN
         xr.testing.assert_equal(ds_res.pouet, ds.pouet)
 
     def test_read_dataset_multi_netcdf_success(self):
-        ds = xr.Dataset(
-            {
-                "pouet": xr.DataArray(
-                    data=np.full(10, 42).reshape((10, 1, 1)),
-                    coords=dict(
-                        latitude=[42],
-                        longitude=[42],
-                        t=pd.date_range("2042-01-01", periods=10, freq="D"),
-                    ),
-                    dims=["t", "latitude", "longitude"],
-                    name="pr",
-                    attrs={"units": "kg m-2 d-1"},
-                )
-            }
-        )
+        # GIVEN
+        ds = xr.Dataset({"pouet": self.pr_da})
         ds.to_netcdf(self.OUTPUT_NC_FILE)
         ds.rename({"pouet": "patapouet"}).to_netcdf(self.OUTPUT_NC_FILE_2)
         # WHEN
@@ -190,21 +146,8 @@ class Test_ReadDataset:
         xr.testing.assert_equal(ds_res.patapouet, ds.pouet)
 
     def test_read_dataset_zarr_store_success(self):
-        ds = xr.Dataset(
-            {
-                "pouet": xr.DataArray(
-                    data=np.full(10, 42).reshape((10, 1, 1)),
-                    coords=dict(
-                        latitude=[42],
-                        longitude=[42],
-                        t=pd.date_range("2042-01-01", periods=10, freq="D"),
-                    ),
-                    dims=["t", "latitude", "longitude"],
-                    name="pr",
-                    attrs={"units": "kg m-2 d-1"},
-                )
-            }
-        )
+        # GIVEN
+        ds = xr.Dataset({"pouet": self.pr_da})
         ds.to_zarr(self.OUTPUT_ZARR_STORE)
         # WHEN
         ds_res = read_dataset(self.OUTPUT_ZARR_STORE)
@@ -218,9 +161,113 @@ class Test_ReadDataset:
             read_dataset(42)  # noqa
 
     def test_read_multiple(self):
-        # TODO
-        read_multiple()
+        # GIVEN
+        ds = xr.Dataset({"tas": self.tas_da})
+        ds.to_netcdf(self.OUTPUT_NC_FILE)
+        # WHEN
+        res_ds = read_multiple(
+            in_data={"ninja": self.OUTPUT_NC_FILE, "precipitoto": self.pr_da}
+        )
+        # THEN
+        # asserts variable names are the ones in the actual DataArray/Datasets
+        assert "ninja" not in res_ds.data_vars
+        assert "precipitoto" in res_ds.data_vars
+        assert "tas" in res_ds.data_vars
+        assert "pr" not in res_ds.data_vars
 
-    def test_guess_variables(self):
-        # TODO
-        guess_var_names()
+    def test_read_multiple__with_percentiles(self):
+        # GIVEN
+        ds = xr.Dataset({"tas": self.tas_da})
+        ds.to_netcdf(self.OUTPUT_NC_FILE)
+        per = self.tas_da
+        per.coords["percentiles"] = 42
+        per = per.rename("tontontonthetatilotetatoux").expand_dims("percentiles")
+        per = PercentileDataArray.from_da(
+            per, climatology_bounds=["1994-12-02", "1999-01-01"]
+        )
+        # WHEN
+        res_ds = read_multiple(
+            in_data={
+                "tatas": {
+                    "study": ds,
+                    "thresholds": per,
+                    "climatology_bounds": ("1994-12-02", "1999-01-01"),
+                    "per_var_name": "tontontonthetatilotetatoux",
+                }
+            }
+        )
+        # THEN
+        assert "tas" in res_ds.data_vars
+        # A bit weird that
+        assert "tatas_thresholds" in res_ds.data_vars
+
+    def test_read_multiple__error_no_percentiles_dimension(self):
+        # GIVEN
+        ds = xr.Dataset({"tas": self.tas_da})
+        ds.to_netcdf(self.OUTPUT_NC_FILE)
+        # WHEN
+        tas: InFileDictionary = {
+            "study": ds,
+            "thresholds": self.tas_da,
+        }
+        # THEN
+        with pytest.raises(InvalidIcclimArgumentError):
+            # WHEN
+            read_multiple(in_data={"tatas": tas})
+
+    def test_guess_variables__error_no_index(self):
+        # GIVEN
+        ds = xr.Dataset({"tas": self.tas_da})
+        # THEN
+        with pytest.raises(InvalidIcclimArgumentError):
+            # WHEN
+            guess_var_names(ds)
+
+    def test_guess_variables__error_too_many_args(self):
+        # GIVEN
+        ds = xr.Dataset({"tas": self.tas_da})
+        # THEN
+        with pytest.raises(InvalidIcclimArgumentError):
+            # WHEN
+            guess_var_names(ds, in_data={}, var_names=["coin-coin"])
+
+    def test_guess_variables__error_wrong_name_for_index(self):
+        # GIVEN
+        ds = xr.Dataset({"tas": self.tas_da})
+        # THEN
+        with pytest.raises(InvalidIcclimArgumentError):
+            # WHEN
+            guess_var_names(ds, index=EcadIndex.DTR.climate_index)
+
+    def test_guess_variables__simple(self):
+        # GIVEN
+        ds = xr.Dataset({"tas": self.tas_da})
+        # WHEN
+        res = guess_var_names(ds, index=EcadIndex.TG.climate_index)
+        # THEN
+        assert res == ["tas"]
+
+    @patch("icclim.pre_processing.input_parsing.InFileType")
+    def test_guess_variables__from_dict(self, in_file_mock: MagicMock):
+        # GIVEN
+        ds = xr.Dataset({"tas": self.tas_da})
+        # WHEN
+        res = guess_var_names(ds, in_data={"pouet": in_file_mock})
+        # THEN
+        assert res == ["pouet"]
+
+    def test_guess_variables__from_string(self):
+        # GIVEN
+        ds = xr.Dataset({"tas": self.tas_da})
+        # WHEN
+        res = guess_var_names(ds, var_names="cocoLasticot")
+        # THEN
+        assert res == ["cocoLasticot"]
+
+    def test_guess_variables__from_list(self):
+        # GIVEN
+        ds = xr.Dataset({"tas": self.tas_da})
+        # WHEN
+        res = guess_var_names(ds, var_names=["pinçon"])
+        # THEN
+        assert res == ["pinçon"]

--- a/icclim/tests/test_input_parsing.py
+++ b/icclim/tests/test_input_parsing.py
@@ -16,7 +16,6 @@ from icclim.pre_processing.input_parsing import (
     InFileDictionary,
     guess_var_names,
     read_dataset,
-    read_multiple,
     update_to_standard_coords,
 )
 
@@ -160,12 +159,12 @@ class Test_ReadDataset:
             # WHEN
             read_dataset(42)  # noqa
 
-    def test_read_multiple(self):
+    def test_read_dataset(self):
         # GIVEN
         ds = xr.Dataset({"tas": self.tas_da})
         ds.to_netcdf(self.OUTPUT_NC_FILE)
         # WHEN
-        res_ds = read_multiple(
+        res_ds = read_dataset(
             in_data={"ninja": self.OUTPUT_NC_FILE, "precipitoto": self.pr_da}
         )
         # THEN
@@ -175,7 +174,7 @@ class Test_ReadDataset:
         assert "tas" in res_ds.data_vars
         assert "pr" not in res_ds.data_vars
 
-    def test_read_multiple__with_percentiles(self):
+    def test_read_dataset__with_percentiles(self):
         # GIVEN
         ds = xr.Dataset({"tas": self.tas_da})
         ds.to_netcdf(self.OUTPUT_NC_FILE)
@@ -186,7 +185,7 @@ class Test_ReadDataset:
             per, climatology_bounds=["1994-12-02", "1999-01-01"]
         )
         # WHEN
-        res_ds = read_multiple(
+        res_ds = read_dataset(
             in_data={
                 "tatas": {
                     "study": ds,
@@ -201,7 +200,7 @@ class Test_ReadDataset:
         # A bit weird that
         assert "tatas_thresholds" in res_ds.data_vars
 
-    def test_read_multiple__error_no_percentiles_dimension(self):
+    def test_read_dataset__error_no_percentiles_dimension(self):
         # GIVEN
         ds = xr.Dataset({"tas": self.tas_da})
         ds.to_netcdf(self.OUTPUT_NC_FILE)
@@ -213,7 +212,7 @@ class Test_ReadDataset:
         # THEN
         with pytest.raises(InvalidIcclimArgumentError):
             # WHEN
-            read_multiple(in_data={"tatas": tas})
+            read_dataset(in_data={"tatas": tas})
 
     def test_guess_variables__error_no_index(self):
         # GIVEN

--- a/icclim/tests/test_main.py
+++ b/icclim/tests/test_main.py
@@ -90,7 +90,7 @@ class Test_Integration:
         res = icclim.su(
             in_files=self.data, out_file=self.OUTPUT_FILE, threshold=[42, 53]
         )
-        assert res.attrs["title"] == "Index SU on threshold(s) [42, 53]"
+        assert res.attrs["title"] == "Index SU on threshold(s) [42, 53] (ºC)"
         np.testing.assert_array_equal(res.coords["thresholds"], [42, 53])
         np.testing.assert_array_equal(0, res.SU)
 
@@ -101,7 +101,7 @@ class Test_Integration:
             threshold=[42, 53],
             save_percentile=True,
         )
-        assert res.attrs["title"] == "Index TX90p on threshold(s) [42, 53]"
+        assert res.attrs["title"] == "Index TX90p on threshold(s) [42, 53] (ºC)"
         np.testing.assert_array_equal(res.coords["percentiles"], [42, 53])
         assert res.percentiles is not None
         np.testing.assert_array_equal(0, res.TX90p)

--- a/icclim/tests/test_main.py
+++ b/icclim/tests/test_main.py
@@ -90,7 +90,7 @@ class Test_Integration:
         res = icclim.su(
             in_files=self.data, out_file=self.OUTPUT_FILE, threshold=[42, 53]
         )
-        assert res.attrs["title"] == "Index SU on threshold(s) [42, 53] (ºC)"
+        assert res.attrs["title"] == "Index SU on threshold(s) [42, 53]"
         np.testing.assert_array_equal(res.coords["thresholds"], [42, 53])
         np.testing.assert_array_equal(0, res.SU)
 
@@ -101,7 +101,7 @@ class Test_Integration:
             threshold=[42, 53],
             save_percentile=True,
         )
-        assert res.attrs["title"] == "Index TX90p on threshold(s) [42, 53] (ºC)"
+        assert res.attrs["title"] == "Index TX90p on threshold(s) [42, 53]"
         np.testing.assert_array_equal(res.coords["percentiles"], [42, 53])
         assert res.percentiles is not None
         np.testing.assert_array_equal(0, res.TX90p)

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,5 @@ pyyaml
 rechunker>=0.3.3
 setuptools
 xarray
-xclim~=0.34.0
+xclim~=0.37.0
 zarr

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -21,5 +21,5 @@ setuptools>=49.6.0
 sphinx
 twine
 xarray~=0.19.0
-xclim~=0.34.0
+xclim~=0.37.0
 zarr

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ MINIMAL_REQUIREMENTS = [
     #       https://github.com/numba/numba/issues/7754
     "numpy>=1.16,<1.22",
     "xarray>=0.17",
-    "xclim @ git+https://github.com/Ouranosinc/xclim.git",
+    "xclim>=0.37",
     "cftime>=1.4.1",
     "dask[array]",
     "netCDF4>=1.5.7",

--- a/tools/extract-icclim-funs.py
+++ b/tools/extract-icclim-funs.py
@@ -76,7 +76,6 @@ from __future__ import annotations
 
 import datetime
 
-from xarray.core.dataarray import DataArray
 from xarray.core.dataset import Dataset
 
 import icclim
@@ -85,6 +84,7 @@ from icclim.models.frequency import Frequency, SliceMode
 from icclim.models.netcdf_version import NetcdfVersion
 from icclim.models.quantile_interpolation import QuantileInterpolation
 from icclim.models.user_index_dict import UserIndexDict
+from icclim.pre_processing.input_parsing import InFileType
 
 __all__ = [
 '''


### PR DESCRIPTION
<!--
The following checklist points should all be checked before merging the PR.

Please replace xxx by your issue number (leave the prefixing '#').
-->

### Pull Request to resolve #179 
- [x] Unit tests cover the changes.
- [x] These changes were tested on real data.
- [x] The relevant documentation has been added or updated.
- [x] A short description of the changes has been added to `doc/source/references/release_notes.rst`.

### Describe the changes you made

This PR makes it possible to give percentiles as an input instead of computing them:
```
x = icclim.index(
        index_name="Tx90p",
        in_files={
            "tmax": {
                "study": "tmax.nc",
                "percentiles": "tas_per.nc",
                "climatology_bounds": ["1991", "2010"],
            }
        },
    )
```

This syntax can also be used to replace `var_name`:
```
x = icclim.index(
        index_name="DTR",
        in_files={
            "tmax": "a_file.nc",
            "tmin": "another_file.nc",
        },
    )
```
