### PR TITLE
Fix e-obs dataset file merge

### DIFF
--- a/doc/source/references/release_notes.rst
+++ b/doc/source/references/release_notes.rst
@@ -1,6 +1,11 @@
 Release history
 ===============
 
+5.4.0
+-----
+* [fix] When giving input as a list of netcdf files, the coordinate values are now merged using the `override` strategy, thus the first file with a given dimension define this dimension for all the files.
+* [fix] Fix the output unit of some indices (from "ºC" to "degree_Celsius")
+
 5.3.0
 -----
 * [enh] Add icclim version to history in outputted metadata.

--- a/icclim/ecad/ecad_functions.py
+++ b/icclim/ecad/ecad_functions.py
@@ -133,7 +133,7 @@ def txn(config: IndexConfig) -> DataArray:
     result = atmos.tx_min(
         config.tasmax.study_da, **config.frequency.build_frequency_kwargs()
     )
-    result = convert_units_to(result, "°C")
+    result = convert_units_to(result, "degree_Celsius")
     return result
 
 
@@ -141,7 +141,7 @@ def tnn(config: IndexConfig) -> DataArray:
     result = atmos.tn_min(
         config.tasmin.study_da, **config.frequency.build_frequency_kwargs()
     )
-    result = convert_units_to(result, "°C")
+    result = convert_units_to(result, "degree_Celsius")
     return result
 
 
@@ -236,7 +236,7 @@ def txx(config: IndexConfig) -> DataArray:
     result = atmos.tx_max(
         config.tasmax.study_da, **config.frequency.build_frequency_kwargs()
     )
-    result = convert_units_to(result, "°C")
+    result = convert_units_to(result, "degree_Celsius")
     return result
 
 
@@ -244,7 +244,7 @@ def tnx(config: IndexConfig) -> DataArray:
     result = atmos.tn_max(
         config.tasmin.study_da, **config.frequency.build_frequency_kwargs()
     )
-    result = convert_units_to(result, "°C")
+    result = convert_units_to(result, "degree_Celsius")
     return result
 
 
@@ -419,7 +419,7 @@ def tg(config: IndexConfig) -> DataArray:
     result = atmos.tg_mean(
         config.tas.study_da, **config.frequency.build_frequency_kwargs()
     )
-    result = convert_units_to(result, "°C")
+    result = convert_units_to(result, "degree_Celsius")
     return result
 
 
@@ -427,7 +427,7 @@ def tn(config: IndexConfig) -> DataArray:
     result = atmos.tn_mean(
         config.tasmin.study_da, **config.frequency.build_frequency_kwargs()
     )
-    result = convert_units_to(result, "°C")
+    result = convert_units_to(result, "degree_Celsius")
     return result
 
 
@@ -435,7 +435,7 @@ def tx(config: IndexConfig) -> DataArray:
     result = atmos.tx_mean(
         config.tasmax.study_da, **config.frequency.build_frequency_kwargs()
     )
-    result = convert_units_to(result, "°C")
+    result = convert_units_to(result, "degree_Celsius")
     return result
 
 
@@ -445,7 +445,7 @@ def dtr(config: IndexConfig) -> DataArray:
         tasmin=config.tasmin.study_da,
         **config.frequency.build_frequency_kwargs(),
     )
-    result.attrs["units"] = "°C"
+    result.attrs["units"] = "degree_Celsius"
     return result
 
 
@@ -455,7 +455,7 @@ def etr(config: IndexConfig) -> DataArray:
         tasmin=config.tasmin.study_da,
         **config.frequency.build_frequency_kwargs(),
     )
-    result.attrs["units"] = "°C"
+    result.attrs["units"] = "degree_Celsius"
     return result
 
 
@@ -465,7 +465,7 @@ def vdtr(config: IndexConfig) -> DataArray:
         tasmin=config.tasmin.study_da,
         **config.frequency.build_frequency_kwargs(),
     )
-    result.attrs["units"] = "°C"
+    result.attrs["units"] = "degree_Celsius"
     return result
 
 
@@ -658,7 +658,7 @@ def _compute_threshold_index(
     xclim_index_fun: Callable,
 ) -> DataArray:
     result = xclim_index_fun(
-        da, thresh=f"{threshold} °C", **freq.build_frequency_kwargs()
+        da, thresh=f"{threshold} degree_Celsius", **freq.build_frequency_kwargs()
     )
     return result
 

--- a/icclim/pre_processing/input_parsing.py
+++ b/icclim/pre_processing/input_parsing.py
@@ -89,7 +89,9 @@ def read_dataset(
         return _read_dataarray(in_data, index, var_name=var_name)
     elif isinstance(in_data, list):
         # we assumes it's a list of netCDF files
-        return xr.open_mfdataset(in_data, parallel=True)
+        #  join="override" is used for cases some dimension are a tiny bit different
+        #  in different files (was the case with eobs).
+        return xr.open_mfdataset(in_data, parallel=True, join="override")
     elif is_netcdf(in_data):
         return xr.open_dataset(in_data)
     elif is_zarr(in_data):


### PR DESCRIPTION
<!--
The following checklist points should all be checked before merging the PR.

Please replace xxx by your issue number (leave the prefixing '#').
-->

### Pull Request to resolve #xxx
- [ ] Unit tests cover the changes.
- [ ] These changes were tested on real data.
- [ ] The relevant documentation has been added or updated.
- [x] A short description of the changes has been added to `doc/source/references/release_notes.rst`.

### Describe the changes you made
- When giving input as a list of netcdf files, the coordinate values are now merged using the `override` strategy, thus the first file with a given dimension define this dimension for all the files.
- Fix the output unit of some indices (from "ºC" to "degree_Celsius")
