### PR TITLE
DOC|FIX: Make use of the proper degree character

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ From sources:
 How to use icclim
 -----------------
 
-Let's count the number of days above 25ºC for each year, which corresponds to the index ``SU``, from a `tasmax` variable scattered in multiple netcdf files.
+Let's count the number of days above 25°C for each year, which corresponds to the index ``SU``, from a `tasmax` variable scattered in multiple netcdf files.
 
 `SU` is one of the many index that can be computed with icclim. See `the documentation <https://icclim.readthedocs.io/en/latest/explanation/climate_indices.html#icclim-capabilities>`_ to explore what other index you can compute with icclim.
 

--- a/doc/source/how_to/dask.rst
+++ b/doc/source/how_to/dask.rst
@@ -152,7 +152,7 @@ The more there are chunks the more routes are created.
 In extreme cases, when there are a lot of chunks, the graph may take eons to create and the computation may never start.
 This means that configuring a small chunk size leads to a potentially large graph.
 
-The graph is also dependant of the actual calculation. A climate index like "SU" (count of days above 25ºC)
+The graph is also dependant of the actual calculation. A climate index like "SU" (count of days above 25°C)
 will obviously create a much simpler graph than WSDI (longest spell of at least 6 consecutive days where maximum daily
 temperature is above the 90th daily percentile).
 Finally the resampling may also play a role in the graph complexity. In icclim we control it with ``slice_mode`` parameter.

--- a/doc/source/references/icclim_index_api.rst
+++ b/doc/source/references/icclim_index_api.rst
@@ -145,9 +145,9 @@ Additionally, you can define a season between two exact dates:
 ~~~~~~~~~~~~~
 It is possible to set a user define threshold for the following indices:
 
-* SU (default threshold: 25ºC)
-* CSU (default threshold: 25ºC)
-* TR (default threshold: 20ºC)
+* SU (default threshold: 25°C)
+* CSU (default threshold: 25°C)
+* TR (default threshold: 20°C)
 * CSDI (default 10th percentile)
 * WSDI (default 90th percentile)
 * TX90p (default 90th percentile)

--- a/doc/source/references/release_notes.rst
+++ b/doc/source/references/release_notes.rst
@@ -45,7 +45,7 @@ Release history
 5.4.0
 -----
 * [fix] When giving input as a list of netcdf files, the coordinate values are now merged using the `override` strategy, thus the first file with a given dimension define this dimension for all the files.
-* [fix] Fix the output unit of some indices (from "ºC" to "degree_Celsius")
+* [fix] Fix the output unit of some indices (from "°C" to "degree_Celsius")
 * [fix] Fixed issued where dataset having a time_bds variable could not be processed by chunking the DataArray(s) instead of the Dataset.
 
 5.3.0

--- a/icclim/models/threshold.py
+++ b/icclim/models/threshold.py
@@ -200,13 +200,13 @@ def build_threshold(
 
 class Threshold(metaclass=abc.ABCMeta):
     """
-    - scalar thresh:                               "> 25 ºC"
+    - scalar thresh:                               "> 25 °C"
     - per grid cell thresh:                        "> data.nc"
     - doy percentile threshold:                    "> 98th doy_per"
     - period percentile threshold:                 "> 75th period_per"
     - period percentile threshold with min value:  "> 98th period_per",
                                                    threshold_min_value= "1mm"
-    - sequence thresholds (or):                    "> 10 ºC, > 25 ºC"
+    - sequence thresholds (or):                    "> 10 °C, > 25 °C"
                                                      thresholds are a new dimension
     """
 

--- a/icclim/tests/test_generated_api.py
+++ b/icclim/tests/test_generated_api.py
@@ -114,7 +114,7 @@ def test_txx__season_slice_mode():
     # GIVEN
     tas = stub_tas()
     tas.loc[{"time": "2043-02-02"}] = 295
-    tas.loc[{"time": "2043-01-01"}] = 303.15  # 30ºC 273.15
+    tas.loc[{"time": "2043-01-01"}] = 303.15  # 30°C 273.15
     # WHEN
     res = icclim.txx(tas, slice_mode=["season", [11, 12, 1, 2]]).compute()
     # THEN
@@ -130,7 +130,7 @@ def test_txx__season_slice_mode():
 def test_txx__months_slice_mode():
     tas = stub_tas()
     tas.loc[{"time": "2042-11-02"}] = 295
-    tas.loc[{"time": "2042-01-01"}] = 303.15  # 30ºC 273.15
+    tas.loc[{"time": "2042-01-01"}] = 303.15  # 30°C 273.15
     res = icclim.txx(tas, slice_mode=["months", [11, 1]]).compute()
     np.testing.assert_array_equal(res.TXx.isel(time=0), 30)
     np.testing.assert_array_equal(res.TXx.isel(time=1), np.NAN)


### PR DESCRIPTION
Boring PR to fix typo.
The wrong character was used to represent degrees.
We wrote `º`, the ordinal symbol (which is easy to type on mac), but we should use `°` the degree symbol.

