### PR TITLE
ENH: Add BoundedThreshold

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,7 @@ For a detailed description of each ECA&D index, please visit: https://www.ecad.e
 ..
   Pytest Coverage Comment:Begin
 
-.. |coverage| image:: https://img.shields.io/badge/Coverage-93%25-brightgreen.svg
+.. |coverage| image:: https://img.shields.io/badge/Coverage-90%25-brightgreen.svg
         :target: https://github.com/cerfacs-globc/icclim/blob/master/README.rst#code-coverage
         :alt: Code coverage
 

--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,7 @@ For a detailed description of each ECA&D index, please visit: https://www.ecad.e
 ..
   Pytest Coverage Comment:Begin
 
-.. |coverage| image:: https://img.shields.io/badge/Coverage-90%25-brightgreen.svg
+.. |coverage| image:: https://img.shields.io/badge/Coverage-91%25-brightgreen.svg
         :target: https://github.com/cerfacs-globc/icclim/blob/master/README.rst#code-coverage
         :alt: Code coverage
 

--- a/doc/source/references/ecad_functions_api.rst
+++ b/doc/source/references/ecad_functions_api.rst
@@ -78,6 +78,7 @@ Generated API
         cw
         wd
         ww
+        ddnorth
         custom_index
 
         .. Generated API comment:End

--- a/doc/source/references/release_notes.rst
+++ b/doc/source/references/release_notes.rst
@@ -36,6 +36,10 @@ Release history
 * [enh] Improve icclim.indices to enable multi indices computation based on variable names `icclim.indices(index_group='tasmax',in_files=data)`
 * [fix] **BREAKING CHANGE** ECAD snow indices are now expecting a snow (snd) variable instead of a precipitation one.
 * [enh] Add `build_threshold` function that acts as a factory to create different kind of Threshold.
+* [enh] Add BoundedThreshold class. It allows to compute multiple threshold for a single variable.
+  This feature is necessary for indices such as ECAD's "DDnorth".
+  Instances of BoundedThreshold are created with the `build_threshold` factory function, E.G. `build_threshold(">= -20 degree AND <= 20 degree ")`
+
 
 5.4.0
 -----

--- a/doc/source/references/release_notes.rst
+++ b/doc/source/references/release_notes.rst
@@ -39,7 +39,8 @@ Release history
 * [enh] Add BoundedThreshold class. It allows to compute multiple threshold for a single variable.
   This feature is necessary for indices such as ECAD's "DDnorth".
   Instances of BoundedThreshold are created with the `build_threshold` factory function, E.G. `build_threshold(">= -20 degree AND <= 20 degree ")`
-
+* [enh] Make it possible to compute multiple percentiles at once.
+* [maint] Update coverage computation. Now tests files are ignored when calculating the code coverage, thus it dropped a little (by 3%).
 
 5.4.0
 -----

--- a/icclim/_generated_api.py
+++ b/icclim/_generated_api.py
@@ -2541,7 +2541,7 @@ def cdd(
         logs_verbosity=logs_verbosity,
         date_event=date_event,
         threshold=build_threshold(
-            query="< 1 mm day-1",
+            query="< 1 mm/day",
         ),
         out_unit="day",
     )
@@ -2623,7 +2623,7 @@ def prcptot(
         logs_verbosity=logs_verbosity,
         date_event=date_event,
         threshold=build_threshold(
-            query=">= 1 mm day-1",
+            query=">= 1 mm/day",
         ),
         out_unit="mm",
     )
@@ -2705,7 +2705,7 @@ def rr1(
         logs_verbosity=logs_verbosity,
         date_event=date_event,
         threshold=build_threshold(
-            query=">= 1 mm day-1",
+            query=">= 1 mm/day",
         ),
         out_unit="day",
     )
@@ -2787,9 +2787,9 @@ def sdii(
         logs_verbosity=logs_verbosity,
         date_event=date_event,
         threshold=build_threshold(
-            query=">= 1 mm day-1",
+            query=">= 1 mm/day",
         ),
-        out_unit="mm day-1",
+        out_unit="mm/day",
     )
 
 
@@ -2869,7 +2869,7 @@ def cwd(
         logs_verbosity=logs_verbosity,
         date_event=date_event,
         threshold=build_threshold(
-            query=">= 1 mm day-1",
+            query=">= 1 mm/day",
         ),
         out_unit="day",
     )
@@ -3030,7 +3030,7 @@ def r10mm(
         logs_verbosity=logs_verbosity,
         date_event=date_event,
         threshold=build_threshold(
-            query=">= 10 mm day-1",
+            query=">= 10 mm/day",
         ),
         out_unit="day",
     )
@@ -3112,7 +3112,7 @@ def r20mm(
         logs_verbosity=logs_verbosity,
         date_event=date_event,
         threshold=build_threshold(
-            query=">= 20 mm day-1",
+            query=">= 20 mm/day",
         ),
         out_unit="day",
     )
@@ -3193,7 +3193,7 @@ def rx1day(
         netcdf_version=netcdf_version,
         logs_verbosity=logs_verbosity,
         date_event=date_event,
-        out_unit="mm day-1",
+        out_unit="mm/day",
     )
 
 

--- a/icclim/_generated_api.py
+++ b/icclim/_generated_api.py
@@ -71,6 +71,7 @@ __all__ = [
     "cw",
     "wd",
     "ww",
+    "ddnorth",
     "custom_index",
 ]
 
@@ -4823,6 +4824,88 @@ def ww(
                 threshold_min_value="1.0 millimeter / day",
             ),
         ],
+        out_unit="day",
+    )
+
+
+def ddnorth(
+    in_files: InFileLike,
+    var_name: str | Sequence[str] | None = None,
+    slice_mode: FrequencyLike | Frequency = "year",
+    time_range: Sequence[datetime | str] | None = None,
+    out_file: str | None = None,
+    ignore_Feb29th: bool = False,
+    netcdf_version: str | NetcdfVersion = "NETCDF4",
+    logs_verbosity: Verbosity | str = "LOW",
+    date_event: bool = False,
+) -> Dataset:
+    """
+    DDnorth: Days with northerly winds (-45 degree < DD ≤ 45 degree)
+
+    Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
+
+    Parameters
+    ----------
+
+    in_files: str | list[str] | Dataset | DataArray | InputDictionary
+        Absolute path(s) to NetCDF dataset(s), including OPeNDAP URLs,
+        or path to zarr store, or xarray.Dataset or xarray.DataArray.
+    var_name: str | list[str] | None
+        ``optional`` Target variable name to process corresponding to ``in_files``.
+        If None (default) on ECA&D index, the variable is guessed based on the climate
+        index wanted.
+        Mandatory for a user index.
+    slice_mode: SliceMode
+        Type of temporal aggregation:
+        The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
+        "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
+        (where season and month lists can be customized) or any valid pandas frequency.
+        A season can also be defined between two exact dates:
+        ``("season", ("19 july", "14 august"))``.
+        Default is "year".
+        See :ref:`slice_mode` for details.
+    time_range: list[datetime ] | list[str]  | tuple[str, str] | None
+        ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
+        If ``None``, whole period of input files will be processed.
+        The dates can either be given as instance of datetime.datetime or as string
+        values. For strings, many format are accepted.
+        Default is ``None``.
+    out_file: str | None
+        Output NetCDF file name (default: "icclim_out.nc" in the current directory).
+        Default is "icclim_out.nc".
+        If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
+        Use the function returned value instead to retrieve the computed value.
+        If ``out_file`` already exists, icclim will overwrite it!
+    ignore_Feb29th: bool
+        ``optional`` Ignoring or not February 29th (default: False).
+    netcdf_version: str | NetcdfVersion
+        ``optional`` NetCDF version to create (default: "NETCDF3_CLASSIC").
+    logs_verbosity: str | Verbosity
+        ``optional`` Configure how verbose icclim is.
+        Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
+    date_event: bool
+        When True the date of the event (such as when a maximum is reached) will be
+        stored in coordinates variables.
+        **warning** This option may significantly slow down computation.
+    Notes
+    -----
+    This function has been auto-generated.
+
+    """
+    return icclim.index(
+        index_name="DDNORTH",
+        in_files=in_files,
+        var_name=var_name,
+        slice_mode=slice_mode,
+        time_range=time_range,
+        out_file=out_file,
+        ignore_Feb29th=ignore_Feb29th,
+        netcdf_version=netcdf_version,
+        logs_verbosity=logs_verbosity,
+        date_event=date_event,
+        threshold=build_threshold(
+            query="> -45 degree AND <= 45 degree",
+        ),
         out_unit="day",
     )
 

--- a/icclim/ecad/ecad_indices.py
+++ b/icclim/ecad/ecad_indices.py
@@ -348,7 +348,7 @@ class EcadIndexRegistry(Registry[StandardIndex]):
     CDD = StandardIndex(
         reference=ECAD_REFERENCE,
         generic_indicator=GenericIndicatorRegistry.MaxConsecutiveOccurrence,
-        threshold="< 1 mm day-1",
+        threshold="< 1 mm/day",
         output_unit="day",
         definition="Maximum consecutive dry days (Precip < 1mm)",
         source=ECAD_ATBD,
@@ -360,7 +360,7 @@ class EcadIndexRegistry(Registry[StandardIndex]):
     PRCPTOT = StandardIndex(
         reference=ECAD_REFERENCE,
         generic_indicator=GenericIndicatorRegistry.Sum,
-        threshold=">= 1 mm day-1",
+        threshold=">= 1 mm/day",
         output_unit="mm",
         definition="Total precipitation during Wet Days",
         source=ECAD_ATBD,
@@ -371,7 +371,7 @@ class EcadIndexRegistry(Registry[StandardIndex]):
     RR1 = StandardIndex(
         reference=ECAD_REFERENCE,
         generic_indicator=GenericIndicatorRegistry.CountOccurrences,
-        threshold=">= 1 mm day-1",
+        threshold=">= 1 mm/day",
         output_unit="day",
         definition="Number of Wet Days (precip >= 1 mm)",
         source=ECAD_ATBD,
@@ -382,8 +382,8 @@ class EcadIndexRegistry(Registry[StandardIndex]):
     SDII = StandardIndex(
         reference=ECAD_REFERENCE,
         generic_indicator=GenericIndicatorRegistry.Average,
-        threshold=">= 1 mm day-1",
-        output_unit="mm day-1",
+        threshold=">= 1 mm/day",
+        output_unit="mm/day",
         definition="Average precipitation during Wet Days (SDII)",
         source=ECAD_ATBD,
         short_name="SDII",
@@ -393,7 +393,7 @@ class EcadIndexRegistry(Registry[StandardIndex]):
     CWD = StandardIndex(
         reference=ECAD_REFERENCE,
         generic_indicator=GenericIndicatorRegistry.MaxConsecutiveOccurrence,
-        threshold=">= 1 mm day-1",
+        threshold=">= 1 mm/day",
         output_unit="day",
         definition="Maximum consecutive wet days (Precip >= 1mm)",
         source=ECAD_ATBD,
@@ -414,7 +414,7 @@ class EcadIndexRegistry(Registry[StandardIndex]):
     R10MM = StandardIndex(
         reference=ECAD_REFERENCE,
         generic_indicator=GenericIndicatorRegistry.CountOccurrences,
-        threshold=">= 10 mm day-1",
+        threshold=">= 10 mm/day",
         output_unit="day",
         definition="Number of heavy precipitation days (Precip >=10mm)",
         source=ECAD_ATBD,
@@ -425,7 +425,7 @@ class EcadIndexRegistry(Registry[StandardIndex]):
     R20MM = StandardIndex(
         reference=ECAD_REFERENCE,
         generic_indicator=GenericIndicatorRegistry.CountOccurrences,
-        threshold=">= 20 mm day-1",
+        threshold=">= 20 mm/day",
         output_unit="day",
         definition="Number of very heavy precipitation days (Precip >= 20mm)",
         source=ECAD_ATBD,
@@ -436,7 +436,7 @@ class EcadIndexRegistry(Registry[StandardIndex]):
     RX1DAY = StandardIndex(
         reference=ECAD_REFERENCE,
         generic_indicator=GenericIndicatorRegistry.Maximum,
-        output_unit="mm day-1",
+        output_unit="mm/day",
         definition="maximum 1-day total precipitation",  # from xclim
         source=ECAD_ATBD,
         short_name="RX1day",

--- a/icclim/ecad/ecad_indices.py
+++ b/icclim/ecad/ecad_indices.py
@@ -645,3 +645,15 @@ class EcadIndexRegistry(Registry[StandardIndex]):
         qualifiers=[QUANTILE_BASED],
         doy_window_width=5,
     )
+    # WIND
+    DDNORTH = StandardIndex(
+        reference=ECAD_REFERENCE,
+        generic_indicator=GenericIndicatorRegistry.CountOccurrences,
+        threshold="> -45 degree AND <= 45 degree",
+        output_unit="day",
+        definition="Days with northerly winds (-45 degree < DD ≤ 45 degree)",
+        source=ECAD_ATBD,
+        short_name="DDnorth",
+        group=IndexGroupRegistry.WIND,
+        input_variables=[StandardVariableRegistry.WIND_TO_DIRECTION],
+    )

--- a/icclim/generic_indices/generic_indicators.py
+++ b/icclim/generic_indices/generic_indicators.py
@@ -14,7 +14,6 @@ import pint
 import xarray as xr
 from jinja2 import Environment
 from pint import DefinitionSyntaxError, Quantity, UndefinedUnitError
-from utils import icc_convert_units_to
 from xarray import DataArray
 from xarray.core.resample import DataArrayResample
 from xarray.core.rolling import DataArrayRolling
@@ -24,6 +23,7 @@ from xclim.core.datachecks import check_freq
 from xclim.core.missing import MissingBase
 from xclim.core.options import MISSING_METHODS, MISSING_OPTIONS, OPTIONS
 from xclim.core.units import rate2amount, str2pint, to_agg_units
+from xclim.core.units import units as xc_units
 from xclim.indices import run_length
 
 from icclim.generic_indices.generic_templates import INDICATORS_TEMPLATES_EN
@@ -44,6 +44,7 @@ from icclim.models.logical_link import LogicalLink
 from icclim.models.operator import OperatorRegistry
 from icclim.models.registry import Registry
 from icclim.models.threshold import PercentileThreshold, Threshold
+from icclim.utils import icc_convert_units_to
 
 jinja_env = Environment()
 
@@ -1058,7 +1059,7 @@ def _add_date_coords(
 
 def _is_amount_unit(unit: str) -> bool:
     try:
-        return pint.Unit(unit) in pint.Unit("meter").compatible_units()
+        return xc_units.Unit(unit) in pint.Unit("meter").compatible_units()
     except (UndefinedUnitError, DefinitionSyntaxError):
         return False
 

--- a/icclim/generic_indices/generic_templates.py
+++ b/icclim/generic_indices/generic_templates.py
@@ -15,9 +15,6 @@ COMBINED_VARS_LONG_NAME = (
     "{% for i, climate_var in enumerate(climate_vars) %}"
         "{{climate_var.long_name}} is"
         " {{climate_var.threshold.long_name}}"
-        "{% if climate_var.threshold.additional_metadata %}"
-            " {{climate_var.threshold.additional_metadata}}."
-        "{% endif %}"
         "{% if i != len(climate_vars) - 1 %}"
             " And "
         "{% endif%}"
@@ -27,6 +24,7 @@ COMBINED_VARS_LONG_NAME = (
 COMBINED_VARS_STANDARD_NAME = (
     "{% for i, climate_var in enumerate(climate_vars) %}"
         "{{climate_var.standard_name}}"
+        "_is_{{climate_var.threshold.standard_name}}"
         "{% if i != len(climate_vars) - 1 %}"
             "_and_"
         "{% endif %}"
@@ -35,22 +33,17 @@ COMBINED_VARS_STANDARD_NAME = (
 SINGLE_VAR_LONG_NAME = (
     "{{source_freq.adjective}}"
     " {{climate_vars[0].long_name}}"
-    " related to{{climate_vars[0].threshold.value}}"
+    " related to {{climate_vars[0].threshold.value}}"
     " for each {{output_freq.long_name}}."
-    "{% if climate_vars[0].threshold.additional_metadata %}"
-        " {{climate_vars[0].threshold.additional_metadata}}"
-    "{% endif %}"
 )
 SINGLE_VAR_LONG_NAME_WITH_EXCEEDANCE = (
     "{{source_freq.adjective}}"
     " {{climate_vars[0].long_name}}"
     "{% if climate_vars[0].threshold %}"
-        " when {{climate_vars[0].long_name}} is {{climate_vars[0].threshold.long_name}}"
+        " when {{climate_vars[0].long_name}}"
+        " is {{climate_vars[0].threshold.long_name}}"
     "{% endif %}"
     " for each {{output_freq.long_name}}."
-    "{% if climate_vars[0].threshold.additional_metadata %}"
-        " {{climate_vars[0].threshold.additional_metadata}}"
-    "{% endif %}"
 )
 
 INDICATORS_TEMPLATES_EN: dict[str, IndicatorMetadata] = {
@@ -58,14 +51,12 @@ INDICATORS_TEMPLATES_EN: dict[str, IndicatorMetadata] = {
         "long_name":     "Number of {{source_freq.units}}"
                          f" when {COMBINED_VARS_LONG_NAME}",
         "standard_name": "number_of_{{source_freq.units}}_with"
-                         f"_{COMBINED_VARS_STANDARD_NAME}"
-                         "_above_threshold",
+                         f"_{COMBINED_VARS_STANDARD_NAME}",
         "cell_methods":  "time: sum over {{source_freq.units}}",
     },
     "max_consecutive_occurrence": {
         "standard_name": "spell_length_of_{{source_freq.units}}_with"
-                         f"_{COMBINED_VARS_STANDARD_NAME}"
-                         "_above_threshold",
+                         f"_{COMBINED_VARS_STANDARD_NAME}",
         "long_name":     "Maximum number of consecutive {{source_freq.units}} when"
                          f" {COMBINED_VARS_LONG_NAME}",
         "cell_methods":  "time: maximum over {{source_freq.units}}",
@@ -73,8 +64,7 @@ INDICATORS_TEMPLATES_EN: dict[str, IndicatorMetadata] = {
     "sum_of_spell_lengths": {
         "standard_name":  # not CF
                         "spell_length_of_{{source_freq.units}}_with"
-                        f"_{COMBINED_VARS_STANDARD_NAME}"
-                        "_above_thresholds",
+                        f"_{COMBINED_VARS_STANDARD_NAME}",
         "long_name":    "Sum of spell lengths of at least {{min_spell_length}}"
                         " {{source_freq.units}} when"
                         f" {COMBINED_VARS_LONG_NAME}",

--- a/icclim/generic_indices/generic_templates.py
+++ b/icclim/generic_indices/generic_templates.py
@@ -50,7 +50,7 @@ INDICATORS_TEMPLATES_EN: dict[str, IndicatorMetadata] = {
     "count_occurrences": {
         "long_name":     "Number of {{source_freq.units}}"
                          f" when {COMBINED_VARS_LONG_NAME}",
-        "standard_name": "number_of_{{source_freq.units}}_with"
+        "standard_name": "number_of_{{source_freq.units}}_when"
                          f"_{COMBINED_VARS_STANDARD_NAME}",
         "cell_methods":  "time: sum over {{source_freq.units}}",
     },

--- a/icclim/generic_indices/generic_templates.py
+++ b/icclim/generic_indices/generic_templates.py
@@ -6,7 +6,6 @@ from typing import TypedDict
 # flake8: noqa
 
 class IndicatorMetadata(TypedDict):
-    identifier: str
     standard_name: str
     long_name: str
     cell_methods: str

--- a/icclim/generic_indices/threshold_templates.py
+++ b/icclim/generic_indices/threshold_templates.py
@@ -4,8 +4,8 @@ from typing import Any, TypedDict
 
 # fmt: off
 # flake8: noqa
+from numpy import ndarray
 from pint import Quantity
-from xarray import DataArray
 
 
 class ThresholdMetadata(TypedDict):
@@ -20,6 +20,7 @@ class ThresholdTemplateDict(TypedDict):
     multiple_doy_percentiles: ThresholdMetadata
     single_period_percentile: ThresholdMetadata
     multiple_period_percentiles: ThresholdMetadata
+    bounded_threshold: ThresholdMetadata
 
 class PercentileTemplateConfig(TypedDict, total=False):
     climatology_bounds: list[str]
@@ -27,7 +28,7 @@ class PercentileTemplateConfig(TypedDict, total=False):
     src_freq: Any
     operator: Any
     unit: str | None
-    per_coord: DataArray | float
+    per_coord: ndarray | float
     threshold_min_value: Quantity | None
     must_run_bootstrap: bool
 
@@ -68,7 +69,7 @@ EN_THRESHOLD_TEMPLATE: ThresholdTemplateDict = {
                              " and {{max_value}}"
                              " {{unit}}."
                          "{% endif %}"
-                         "{% if threshold_min_value is not None %}"
+                         "{% if threshold_min_value %}"
                              f" {THRESHOLD_MIN_VALUE_TEMPLATE}"
                          "{% endif %}",
         "short_name":    "{{operator.short_name}}_threshold",
@@ -77,7 +78,7 @@ EN_THRESHOLD_TEMPLATE: ThresholdTemplateDict = {
         "standard_name": "{{operator.standard_name}}_doy_percentile_threshold",
         "long_name":     "{{operator.long_name}}"
                          " {{per_coord}}th day of year percentile"
-                         "{% if threshold_min_value is not None %}"
+                         "{% if threshold_min_value %}"
                              f" {THRESHOLD_MIN_VALUE_TEMPLATE}"
                          "{% endif %}",
         "short_name":    "doy_per_threshold",
@@ -86,7 +87,7 @@ EN_THRESHOLD_TEMPLATE: ThresholdTemplateDict = {
         "standard_name": "{{operator.standard_name}}_doy_percentile_thresholds",
         "long_name":     "{{operator.long_name}}"
                          " {{per_coord}} day of year percentiles"
-                         "{% if threshold_min_value is not None %}"
+                         "{% if threshold_min_value %}"
                              f" {THRESHOLD_MIN_VALUE_TEMPLATE}"
                          "{% endif %}",
         "short_name":    "doy_per_thresholds",
@@ -95,7 +96,7 @@ EN_THRESHOLD_TEMPLATE: ThresholdTemplateDict = {
         "standard_name": "{{operator.standard_name}}_period_percentile_threshold",
         "long_name":     "{{operator.long_name}}"
                          " {{per_coord}}th period percentile"
-                         "{% if threshold_min_value is not None %}"
+                         "{% if threshold_min_value %}"
                              f" {THRESHOLD_MIN_VALUE_TEMPLATE}"
                          "{% endif %}",
         "short_name":    "period_per_threshold",
@@ -104,9 +105,20 @@ EN_THRESHOLD_TEMPLATE: ThresholdTemplateDict = {
         "standard_name": "{{operator.standard_name}}_period_percentile_thresholds",
         "long_name":     "{{operator.long_name}}"
                          " {{per_coord}} period percentiles"
-                         "{% if threshold_min_value is not None %}"
+                         "{% if threshold_min_value %}"
                              f" {THRESHOLD_MIN_VALUE_TEMPLATE}"
                          "{% endif %}",
         "short_name":    "period_per_thresholds",
+    },
+    "bounded_threshold": {
+        "standard_name": "{{left_threshold.standard_name}}"
+                         "_{{logical_link.standard_name}}"
+                         "_{{right_threshold.standard_name}}",
+        "long_name":     "{{left_threshold.long_name}}"
+                         " {{logical_link.long_name}}"
+                         " {{right_threshold.long_name}}",
+        "short_name":    "{{left_threshold.short_name}}"
+                         "_{{logical_link.short_name}}"
+                         "_{{right_threshold.short_name}}",
     },
 }

--- a/icclim/main.py
+++ b/icclim/main.py
@@ -454,7 +454,7 @@ def index(
         date_event=date_event,
         sampling_method=sampling_method,
     )
-    result_ds = _compute_standard_climate_index(
+    result_ds = _compute_climate_index(
         climate_index=indicator,
         config=config,
         initial_history=climate_vars[0].global_metadata["history"],
@@ -553,7 +553,7 @@ def _get_unit(output_unit: str | None, da: DataArray) -> str | None:
         return da_unit
 
 
-def _compute_standard_climate_index(
+def _compute_climate_index(
     climate_index: GenericIndicator | None,
     config: IndexConfig,
     initial_history: str | None,

--- a/icclim/models/constants.py
+++ b/icclim/models/constants.py
@@ -49,6 +49,7 @@ DOY_PERCENTILE_UNIT = "doy_per"
 
 # Mapping of frequencies to generate metadata
 # copied from xclim and updated.
+# todo: we should probably turn that mapping to jinja templates to make it easier to maintain
 EN_FREQ_MAPPING = {
     "YS": "year(s)", "Y": "year(s)", "AS": "year(s)", "A": "year(s)",
     "QS": "season(s)", "Q": "season(s)",

--- a/icclim/models/frequency.py
+++ b/icclim/models/frequency.py
@@ -478,7 +478,7 @@ def _get_long_name(pandas_freq: str) -> str:
     freqs = [EN_FREQ_MAPPING[f] for f in freqs]
     freqs = " ".join(freqs)
     if multiplier:
-        return multiplier[0] + freqs
+        return f"{multiplier[0]} {freqs}"
     else:
         return freqs
 

--- a/icclim/models/logical_link.py
+++ b/icclim/models/logical_link.py
@@ -23,8 +23,10 @@ class LogicalLinkRegistry(Registry[LogicalLink]):
     _item_class = LogicalLink
 
     LOGICAL_OR = LogicalLink(
-        "or", lambda data_list: reduce(np.logical_or, data_list)  # type:ignore
+        name="or",
+        compute=lambda data_list: reduce(np.logical_or, data_list),  # type:ignore
     )
     LOGICAL_AND = LogicalLink(
-        "and", lambda data_list: reduce(np.logical_and, data_list)  # type:ignore
+        name="and",
+        compute=lambda data_list: reduce(np.logical_and, data_list),  # type:ignore
     )

--- a/icclim/models/logical_link.py
+++ b/icclim/models/logical_link.py
@@ -13,6 +13,9 @@ from icclim.models.registry import Registry
 @dataclasses.dataclass
 class LogicalLink:
     name: str
+    standard_name: str
+    long_name: str
+    short_name: str
     compute: Callable[[list[DataArray]], DataArray]
 
     def __call__(self, *args, **kwargs) -> DataArray:
@@ -24,9 +27,15 @@ class LogicalLinkRegistry(Registry[LogicalLink]):
 
     LOGICAL_OR = LogicalLink(
         name="or",
+        standard_name="OR",
+        long_name="OR",
+        short_name="OR",
         compute=lambda data_list: reduce(np.logical_or, data_list),  # type:ignore
     )
     LOGICAL_AND = LogicalLink(
         name="and",
+        standard_name="AND",
+        long_name="AND",
+        short_name="AND",
         compute=lambda data_list: reduce(np.logical_and, data_list),  # type:ignore
     )

--- a/icclim/models/registry.py
+++ b/icclim/models/registry.py
@@ -20,7 +20,7 @@ class Registry(Generic[T]):
     tables for items with aliases and no case sensitivity.
     """
 
-    _item_class: type  # runtime T
+    _item_class: type  # runtime type for the generic `T`
 
     def __init__(self):
         raise NotImplementedError("Don't instantiate Registry, use its class methods.")

--- a/icclim/models/threshold.py
+++ b/icclim/models/threshold.py
@@ -780,7 +780,7 @@ def _read_bounded_threshold(
             raise NotImplementedError(f"Unknown type '{type(t)}'")
     if len(acc) > 2:
         raise NotImplementedError(
-            "Can't build BoundedThreshold on more than 2" " thresholds."
+            "Can't build BoundedThreshold on more than 2 thresholds."
         )
     return {  # noqa
         "initial_query": None,

--- a/icclim/pre_processing/input_parsing.py
+++ b/icclim/pre_processing/input_parsing.py
@@ -9,7 +9,6 @@ import xclim
 from pint import Quantity
 from xarray.core.dataarray import DataArray
 from xarray.core.dataset import Dataset
-from xclim.core.units import convert_units_to
 from xclim.core.utils import PercentileDataArray
 
 from icclim.generic_indices.cf_var_metadata import (
@@ -21,7 +20,7 @@ from icclim.icclim_types import InFileBaseType
 from icclim.models.cf_calendar import CfCalendarRegistry
 from icclim.models.constants import UNITS_KEY, VALID_PERCENTILE_DIMENSION
 from icclim.models.standard_index import StandardIndex
-from icclim.utils import get_date_to_iso_format
+from icclim.utils import get_date_to_iso_format, icc_convert_units_to
 
 DEFAULT_INPUT_FREQUENCY = "days"
 
@@ -289,7 +288,9 @@ def read_threshold_DataArray(
     else:
         if threshold_min_value:
             if isinstance(threshold_min_value, str):
-                threshold_min_value = convert_units_to(threshold_min_value, thresh_da)
+                threshold_min_value = icc_convert_units_to(
+                    threshold_min_value, thresh_da
+                )
             # todo in prcptot the replacing value (np.nan) needs to be 0
             built_value = thresh_da.where(thresh_da > threshold_min_value, np.nan)
         else:
@@ -319,6 +320,8 @@ def build_reference_da(
     if only_leap_years:
         reference = reduce_only_leap_years(original_da)
     if percentile_min_value is not None:
-        percentile_min_value = convert_units_to(str(percentile_min_value), reference)
+        percentile_min_value = icc_convert_units_to(
+            str(percentile_min_value), reference
+        )
         reference = reference.where(reference >= percentile_min_value, np.nan)
     return reference

--- a/icclim/pre_processing/input_parsing.py
+++ b/icclim/pre_processing/input_parsing.py
@@ -9,6 +9,7 @@ import xclim
 from pint import Quantity
 from xarray.core.dataarray import DataArray
 from xarray.core.dataset import Dataset
+from xclim.core.units import convert_units_to
 from xclim.core.utils import PercentileDataArray
 
 from icclim.generic_indices.cf_var_metadata import (
@@ -20,7 +21,7 @@ from icclim.icclim_types import InFileBaseType
 from icclim.models.cf_calendar import CfCalendarRegistry
 from icclim.models.constants import UNITS_KEY, VALID_PERCENTILE_DIMENSION
 from icclim.models.standard_index import StandardIndex
-from icclim.utils import get_date_to_iso_format, icc_convert_units_to
+from icclim.utils import get_date_to_iso_format
 
 DEFAULT_INPUT_FREQUENCY = "days"
 
@@ -298,9 +299,7 @@ def read_threshold_DataArray(
     else:
         if threshold_min_value:
             if isinstance(threshold_min_value, str):
-                threshold_min_value = icc_convert_units_to(
-                    threshold_min_value, thresh_da
-                )
+                threshold_min_value = convert_units_to(threshold_min_value, thresh_da)
             # todo in prcptot the replacing value (np.nan) needs to be 0
             built_value = thresh_da.where(thresh_da > threshold_min_value, np.nan)
         else:
@@ -330,8 +329,6 @@ def build_reference_da(
     if only_leap_years:
         reference = reduce_only_leap_years(original_da)
     if percentile_min_value is not None:
-        percentile_min_value = icc_convert_units_to(
-            str(percentile_min_value), reference
-        )
+        percentile_min_value = convert_units_to(str(percentile_min_value), reference)
         reference = reference.where(reference >= percentile_min_value, np.nan)
     return reference

--- a/icclim/pre_processing/input_parsing.py
+++ b/icclim/pre_processing/input_parsing.py
@@ -170,7 +170,7 @@ def _guess_dataset_var_names(
             for alias in expected_standard_var.aliases:
                 # check if dataset contains this alias
                 if _is_alias_valid(ds, alias):
-                    climate_var_names.append(alias)
+                    climate_var_names.append(_get_actual_name(ds, alias))
                     break
         if len(climate_var_names) < len(standard_index.input_variables):
             raise InvalidIcclimArgumentError(error_msg)
@@ -247,8 +247,18 @@ def check_time_range_post_validity(da, original_da, key: str, tr: list) -> None:
         )
 
 
-def _is_alias_valid(ds, alias):
-    return ds.get(alias, None) is not None
+def _is_alias_valid(ds, alias) -> bool:
+    for ds_var in ds.data_vars:
+        if str(ds_var).upper() == alias.upper():
+            return True
+    return False
+
+
+def _get_actual_name(ds, alias) -> str:
+    for ds_var in ds.data_vars:
+        if str(ds_var).upper() == alias.upper():
+            return ds_var
+    raise KeyError(f"Could not find {alias} in dataset.")
 
 
 def get_name_of_first_var(ds: Dataset) -> str:

--- a/icclim/tests/test_main.py
+++ b/icclim/tests/test_main.py
@@ -350,6 +350,8 @@ class Test_Integration:
         ds["pr"].attrs[UNITS_KEY] = "kg m-2 d-1"
         ds["snd"] = self.data.copy(deep=True)
         ds["snd"].attrs[UNITS_KEY] = "cm"
+        ds["DD"] = self.data.copy(deep=True)
+        ds["DD"].attrs[UNITS_KEY] = "degree"
         res = icclim.indices(index_group="all", in_files=ds, out_file=self.OUTPUT_FILE)
         for i in EcadIndexRegistry.values():
             assert res[i.short_name] is not None
@@ -362,6 +364,8 @@ class Test_Integration:
         ds["pr"].attrs[UNITS_KEY] = "kg m-2 d-1"
         ds["snd"] = self.data.copy(deep=True)
         ds["snd"].attrs[UNITS_KEY] = "cm"
+        ds["DD"] = self.data.copy(deep=True)
+        ds["DD"].attrs[UNITS_KEY] = "degree"
         res = icclim.indices(
             index_group="all",
             in_files=ds,
@@ -379,6 +383,8 @@ class Test_Integration:
         ds["pr"].attrs[UNITS_KEY] = "kg m-2 d-1"
         ds["snd"] = self.data.copy(deep=True)
         ds["snd"].attrs[UNITS_KEY] = "cm"
+        ds["DD"] = self.data.copy(deep=True)
+        ds["DD"].attrs[UNITS_KEY] = "degree"
         res = icclim.indices(
             index_group="all",
             in_files=ds,
@@ -396,6 +402,8 @@ class Test_Integration:
         ds["pr"].attrs[UNITS_KEY] = "kg m-2 d-1"
         ds["snd"] = self.data.copy(deep=True)
         ds["snd"].attrs[UNITS_KEY] = "cm"
+        ds["DD"] = self.data.copy(deep=True)
+        ds["DD"].attrs[UNITS_KEY] = "degree"
         res = icclim.indices(
             index_group="all",
             in_files=ds,
@@ -413,6 +421,8 @@ class Test_Integration:
         ds["pr"].attrs[UNITS_KEY] = "kg m-2 d-1"
         ds["snd"] = self.data.copy(deep=True)
         ds["snd"].attrs[UNITS_KEY] = "cm"
+        ds["DD"] = self.data.copy(deep=True)
+        ds["DD"].attrs[UNITS_KEY] = "degree"
         res = icclim.indices(
             index_group="all",
             in_files=ds,
@@ -428,6 +438,8 @@ class Test_Integration:
         ds["tasmin"] = self.data
         ds["pr"] = self.data.copy(deep=True)
         ds["pr"].attrs[UNITS_KEY] = "kg m-2 d-1"
+        ds["DD"] = self.data.copy(deep=True)
+        ds["DD"].attrs[UNITS_KEY] = "degree"
         res: xr.Dataset = icclim.indices(
             index_group="all",
             in_files=ds,
@@ -812,3 +824,22 @@ class Test_Integration:
         # the index
         np.testing.assert_almost_equal(rr.RR.isel(time=0), 5.3)
         np.testing.assert_almost_equal(rr.RR.isel(time=1), 0)
+
+    def test_ddnorth(self):
+        # GIVEN
+        time_range = xr.DataArray(
+            pd.date_range("2000", periods=365, freq="D"), dims=["time"]
+        )
+        dd = xr.DataArray(
+            np.zeros(365),
+            coords={"time": time_range, "lat": 1, "lon": 1},
+            dims="time",
+            attrs={"units": "degree"},
+        )
+        dd.loc[{"time": slice("2000-01-01", "2000-01-05")}] = 50
+        dd.loc[{"time": slice("2000-03-01", "2000-03-02")}] = -50
+        # WHEN
+        ddnorth = icclim.ddnorth(in_files=dd, slice_mode="month")
+        # THEN
+        assert ddnorth.isel(time=0) == 26
+        assert ddnorth.isel(time=3) == 29

--- a/icclim/tests/test_main.py
+++ b/icclim/tests/test_main.py
@@ -176,7 +176,12 @@ class Test_Integration:
         assert res.time_bounds[0, 1] == np.datetime64(datetime(2042, 1, 14))
         assert (
             res.SU.attrs["standard_name"]
-            == "number_of_days_with_maximum_air_temperature_above_threshold"
+            == "number_of_days_when_maximum_air_temperature_is_greater_than_threshold"
+        )
+        assert (
+            res.SU.attrs["long_name"]
+            == "Number of days when maximum air temperature is greater than 25.0"
+            " degC for each 2 wednesday starting week(s)."
         )
 
     def test_index_SU__monthy_sampled(self):

--- a/icclim/utils.py
+++ b/icclim/utils.py
@@ -1,16 +1,10 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import TypeVar
 
 import dateparser
-import xclim
-from xarray import DataArray
-from xclim.core.units import str2pint
-from xclim.core.units import units as xc_units
 
 from icclim.icclim_exceptions import InvalidIcclimArgumentError
-from icclim.models.constants import UNITS_KEY
 
 
 def read_date(in_date: str | datetime) -> datetime:
@@ -36,66 +30,3 @@ def is_number_sequence(values) -> bool:
     return isinstance(values, (tuple, list)) and all(
         map(lambda x: isinstance(x, (float, int)), values)
     )
-
-
-_T = TypeVar("_T")
-_X = TypeVar("_X")
-
-
-def icc_convert_units_to(
-    source: _T,
-    target: _X,
-    context: str | None = None,
-) -> _T:
-    """Overload xclim'sicc_convert_units_to to handle 'mm'->'kg/day/m2'"""
-    src_unit = get_unit(source)
-    target_unit = get_unit(target)
-    if is_mm(src_unit) and has_standard_precip_unit(target_unit):
-        return override_unit(source, target_unit)
-    if is_mm(target_unit) and has_standard_precip_unit(src_unit):
-        return source
-    return xclim.units.convert_units_to(source, target, context)
-
-
-def get_unit(
-    query: str | DataArray | xc_units.Quantity | xc_units.Unit,
-) -> xc_units.Unit:
-    if isinstance(query, str):
-        return str2pint(query).units
-    elif isinstance(query, DataArray):
-        return str2pint(query.attrs[UNITS_KEY]).units
-    elif isinstance(query, xc_units.Quantity):
-        return query.units
-    elif isinstance(query, xc_units.Unit):
-        return query
-    else:
-        return None
-
-
-def is_mm(query: xc_units.Unit) -> bool:
-    return query == xc_units.Unit("mm")
-
-
-def has_standard_precip_unit(query: xc_units.Unit) -> bool:
-    return xc_units.Quantity(1, query).check("[mass]/[time]/[length]**2")
-
-
-def override_unit(
-    query: str | DataArray | xc_units.Quantity | xc_units.Unit,
-    overriding_unit: xc_units.Unit,
-) -> str | DataArray | xc_units.Quantity | xc_units.Unit:
-    """
-    Override the unit of `query` by `overriding_unit`.
-    No conversion is attempted.
-    """
-    if isinstance(query, str):
-        return f"{str2pint(query).m} {overriding_unit}"
-    elif isinstance(query, DataArray):
-        query.attrs[UNITS_KEY] = str(overriding_unit)
-        return query
-    elif isinstance(query, xc_units.Quantity):
-        return xc_units.Quantity(query.m, overriding_unit)
-    elif isinstance(query, xc_units.Unit):
-        return overriding_unit
-    else:
-        raise NotImplementedError(f"Can't get unit from a {type(query)}")

--- a/icclim/utils.py
+++ b/icclim/utils.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import TypeVar
 
 import dateparser
+import xclim
+from xarray import DataArray
+from xclim.core.units import str2pint
+from xclim.core.units import units as xc_units
 
 from icclim.icclim_exceptions import InvalidIcclimArgumentError
+from icclim.models.constants import UNITS_KEY
 
 
 def read_date(in_date: str | datetime) -> datetime:
@@ -30,3 +36,66 @@ def is_number_sequence(values) -> bool:
     return isinstance(values, (tuple, list)) and all(
         map(lambda x: isinstance(x, (float, int)), values)
     )
+
+
+_T = TypeVar("_T")
+_X = TypeVar("_X")
+
+
+def icc_convert_units_to(
+    source: _T,
+    target: _X,
+    context: str | None = None,
+) -> _T:
+    """Overload xclim'sicc_convert_units_to to handle 'mm'->'kg/day/m2'"""
+    src_unit = get_unit(source)
+    target_unit = get_unit(target)
+    if is_mm(src_unit) and has_standard_precip_unit(target_unit):
+        return override_unit(source, target_unit)
+    if is_mm(target_unit) and has_standard_precip_unit(src_unit):
+        return source
+    return xclim.units.convert_units_to(source, target, context)
+
+
+def get_unit(
+    query: str | DataArray | xc_units.Quantity | xc_units.Unit,
+) -> xc_units.Unit:
+    if isinstance(query, str):
+        return str2pint(query).units
+    elif isinstance(query, DataArray):
+        return str2pint(query.attrs[UNITS_KEY]).units
+    elif isinstance(query, xc_units.Quantity):
+        return query.units
+    elif isinstance(query, xc_units.Unit):
+        return query
+    else:
+        return None
+
+
+def is_mm(query: xc_units.Unit) -> bool:
+    return query == xc_units.Unit("mm")
+
+
+def has_standard_precip_unit(query: xc_units.Unit) -> bool:
+    return xc_units.Quantity(1, query).check("[mass]/[time]/[length]**2")
+
+
+def override_unit(
+    query: str | DataArray | xc_units.Quantity | xc_units.Unit,
+    overriding_unit: xc_units.Unit,
+) -> str | DataArray | xc_units.Quantity | xc_units.Unit:
+    """
+    Override the unit of `query` by `overriding_unit`.
+    No conversion is attempted.
+    """
+    if isinstance(query, str):
+        return f"{str2pint(query).m} {overriding_unit}"
+    elif isinstance(query, DataArray):
+        query.attrs[UNITS_KEY] = str(overriding_unit)
+        return query
+    elif isinstance(query, xc_units.Quantity):
+        return xc_units.Quantity(query.m, overriding_unit)
+    elif isinstance(query, xc_units.Unit):
+        return overriding_unit
+    else:
+        raise NotImplementedError(f"Can't get unit from a {type(query)}")

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,3 +34,6 @@ testpaths = icclim/tests
 profile = black
 known_first_party = icclim
 skip = conf.py
+
+[coverage:run]
+omit = */tests/*.py


### PR DESCRIPTION
<!--
The following checklist points should all be checked before merging the PR.

Please replace xxx by your issue number (leave the prefixing '#').
-->

### Pull Request to resolve #xxx
- [x] Unit tests cover the changes.
- [x] These changes were tested on real data.
- [x] The relevant documentation has been added or updated.
- [x] A short description of the changes has been added to `doc/source/references/release_notes.rst`.

### Describe the changes you made
Add new Threshold sub-type BoundedThreshold.
It wraps 2 threshold bounded by a LogicalLink ("and" or "or") into one Htreshold that can be computed on a single climate variable.

This is particularly useful for some ECAD's indices such as `DDnorth` where we must count the exceedance of a single climate variable (dd) over a threshold AND below another one.
In DDNorth case it would be `-45º< dd <45º`
