### PR TITLE
MAINT: Remove constraint on numpy version

### DIFF
--- a/doc/source/references/release_notes.rst
+++ b/doc/source/references/release_notes.rst
@@ -28,6 +28,10 @@ Note: We no longer strictly follow the yaml given by clix-meta.
 * [enh] ``in_file`` dictionary can now be used to pass percentiles thresholds. These thresholds will be used instead of computing them on relevant indices.
 * [maint/internal] Refactored IndexConfig and moved all the logic to input_parsing.
 
+5.2.2
+-----
+[maint] Remove constraint on numpy version as numba is now working with np 1.22.
+
 5.2.1
 -----
 * [maint] Made Frequency part of SliceMode union.

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
 # Core dependencies
  - python>=3.8
  - xclim>=0.37
- - numpy==1.21.5
+ - numpy
  - xarray>=0.19
  - dask[array]
  - netCDF4>=1.5.7

--- a/icclim/ecad/ecad_functions.py
+++ b/icclim/ecad/ecad_functions.py
@@ -754,7 +754,7 @@ def compute_compound_index(
     )
     pr_per = pr_per.squeeze(PERCENTILES_COORD, drop=True)
     result = xclim_index_fun(
-        tas.study_da, pr.study_da, tas_per, pr_per, **freq.build_frequency_kwargs()
+        tas=tas.study_da, pr=pr.study_da, tas_per=tas_per, pr_per=pr_per, **freq.build_frequency_kwargs()
     )
     if save_percentile:
         # FIXME, not consistent with other percentile based indices

--- a/icclim/ecad/ecad_functions.py
+++ b/icclim/ecad/ecad_functions.py
@@ -754,7 +754,11 @@ def compute_compound_index(
     )
     pr_per = pr_per.squeeze(PERCENTILES_COORD, drop=True)
     result = xclim_index_fun(
-        tas=tas.study_da, pr=pr.study_da, tas_per=tas_per, pr_per=pr_per, **freq.build_frequency_kwargs()
+        tas=tas.study_da,
+        pr=pr.study_da,
+        tas_per=tas_per,
+        pr_per=pr_per,
+        **freq.build_frequency_kwargs(),
     )
     if save_percentile:
         # FIXME, not consistent with other percentile based indices

--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,7 @@
 from setuptools import find_packages, setup
 
 MINIMAL_REQUIREMENTS = [
-    # todo: Unpin numpy 1.22 once numba work with it (numba comes with xclim)
-    #       https://github.com/numba/numba/issues/7754
-    "numpy>=1.16,<1.22",
+    "numpy>=1.16",
     "xarray>=0.17",
     "xclim>=0.37",
     "cftime>=1.4.1",


### PR DESCRIPTION
<!--
The following checklist points should all be checked before merging the PR.

Please replace xxx by your issue number (leave the prefixing '#').
-->

### Pull Request to resolve #190 
- [x] Unit tests cover the changes.
- [ ] These changes were tested on real data.
- [x] The relevant documentation has been added or updated.
- [x] A short description of the changes has been added to `doc/source/references/release_notes.rst`.

### Describe the changes you made
Numpy is no longer pin to below 1.22.

This propagates the changes made for icclim v5.2.2
