### PR TITLE
FIX[#199]: Make the chunking on DataArrays

### DIFF
--- a/doc/source/references/release_notes.rst
+++ b/doc/source/references/release_notes.rst
@@ -1,10 +1,11 @@
 Release history
 ===============
 
-5.4.0
------
+5.4.0 (unreleased)
+------------------
 * [fix] When giving input as a list of netcdf files, the coordinate values are now merged using the `override` strategy, thus the first file with a given dimension define this dimension for all the files.
 * [fix] Fix the output unit of some indices (from "ºC" to "degree_Celsius")
+* [fix] Fixed issued where dataset having a time_bds variable could not be processed by chunking the DataArray(s) instead of the Dataset.
 
 5.3.0
 -----

--- a/icclim/main.py
+++ b/icclim/main.py
@@ -262,7 +262,6 @@ def index(
     input_dataset = read_dataset(in_files, index, var_name)
     input_dataset, reset_coords_dict = update_to_standard_coords(input_dataset)
     sampling_frequency = Frequency.lookup(slice_mode)
-    input_dataset = input_dataset.chunk("auto")
     cf_vars = build_cf_variables(
         var_names=guess_var_names(input_dataset, in_files, index, var_name),
         ds=input_dataset,

--- a/icclim/pre_processing/input_parsing.py
+++ b/icclim/pre_processing/input_parsing.py
@@ -302,6 +302,8 @@ def _build_cf_variable(
     #       update the metadata of the index, at the end.
     #       We could have a singleton "taking notes" of each operation that must be
     #       logged into the output netcdf/provenance/metadata
+    study_da = study_da.chunk("auto")
+    reference_da = reference_da.chunk("auto")
     return CfVariable(name, study_da, reference_da)
 
 


### PR DESCRIPTION
When chunking on the Dataset we would try to chunk variables that
have nothing to do with the computation such as `time_bds`.
This is unnecessary plus, if the variable is not properly decoded
and keep a dtype "object", dask would fail to chunk it.
Instead, we now chunk DataArray(s) that we are sure to read for the computation.

<!--
The following checklist points should all be checked before merging the PR.

Please replace xxx by your issue number (leave the prefixing '#').
-->

### Pull Request to resolve #199
- [x] Unit tests cover the changes.
- [ ] These changes were tested on real data.
- [ ] The relevant documentation has been added or updated.
- [x] A short description of the changes has been added to `doc/source/references/release_notes.rst`.

### Describe the changes you made

Ignore time_bounds and other variables that are not used for the computation when chunking the data.
