### PR TITLE
Enh: release the krak... bird!

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 # LFS tracking
 # .svg files are the logo(s) that are automatically updated in our C.I.
 *.svg filter=lfs diff=lfs merge=lfs -text
+*.ico filter=lfs diff=lfs merge=lfs -text

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# LFS tracking
+# .svg files are the logo(s) that are automatically updated in our C.I.
+*.svg filter=lfs diff=lfs merge=lfs -text

--- a/.github/CONTRIBUTING.rst
+++ b/.github/CONTRIBUTING.rst
@@ -82,6 +82,13 @@ Alternatively, you can use `sphinx-autobuild <https://pypi.org/project/sphinx-au
 First install it with pip. Then, in a separate terminal, cd into doc directory and run `sphinx-autobuild source _build`
 By default it will serve the documentation on ``localhost://8000``.
 
+Additionally, icclim now has a logo that is displayed on github and readthedocs.
+Logos are stored in `/doc/source/_static/` directory.
+The logos are svg images and the icclim version number is embed in them. Thus, they must be updated for each new icclim version.
+The `xyz__base.svg` files contains the placeholder `{{icclim.__version__}}` which is replaced in the `xyz__display.svg` files.
+Fortunately, this version number update process is automated in our C.I. as github actions (see :ref:`Continuous integration`).
+However, if one wish to edit the logo manually, he/she will need to initialize git LFS on his/her local repository.
+Refer to `this guide <https://git-lfs.github.com/>` for what is git lfs and how to init it locally.
 
 Add new standard indices
 ========================

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: setup git config
         run: |
           # setup the username and email.
-          git config user.name "GitHub Actions Bot"
+          git config user.name "GitHub Actions Bot - API updater"
           git config user.email "<>"
       - name: commit
         run: |
@@ -90,7 +90,7 @@ jobs:
         run: |
           # Stage the file, commit and push
           git add README.rst
-          # Ignore error cases
+          # Ignore error cases with `|| true`
           git commit -m "[skip ci] DOC: Update coverage" || true
           git push origin ${{ github.head_ref }}
 
@@ -111,7 +111,7 @@ jobs:
       - name: Install icclim
         run: python -m pip install -e .
       - name: Generate logo
-        run: python ./tools/update_logo_version.py ./doc/source/_static/logo_icclim_colored__base.svg ./doc/source/_static/logo_icclim_colored__display.svg
+        run: python ./tools/update_logo_version.py ./doc/source/_static/logo_icclim_colored__base.svg ./doc/source/_static/logo_icclim_colored__displayed.svg
       - name: create local ref
         run: |
           git fetch origin ${{ github.head_ref }}
@@ -119,12 +119,12 @@ jobs:
       - name: setup git config
         run: |
           # setup the username and email.
-          git config user.name "GitHub Actions Bot"
+          git config user.name "GitHub Actions Bot - logo updater"
           git config user.email "<>"
       - name: commit
         run: |
           # Stage the file, commit and push
-          git add icclim/_generated_api.py
-          # Ignore error cases
-          git commit -m "MAINT: Update generated API" || true
+          git add doc/source/_static/logo_icclim_colored__displayed.svg
+          # Ignore error cases with `|| true`
+          git commit -m "MAINT: Update logo" || true
           git push origin ${{ github.head_ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,8 +110,11 @@ jobs:
         run: pip install pytest-cov
       - name: Install icclim
         run: python -m pip install -e .
-      - name: Generate logo
-        run: python ./tools/update_logo_version.py ./doc/source/_static/logo_icclim_colored__base.svg ./doc/source/_static/logo_icclim_colored__displayed.svg
+      - name: Generate logos
+        run: |
+          python ./tools/update_logo_version.py ./doc/source/_static/logo_icclim_colored__base.svg ./doc/source/_static/logo_icclim_colored__displayed.svg
+          python ./tools/update_logo_version.py ./doc/source/_static/logo_icclim_grey__base.svg ./doc/source/_static/logo_icclim_grey__displayed.svg
+          python ./tools/update_logo_version.py ./doc/source/_static/logo_icclim_white__base.svg ./doc/source/_static/logo_icclim_white__displayed.svg
       - name: create local ref
         run: |
           git fetch origin ${{ github.head_ref }}
@@ -124,7 +127,7 @@ jobs:
       - name: commit
         run: |
           # Stage the file, commit and push
-          git add doc/source/_static/logo_icclim_colored__displayed.svg
+          git add doc/source/_static/*__displayed.svg
           # Ignore error cases with `|| true`
-          git commit -m "MAINT: Update logo" || true
+          git commit -m "MAINT: Update logos" || true
           git push origin ${{ github.head_ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          lfs: true
       - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Install icclim
         run: python -m pip install -e .
       - name: Generate logo
-        run: python ./tools/update_logo_version.py ./doc/_static/logo_icclim_colored__base.svg ./doc/_static/logo_icclim_colored__display.svg
+        run: python ./tools/update_logo_version.py ./doc/source/_static/logo_icclim_colored__base.svg ./doc/source/_static/logo_icclim_colored__display.svg
       - name: create local ref
         run: |
           git fetch origin ${{ github.head_ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,3 +93,36 @@ jobs:
           # Ignore error cases
           git commit -m "[skip ci] DOC: Update coverage" || true
           git push origin ${{ github.head_ref }}
+
+  logo-update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install requirements
+        run: pip install -r requirements.txt
+      - name: Install pytest-cov
+        run: pip install pytest-cov
+      - name: Install icclim
+        run: python -m pip install -e .
+      - name: Generate logo
+        run: python ./tools/update_logo_version.py ./doc/_static/logo_icclim_colored__base.svg ./doc/_static/logo_icclim_colored__display.svg
+      - name: create local ref
+        run: |
+          git fetch origin ${{ github.head_ref }}
+          git checkout ${{ github.head_ref }}
+      - name: setup git config
+        run: |
+          # setup the username and email.
+          git config user.name "GitHub Actions Bot"
+          git config user.email "<>"
+      - name: commit
+        run: |
+          # Stage the file, commit and push
+          git add icclim/_generated_api.py
+          # Ignore error cases
+          git commit -m "MAINT: Update generated API" || true
+          git push origin ${{ github.head_ref }}

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,8 @@
 icclim
 ======
 
+|logo|
+
 |build| |pypi| |black| |docs| |conda| |coverage| |doi|
 
 icclim is a Python library to compute climate indices.
@@ -97,3 +99,7 @@ For a detailed description of each ECA&D index, please visit: https://www.ecad.e
 .. |doi| image:: https://zenodo.org/badge/15936714.svg
         :target: https://zenodo.org/badge/latestdoi/15936714
         :alt: D.O.I link
+
+.. |logo| image:: https://raw.githubusercontent.com/cerfacs-globc/icclim/master/_static/_images/logo_icclim_colored__base.svg
+        :target: https://github.com/cerfacs-globc/icclim
+        :alt: icclim logo

--- a/README.rst
+++ b/README.rst
@@ -100,6 +100,6 @@ For a detailed description of each ECA&D index, please visit: https://www.ecad.e
         :target: https://zenodo.org/badge/latestdoi/15936714
         :alt: D.O.I link
 
-.. |logo| image:: https://raw.githubusercontent.com/cerfacs-globc/icclim/master/source/_static/_images/logo_icclim_colored__base.svg
+.. |logo| image:: https://raw.githubusercontent.com/cerfacs-globc/icclim/master/source/_static/_images/logo_icclim_colored__displayed.svg
         :target: https://github.com/cerfacs-globc/icclim
         :alt: icclim logo

--- a/README.rst
+++ b/README.rst
@@ -100,6 +100,6 @@ For a detailed description of each ECA&D index, please visit: https://www.ecad.e
         :target: https://zenodo.org/badge/latestdoi/15936714
         :alt: D.O.I link
 
-.. |logo| image:: https://raw.githubusercontent.com/cerfacs-globc/icclim/master/_static/_images/logo_icclim_colored__base.svg
+.. |logo| image:: https://raw.githubusercontent.com/cerfacs-globc/icclim/master/source/_static/_images/logo_icclim_colored__base.svg
         :target: https://github.com/cerfacs-globc/icclim
         :alt: icclim logo

--- a/doc/source/_static/css/custom.css
+++ b/doc/source/_static/css/custom.css
@@ -1,0 +1,3 @@
+.logo__image {
+    height: 180% !important;
+}

--- a/doc/source/_static/logo_icclim_colored__base.svg
+++ b/doc/source/_static/logo_icclim_colored__base.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eef5e5af4ee2d0d3ff6876412eac0d6491a6573c580a3b83ddfd511d2ee8b87a
+size 66313

--- a/doc/source/_static/logo_icclim_colored__displayed.svg
+++ b/doc/source/_static/logo_icclim_colored__displayed.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b355223788a5f293a3e3f4f1a4431b4937a4f4fedec7135fcd983fc923477dfc
+size 66296

--- a/doc/source/_static/logo_icclim_favicon__base.svg
+++ b/doc/source/_static/logo_icclim_favicon__base.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8082881f8418e3c4530f07785f269ad4e6723eee281984f34082b9b12d18ee62
+size 64426

--- a/doc/source/_static/logo_icclim_favicon__displayed.ico
+++ b/doc/source/_static/logo_icclim_favicon__displayed.ico
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1498370dcfec32eae795960216315a93908233f67e8b6eb2dd2ed55c2ab0726e
+size 4286

--- a/doc/source/_static/logo_icclim_grey__base.svg
+++ b/doc/source/_static/logo_icclim_grey__base.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e77578a7be1ee138a77a381110c09b2735ec551e2ad6f77a28edc9501259c276
+size 63696

--- a/doc/source/_static/logo_icclim_grey__base.svg
+++ b/doc/source/_static/logo_icclim_grey__base.svg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e77578a7be1ee138a77a381110c09b2735ec551e2ad6f77a28edc9501259c276
-size 63696
+oid sha256:f39101b5168c5f01cf4d88fff9cca6c89aee2e6508eabec5d6afa832dab24fb7
+size 63695

--- a/doc/source/_static/logo_icclim_grey__displayed.svg
+++ b/doc/source/_static/logo_icclim_grey__displayed.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:584186c219c976c57854dd0be4a7a4e755e2000eecaeb6bcb6a97cbb8707ea81
+size 63679

--- a/doc/source/_static/logo_icclim_grey__displayed.svg
+++ b/doc/source/_static/logo_icclim_grey__displayed.svg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:584186c219c976c57854dd0be4a7a4e755e2000eecaeb6bcb6a97cbb8707ea81
-size 63679
+oid sha256:5b4ec2b65ca91457d42b54aa231d3ba275324b84231c5ce397a224cfdba668c1
+size 63678

--- a/doc/source/_static/logo_icclim_white__base.svg
+++ b/doc/source/_static/logo_icclim_white__base.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ce1c2fcb8e818ac5b6535dbe8d329f4878d4a8229d901d0726d42f9533306bdf
+size 39132

--- a/doc/source/_static/logo_icclim_white__base.svg
+++ b/doc/source/_static/logo_icclim_white__base.svg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ce1c2fcb8e818ac5b6535dbe8d329f4878d4a8229d901d0726d42f9533306bdf
-size 39132
+oid sha256:f26d89699d2757ebfdb005dc47efc70e18562918a451c0c0478f18e8ae5a8f7b
+size 39038

--- a/doc/source/_static/logo_icclim_white__displayed.svg
+++ b/doc/source/_static/logo_icclim_white__displayed.svg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5ad79b6602267d494a8f52d4b4810d2d9b78cb37497b950f9ae20a423f727dc6
-size 39115
+oid sha256:7c654390dcc5acee35fa81da32bc3dd20baf6b37af2a3f7eeb6b753339a83f62
+size 39021

--- a/doc/source/_static/logo_icclim_white__displayed.svg
+++ b/doc/source/_static/logo_icclim_white__displayed.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5ad79b6602267d494a8f52d4b4810d2d9b78cb37497b950f9ae20a423f727dc6
+size 39115

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -60,6 +60,14 @@ html_logo = "logo_icclim_colored__displayed.svg"
 html_theme_options = {
     "logo_only": True,
     "display_version": False,
+    "icon_links": [
+        {
+            "name": "GitHub",
+            "url": "https://github.com/cerfacs-globc/icclim",  # required
+            "icon": "fab fa-github-square",
+            "type": "fontawesome",
+        },
+    ],
 }
 # The master toctree document.
 master_doc = "index"

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -56,9 +56,8 @@ html_theme = "pydata_sphinx_theme"
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
-html_logo = "logo_icclim_colored__displayed.svg"
+html_favicon = "_static/logo_icclim_favicon__displayed.ico"
 html_theme_options = {
-    "logo_only": True,
     "display_version": False,
     "icon_links": [
         {
@@ -68,6 +67,10 @@ html_theme_options = {
             "type": "fontawesome",
         },
     ],
+    "logo": {
+        "image_light": "_static/logo_icclim_colored__displayed.svg",
+        "image_dark": "_static/logo_icclim_white__displayed.svg",
+    },
 }
 # The master toctree document.
 master_doc = "index"

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -56,9 +56,14 @@ html_theme = "pydata_sphinx_theme"
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
+html_css_files = ["css/custom.css"]
+
 html_favicon = "_static/logo_icclim_favicon__displayed.ico"
 html_theme_options = {
-    "display_version": False,
+    "logo": {
+        "image_light": "logo_icclim_colored__displayed.svg",
+        "image_dark": "logo_icclim_white__displayed.svg",
+    },
     "icon_links": [
         {
             "name": "GitHub",
@@ -67,10 +72,6 @@ html_theme_options = {
             "type": "fontawesome",
         },
     ],
-    "logo": {
-        "image_light": "_static/logo_icclim_colored__displayed.svg",
-        "image_dark": "_static/logo_icclim_white__displayed.svg",
-    },
 }
 # The master toctree document.
 master_doc = "index"

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -56,6 +56,10 @@ html_theme = "pydata_sphinx_theme"
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
-
+html_logo = "logo_icclim_colored__displayed.svg"
+html_theme_options = {
+    "logo_only": True,
+    "display_version": False,
+}
 # The master toctree document.
 master_doc = "index"

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -34,6 +34,7 @@ extensions = [
     "sphinx.ext.autosummary",
     "sphinx.ext.intersphinx",
     "sphinx.ext.napoleon",
+    "sphinx_lfs_content",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/doc/source/references/icclim_index_api.rst
+++ b/doc/source/references/icclim_index_api.rst
@@ -59,7 +59,7 @@ The ``thresholds`` input should contain percentile thresholds that will be used 
 It allow to reuse percentiles computed and stored elsewhere easily.
 For the record, you can generate percentiles with ``save_percentile`` parameter of icclim.index.
 
-.. notes::
+.. note::
         Be aware that percentiles will **not** be bootstrapped. Thus, the result could be biased if the period on which percentiles
         were computed partially overlap the index studied period.
         See `<Computing percentile thresholds>`_ for more information on this topic.

--- a/doc/source/references/release_notes.rst
+++ b/doc/source/references/release_notes.rst
@@ -7,23 +7,23 @@ Release history
 * [enh] Make in_files.var.threshold and threshold parameters work with string values (a value with a unit or a percentile stamp)
 * [maint] **BREAKING CHANGE:** ECAD indices are no longer configurable! Use generic indices instead.
 * [fix] **BREAKING CHANGE:** ECAD indices CW, CD, WW, WD were computing the precipitation percentiles on day of year
-values where it should have been percentiles of the whole period (excluding dry days). This has been fixed.
+  values where it should have been percentiles of the whole period (excluding dry days). This has been fixed.
 * [maint] icclim no longer carries a version of the clix-meta yml file.
-Previously it was used to generate the doc string and a few metadata of ECAD indices.
-It's no longer needed as we have put these metadata within StandardIndex declaration.
+  Previously it was used to generate the doc string and a few metadata of ECAD indices.
+  It's no longer needed as we have put these metadata within StandardIndex declaration.
 * [maint] **BREAKING CHANGE:** Removed the `clipped_season` option from `slice_mode`.
-With generic indices, `season` can be used with every indices.
-In particular, spell based indices (e.g. wsdi, cdd) are mapped to `max_consecutive_occurrence` or `sum_of_spell_lengths`
-generic indicators. Both compute the spell length before doing the resampling operation.
-So a spell that start and end outside the output frequency interval is properly accounted for its whole duration.
-That's for example the case of `slice_mode="month"`, a spell that would start in january and end in March,
-would be accounted in january results.
-However, when `slice_mode` is set to a season, where time is clipped and thus where xclim `select_time` is called,
-the behavior is similar to the former `clipped_season`, we first clip the time to the expected season, then we compute the index.
-Thus, events of spells that are before the season bound will be ignored in the results.
+  With generic indices, `season` can be used with every indices.
+  In particular, spell based indices (e.g. wsdi, cdd) are mapped to `max_consecutive_occurrence` or `sum_of_spell_lengths`
+  generic indicators. Both compute the spell length before doing the resampling operation.
+  So a spell that start and end outside the output frequency interval is properly accounted for its whole duration.
+  That's for example the case of `slice_mode="month"`, a spell that would start in january and end in March,
+  would be accounted in january results.
+  However, when `slice_mode` is set to a season, where time is clipped and thus where xclim `select_time` is called,
+  the behavior is similar to the former `clipped_season`, we first clip the time to the expected season, then we compute the index.
+  Thus, events of spells that are before the season bound will be ignored in the results.
 * [maint] **BREAKING CHANGE:** User index `max_nb_consecutive_events` is also mapped to `max_consecutive_occurrence`, consequently spells are also counted for their whole duration.
 * [enh] Make it possible to pass a simple dictionary in `in_files`, merging together basic `in_files` and `var_name` features.
-It looks like `in_files={"tasmax": "tasmax.nc", "tasmin": "tasmin.zarr"}`
+  It looks like `in_files={"tasmax": "tasmax.nc", "tasmin": "tasmin.zarr"}`
 * [enh] Add `min_spell_length` parameter to index API in order to control the minimum duration of spells in `sum_of_spell_lengths`.
 * [enh] Add `rolling_window_width` parameter to index API in order to control the width of the rolling window in `max|min_of_rolling_sum|average`.
 * [enh] Add `doy_window_width` parameter to index API in order to control the width of aggregation windows when computing doy percentiles.
@@ -48,7 +48,7 @@ It looks like `in_files={"tasmax": "tasmax.nc", "tasmin": "tasmin.zarr"}`
 * [enh] ``slice_mode`` type can now be tuple[str, list], it works similarly to the list in input of seasons but, it enforces a length of 2.
 * [enh] ``slice_mode``: Added `clipped_season` keyword which ignores events starting before the season bounds (original behavior of ``season``).
 * [maint] ``slice_mode``: Modified `season` keyword to take into account events (such as in CDD) starting before the season bounds.
-This should improve the scientific validity of these seasonal computations. Plus it is in accordance to xclim way of doing this.
+  This should improve the scientific validity of these seasonal computations. Plus it is in accordance to xclim way of doing this.
 * [maint] Added dataclass ClimateIndex to ease the introduction of new indices not in the ECAD standard.
 * [maint] Made use the new typing syntax thanks to ``from __future__ import annotations``.
 * [maint] Add docstring validation into flake8 checks.

--- a/doc/source/references/release_notes.rst
+++ b/doc/source/references/release_notes.rst
@@ -32,7 +32,7 @@ It looks like `in_files={"tasmax": "tasmax.nc", "tasmin": "tasmin.zarr"}`
 * [maint] Add BlackDoc to C.I (github actions) to keep or doc code example clean.
 * [enh] Add ECAD's RR index. It computes the sum of precipitations over days.
 * [enh] Add icclim logo and auto-generate it's version number
-
+* [maint] git lfs (large file storage) has been enabled for .svg files in order to minimise the impact of logo images and their update.
 
 5.4.0
 -----

--- a/doc/source/references/release_notes.rst
+++ b/doc/source/references/release_notes.rst
@@ -31,6 +31,7 @@ It looks like `in_files={"tasmax": "tasmax.nc", "tasmin": "tasmin.zarr"}`
 * [maint] Upgrade to xclim 0.38 and to xarray 2022.6.
 * [maint] Add BlackDoc to C.I (github actions) to keep or doc code example clean.
 * [enh] Add ECAD's RR index. It computes the sum of precipitations over days.
+* [enh] Add icclim logo and auto-generate it's version number
 
 
 5.4.0

--- a/doc/source/references/release_notes.rst
+++ b/doc/source/references/release_notes.rst
@@ -53,15 +53,15 @@ Release history
 * [maint] Made use the new typing syntax thanks to ``from __future__ import annotations``.
 * [maint] Add docstring validation into flake8 checks.
 * [enh] Improve API for date related parameters ``{time_range, base_period_time_range, ref_time_range}``
-They can still be filled with a datetime object but additionally various string format are now available.
-This comes with dateparser library.
+  They can still be filled with a datetime object but additionally various string format are now available.
+  This comes with dateparser library.
 * [doc] Update callback doc as its outputted value is very inaccurate when dask is enable.
 * [enh] T(X/N/G)(10/90)p indices threshold is now configurable with `threshold` parameter.
-Example of use: `icclim.tx90p(in_files=data, threshold=[42, 99])`
+  Example of use: `icclim.tx90p(in_files=data, threshold=[42, 99])`
 * [enh|maint] threshold, history and source metadata have been updated to better describe what happens during icclim process.
 * [fix/doc] The documentation of the generated API for T(X/N/G)(10/90)p indices now properly use thier ECAD definitions instead of those from ETCCDI.
 * [enh/doc] Add [WSDI, CSDI, rxxp, rxxpTOT, CW, CD, WW, WD] indices in yaml definition.
-Note: We no longer strictly follow the yaml given by clix-meta.
+  Note: We no longer strictly follow the yaml given by clix-meta.
 * [fix] custom seasonal slice_mode was broken when it ended in december. It's now fixed and unit tested.
 * [enh] Make ``in_file`` accept a dictionary merging together ``var_name`` and ``in_file`` features.
 * [enh] ``in_file`` dictionary can now be used to pass percentiles thresholds. These thresholds will be used instead of computing them on relevant indices.
@@ -76,7 +76,7 @@ Note: We no longer strictly follow the yaml given by clix-meta.
 -----
 * [maint] Made Frequency part of SliceMode union.
 * [fix] slice_mode seasonal samplings was giving wrong results for quite a few indices. This has been fixed and the performances should also be improved by the fix.
-        However, now seasonal slice_mode does not allow to use xclim missing values mechanisms.
+  However, now seasonal slice_mode does not allow to use xclim missing values mechanisms.
 * [fix] user_index ExtremeMode config was not properly parsed when a string was used.
 * [fix] user_index Anomaly operator was not properly using the `ref_time_range` to setup a reference period as it should.
 * [fix] user_index Sum and Mean operators were broken due to a previous refactoring and a lack of unit tests, it is now fixed and tested.

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ pytest
 pyyaml
 rechunker>=0.3.3
 setuptools
+sphinx_lfs_content
 xarray>=2022.6
 xclim~=0.38.0
 zarr

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -19,6 +19,7 @@ pytest-cov
 rechunker>=0.3.3
 setuptools>=49.6.0
 sphinx
+sphinx_lfs_content
 twine
 xarray~=0.19.0
 xclim~=0.37.0

--- a/tools/update_logo_version.py
+++ b/tools/update_logo_version.py
@@ -1,0 +1,30 @@
+"""
+Icclim Logo updater.
+This should update the version number within icclim svg logo
+"""
+
+from __future__ import annotations
+
+import sys
+
+import icclim
+
+VERSION_PLACEHOLDER = "{{icclim.__version__}}"
+
+
+def run(inpath, outpath):
+    with open(inpath, "r") as in_file, open(outpath, "w") as out_file:
+        for line in in_file:
+            if VERSION_PLACEHOLDER in line:
+                line = line.replace(VERSION_PLACEHOLDER, str(icclim.__version__))
+            out_file.write(line)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 3:
+        raise NotImplementedError(
+            "This script needs 2 arguments,"
+            " the input file path where a placeholder exists"
+            " and the output file path"
+        )
+    run(sys.argv[1], sys.argv[2])


### PR DESCRIPTION
<!--
The following checklist points should all be checked before merging the PR.

Please replace xxx by your issue number (leave the prefixing '#').
-->

### Pull Request to resolve #125 
- [na] Unit tests cover the changes.
- [na] These changes were tested on real data.
- [x] The relevant documentation has been added or updated.
- [x] A short description of the changes has been added to `doc/source/references/release_notes.rst`.

### Describe the changes you made
Add icclim logo

## BREAKING CHANGE
This PR introduce [git lfs ](https://git-lfs.github.com/) to icclim repository to store logo images.
This doesn't break anything per se, but contributors would need to manually init lfs locally if (and only if) they need to edit lfs stored files.
As for the why, even if our logo svg images are quite small (around 65KB), every version of icclim will update the version number within the svg. There is absolutely no need to version each updated logo image that's why git lfs seems to be a good option here. It allows to 1. store the latest image version in the repo, 2. store the updates within a lightweight text file.

In the future, we could also benefit from lfs when we would add a netcdf example file to lfs in order to automatize some integration tests.



