### PR TITLE
[ENH] Bind xclim indicators to missing ECAD indices

### DIFF
--- a/doc/source/how_to/index.rst
+++ b/doc/source/how_to/index.rst
@@ -15,5 +15,6 @@ To find more in depth technical knowledge see :ref:`references`.
     Chunk data and parallelize computation <dask>
     Run our jupyter notebooks <notebooks>
     Compute ECA&D indices <recipes_ecad>
-    Create customized indices <recipes_custom>
+    Compute Generic indices <recipes_generic>
     Use icclim through OCGIS <ocgis>
+    Create customized indices (deprecated) <recipes_custom>

--- a/doc/source/how_to/recipes_custom.rst
+++ b/doc/source/how_to/recipes_custom.rst
@@ -3,6 +3,9 @@
 Custom indices recipes
 ----------------------
 
+.. note::
+    Custom indices are deprecated. You should switch to :ref:`generic_indices_recipes` API.
+
 >>> import icclim
 >>> import datetime
 

--- a/doc/source/how_to/recipes_generic.rst
+++ b/doc/source/how_to/recipes_generic.rst
@@ -1,0 +1,363 @@
+.. _`generic_indices_recipes`:
+
+Generic indices recipes
+-----------------------
+
+You will find below a few example of icclim v6 :ref:`generic_functions_api`.
+
+.. code-block:: python
+
+    import icclim
+    from icclim import build_threshold
+
+    # Change `data` to your own netcdf file path.
+    data = "netcdf_files/gridded.1991-2010.nc"
+
+
+Count occurrences
++++++++++++++++++
+
+Occurrences of events where tas is between 20 and 30 degree Celsius and precipitation are above 3 mm/day.
+
+.. code-block:: python
+
+    # Equivalent to using `reasonable_temp = "<= 30 deg_C AND >= 20 deg_C"`
+    reasonable_temp = build_threshold("<= 30 deg_C") & build_threshold(">= 20 deg_C")
+    some_rain = icclim.build_threshold("> 3 mm/day")
+
+    dataset = icclim.count_occurrences(
+        in_files={
+            "tmax": {"study": data, "thresholds": reasonable_temp},
+            "precip": {"study": data, "thresholds": some_rain},
+        }
+    )
+    # .compute must be called to ask dask to run the actual computation
+    conputed_data = dataset.count_occurrences.compute()
+
+.. code-block:: python
+
+    tx99p_dataset = icclim.count_occurrences(
+        in_files=data, var_name="tasmax", threshold=">= 99 doy_per"
+    )
+    # .compute must be called to ask dask to run the actual computation
+    tx99p = dataset.count_occurrences.compute()
+
+Sum
++++
+
+Sum of precipitation that are above 4 mm/day.
+
+.. code-block:: python
+
+    rain_sum_above_4mm = icclim.sum(
+        in_files=data, var_name="precip", threshold="> 4 mm/day"
+    ).sum.compute()
+
+
+Standard Deviation
+++++++++++++++++++
+
+Standard deviation of ``tas`` variable.
+
+.. code-block:: python
+
+    tas_std = icclim.std(in_files=data, var_name="tas").std.compute()
+
+
+Average
++++++++
+
+Average of the ``tas`` variable, per year by default.
+
+.. code-block:: python
+
+    tas_average = icclim.average(in_files=data, var_name="tas").average.compute()
+
+
+Average of the ``tas`` values that are above the 87th period percentile (computed on the whole period here),
+per year by default.
+
+.. code-block:: python
+
+    tas_average_above_percentile_of_period = icclim.average(
+        in_files=data, var_name="tas", threshold="> 87 period_per"
+    ).average.compute()
+
+
+Maximum Consecutive Occurrences
++++++++++++++++++++++++++++++++
+
+Almost equivalent to ECAD's index CDD (Consecutive Dry Days, days when pr is below 1 mm/day).
+
+.. code-block:: python
+
+    CDD = icclim.max_consecutive_occurrence(
+        in_files=data, var_name="precip", threshold="< 1.3 mm/day"
+    ).max_consecutive_occurrence.compute()
+
+
+Sum of Spell Lengths
+++++++++++++++++++++
+
+Almost equivalent to ECAD's index WSDI (Warm Spell Duration Index,
+maximum consecutive occurrence of tasmax > 90th doy percentile)
+
+.. code-block:: python
+
+    custom_wsdi = icclim.sum_of_spell_lengths(
+        in_files=data, var_name="precip", threshold="> 90 doy_per AND > 28 degC"
+    ).sum_of_spell_lengths.compute()
+
+Excess
+++++++
+
+Excess of minimal daily temperature above the 22 daily percentile threshold computed overs the 1991-1995 reference
+period, with a focus on the June to August periods.
+
+.. code-block:: python
+
+    jja_tmin_excess = (
+        icclim.excess(
+            climp_file,
+            var_name=["tmin"],
+            threshold=icclim.build_threshold(
+                "22 doy_per", base_period_time_range=["1991-01-01", "1995-12-31"]
+            ),
+            slice_mode="jja",
+        )
+        .compute()
+        .excess
+    )
+
+
+Deficit
++++++++
+
+Deficit of minimal daily temperature below 17 degree Celsius.
+
+.. code-block:: python
+
+    result13 = icclim.index(
+        climp_file,
+        var_name=["tmin"],
+        index_name="deficit",
+        threshold=build_threshold("17 degC"),
+    ).compute()
+
+Fraction of Total
++++++++++++++++++
+
+Fraction of precipitations above the 75th period percentile, where percentiles are computed only on values above 1 mm/day
+This is equivalent to the ECAD's index R75pTOT.
+
+.. code-block:: python
+
+    result14 = (
+        icclim.fraction_of_total(
+            climp_file,
+            var_name=["precip"],
+            threshold=build_threshold(
+                "> 75 period_per", threshold_min_value="1 mm/day"
+            ),
+        )
+        .compute()
+        .fraction_of_total
+    )
+
+Maximum
++++++++
+
+Maximum of tas temperature per month.
+
+.. code-block:: python
+
+    max_of_tas = (
+        icclim.maximum(
+            climp_file,
+            var_name=["tas"],
+            slice_mode="month",
+        )
+        .compute()
+        .maximum
+    )
+
+Minimum
++++++++
+
+Minimum of tas temperature per month.
+
+.. code-block:: python
+
+    min_of_tas = (
+        icclim.minimum(
+            climp_file,
+            var_name=["tas"],
+            slice_mode="month",
+        )
+        .compute()
+        .minimum
+    )
+
+
+Max of Rolling Sum
+++++++++++++++++++
+
+Maximum of rolling sum of precipitation that are above the period median, where the median is computed for the whole
+period (default behavior when there is no `base_period_time_range`) only on values above 1mm/day.
+
+.. code-block:: python
+
+    max_of_rolling_sum = (
+        icclim.index(
+            climp_file,
+            index_name="max_of_rolling_sum",
+            var_name=["precip"],
+            threshold=build_threshold(
+                ">= 50 period_per", threshold_min_value="1 mmday"
+            ),
+        )
+        .compute()
+        .max_of_rolling_sum
+    )
+
+Min of Rolling Sum
+++++++++++++++++++
+
+Minimum of rolling sum of precipitation that are above the period median, where the median is computed for the whole
+period (default behavior when there is no `base_period_time_range`) only on values above 1mm/day.
+
+.. code-block:: python
+
+    min_of_rolling_sum = (
+        icclim.min_of_rolling_sum(
+            climp_file,
+            var_name=["precip"],
+            threshold=build_threshold(
+                ">= 50 period_per", threshold_min_value="1 mmday"
+            ),
+        )
+        .compute()
+        .min_of_rolling_sum
+    )
+
+Max of Rolling Average
+++++++++++++++++++++++
+
+Maximum of rolling average of precipitation that are above the period median, where the median is computed for the whole
+period (default behavior when there is no `base_period_time_range`) only on values above 1mm/day.
+
+.. code-block:: python
+
+    max_of_rolling_average = (
+        icclim.index(
+            climp_file,
+            index_name="max_of_rolling_average",
+            var_name=["precip"],
+            threshold=build_threshold(
+                ">= 50 period_per", threshold_min_value="1 mmday"
+            ),
+        )
+        .compute()
+        .max_of_rolling_average
+    )
+
+Min of Rolling Average
+++++++++++++++++++++++
+
+Minimum of rolling average of precipitation that are above the period median, where the median is computed for the whole
+period (default behavior when there is no `base_period_time_range`) only on values above 1mm/day.
+
+.. code-block:: python
+
+    min_of_rolling_average = (
+        icclim.min_of_rolling_average(
+            climp_file,
+            var_name=["precip"],
+            threshold=build_threshold(
+                ">= 50 period_per", threshold_min_value="1 mmday"
+            ),
+        )
+        .compute()
+        .min_of_rolling_average
+    )
+
+Mean of difference
+++++++++++++++++++
+
+Mean of the difference between tasmax in tasmin.
+It's a generification of ECAD's index DTR.
+
+.. code-block:: python
+
+    dtr = (
+        icclim.index(
+            climp_file,
+            index_name="mean_of_difference",
+            var_name=["tmax", "tmin"],
+        )
+        .compute()
+        .mean_of_difference
+    )
+
+Difference of extremes
+++++++++++++++++++++++
+
+Difference of the maximum of tasmax and the minimum of tasmin.
+It's a generification of ECAD's index ETR.
+
+.. code-block:: python
+
+    dtr = (
+        icclim.index(
+            climp_file,
+            index_name="difference_of_extremes",
+            var_name=["tmax", "tmin"],
+        )
+        .compute()
+        .difference_of_extremes
+    )
+
+Difference of means
++++++++++++++++++++
+
+Difference between averaged tas and the averaged tas values of the reference period.
+Also known as the ``anomaly``.
+
+
+.. code-block:: python
+
+    anomaly = (
+        icclim.difference_of_means(
+            climp_file,
+            var_name=["tas"],
+            base_period_time_range=["1991-01-01", "1995-12-31"],
+        )
+        .compute()
+        .difference_of_means
+    )
+
+
+Mean Of Absolute One Time Step Difference
++++++++++++++++++++++++++++++++++++++++++
+
+Mean of absolute difference between tasmax and tasmin with a one time step lag (usually 1 day).
+This is equivalent to the pseudo-code:
+
+.. code-block:: python
+
+    a = tasmax[T + 1] - tasmin[T + 1]
+    b = tasmax[T] - tasmin[T]
+    average(a - b)
+
+It's a generification of ECAD's index vDTR.
+
+.. code-block:: python
+
+    result = (
+        icclim.mean_of_absolute_one_time_step_difference(
+            climp_file,
+            var_name=["tmax", "tmin"],
+        )
+        .compute()
+        .mean_of_absolute_one_time_step_difference
+    )

--- a/doc/source/references/ecad_functions_api.rst
+++ b/doc/source/references/ecad_functions_api.rst
@@ -86,6 +86,8 @@ Generated API
         ddeast
         ddsouth
         ddwest
+        gsl
+        spi6
         custom_index
 
         .. Generated API comment:End

--- a/doc/source/references/ecad_functions_api.rst
+++ b/doc/source/references/ecad_functions_api.rst
@@ -88,6 +88,7 @@ Generated API
         ddwest
         gsl
         spi6
+        spi3
         custom_index
 
         .. Generated API comment:End

--- a/doc/source/references/generic_functions_api.rst
+++ b/doc/source/references/generic_functions_api.rst
@@ -21,6 +21,8 @@ As an example, you can compute the number of days where a threshold is reached w
     )
 
 For more details on threshold and how to personalize them, see :ref:`threshold` documentation.
+We also prepared a few examples on :ref:`generic_indices_recipes` so that you get an idea of the capabilities of
+these generic indices.
 
 Generated API
 -------------

--- a/doc/source/references/icclim_index_api.rst
+++ b/doc/source/references/icclim_index_api.rst
@@ -359,7 +359,7 @@ or as percentage of days (``out_unit`` = "%").
 Custom indices
 --------------
 
-Custom indices are now described in their own chapter: `here <custom_indices>`_
+Custom indices are now described in their own chapter: :ref:`custom_indices`
 
 
 .. _table_index_sourceVar_label:

--- a/doc/source/references/release_notes.rst
+++ b/doc/source/references/release_notes.rst
@@ -8,6 +8,8 @@ Release history
   `ddnorth` and `ddsouth` do not follow the ECAD's ATBD v11 requirements as their definition seems to be wrong in the document.
 * [enh] Add generic indicators as stand-alone functions in `icclim` namespace.
 * [doc] Add documentation for generic indicators stand-alone functions.
+* [doc] Add a recipe "how to" documentation for generic indicators.
+* [enh] Add ECAD's indices GSL, SPI3, SPI6 by binding them to xclim's indicators.
 
 
 6.0.0

--- a/icclim/_generated_api.py
+++ b/icclim/_generated_api.py
@@ -98,6 +98,8 @@ __all__ = [
     "ddeast",
     "ddsouth",
     "ddwest",
+    "gsl",
+    "spi6",
     "custom_index",
 ]
 
@@ -7302,6 +7304,162 @@ def ddwest(
             query="> 225 degree AND <= 315 degree",
         ),
         out_unit="day",
+    )
+
+
+def gsl(
+    in_files: InFileLike,
+    var_name: str | Sequence[str] | None = None,
+    slice_mode: FrequencyLike | Frequency = "year",
+    time_range: Sequence[datetime | str] | None = None,
+    out_file: str | None = None,
+    ignore_Feb29th: bool = False,
+    netcdf_version: str | NetcdfVersion = "NETCDF4",
+    logs_verbosity: Verbosity | str = "LOW",
+    date_event: bool = False,
+) -> Dataset:
+    """
+    GSL: Growing season length
+    Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
+
+    Parameters
+    ----------
+
+    in_files: str | list[str] | Dataset | DataArray | InputDictionary
+        Absolute path(s) to NetCDF dataset(s), including OPeNDAP URLs,
+        or path to zarr store, or xarray.Dataset or xarray.DataArray.
+    var_name: str | list[str] | None
+        ``optional`` Target variable name to process corresponding to ``in_files``.
+        If None (default) on ECA&D index, the variable is guessed based on the climate
+        index wanted.
+        Mandatory for a user index.
+    slice_mode: SliceMode
+        Type of temporal aggregation:
+        The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
+        "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
+        (where season and month lists can be customized) or any valid pandas frequency.
+        A season can also be defined between two exact dates:
+        ``("season", ("19 july", "14 august"))``.
+        Default is "year".
+        See :ref:`slice_mode` for details.
+    time_range: list[datetime ] | list[str]  | tuple[str, str] | None
+        ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
+        If ``None``, whole period of input files will be processed.
+        The dates can either be given as instance of datetime.datetime or as string
+        values. For strings, many format are accepted.
+        Default is ``None``.
+    out_file: str | None
+        Output NetCDF file name (default: "icclim_out.nc" in the current directory).
+        Default is "icclim_out.nc".
+        If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
+        Use the function returned value instead to retrieve the computed value.
+        If ``out_file`` already exists, icclim will overwrite it!
+    ignore_Feb29th: bool
+        ``optional`` Ignoring or not February 29th (default: False).
+    netcdf_version: str | NetcdfVersion
+        ``optional`` NetCDF version to create (default: "NETCDF3_CLASSIC").
+    logs_verbosity: str | Verbosity
+        ``optional`` Configure how verbose icclim is.
+        Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
+    date_event: bool
+        When True the date of the event (such as when a maximum is reached) will be
+        stored in coordinates variables.
+        **warning** This option may significantly slow down computation.
+
+    Notes
+    -----
+    This function has been auto-generated.
+
+    """
+    return icclim.index(
+        index_name="GSL",
+        in_files=in_files,
+        var_name=var_name,
+        slice_mode=slice_mode,
+        time_range=time_range,
+        out_file=out_file,
+        ignore_Feb29th=ignore_Feb29th,
+        netcdf_version=netcdf_version,
+        logs_verbosity=logs_verbosity,
+        date_event=date_event,
+    )
+
+
+def spi6(
+    in_files: InFileLike,
+    var_name: str | Sequence[str] | None = None,
+    slice_mode: FrequencyLike | Frequency = "year",
+    time_range: Sequence[datetime | str] | None = None,
+    out_file: str | None = None,
+    ignore_Feb29th: bool = False,
+    netcdf_version: str | NetcdfVersion = "NETCDF4",
+    logs_verbosity: Verbosity | str = "LOW",
+    date_event: bool = False,
+) -> Dataset:
+    """
+    SPI6: 6-Month Standardized Precipitation Inde
+    Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
+
+    Parameters
+    ----------
+
+    in_files: str | list[str] | Dataset | DataArray | InputDictionary
+        Absolute path(s) to NetCDF dataset(s), including OPeNDAP URLs,
+        or path to zarr store, or xarray.Dataset or xarray.DataArray.
+    var_name: str | list[str] | None
+        ``optional`` Target variable name to process corresponding to ``in_files``.
+        If None (default) on ECA&D index, the variable is guessed based on the climate
+        index wanted.
+        Mandatory for a user index.
+    slice_mode: SliceMode
+        Type of temporal aggregation:
+        The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
+        "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
+        (where season and month lists can be customized) or any valid pandas frequency.
+        A season can also be defined between two exact dates:
+        ``("season", ("19 july", "14 august"))``.
+        Default is "year".
+        See :ref:`slice_mode` for details.
+    time_range: list[datetime ] | list[str]  | tuple[str, str] | None
+        ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
+        If ``None``, whole period of input files will be processed.
+        The dates can either be given as instance of datetime.datetime or as string
+        values. For strings, many format are accepted.
+        Default is ``None``.
+    out_file: str | None
+        Output NetCDF file name (default: "icclim_out.nc" in the current directory).
+        Default is "icclim_out.nc".
+        If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
+        Use the function returned value instead to retrieve the computed value.
+        If ``out_file`` already exists, icclim will overwrite it!
+    ignore_Feb29th: bool
+        ``optional`` Ignoring or not February 29th (default: False).
+    netcdf_version: str | NetcdfVersion
+        ``optional`` NetCDF version to create (default: "NETCDF3_CLASSIC").
+    logs_verbosity: str | Verbosity
+        ``optional`` Configure how verbose icclim is.
+        Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
+    date_event: bool
+        When True the date of the event (such as when a maximum is reached) will be
+        stored in coordinates variables.
+        **warning** This option may significantly slow down computation.
+
+    Notes
+    -----
+    This function has been auto-generated.
+
+    """
+    return icclim.index(
+        index_name="SPI6",
+        in_files=in_files,
+        var_name=var_name,
+        slice_mode=slice_mode,
+        time_range=time_range,
+        out_file=out_file,
+        ignore_Feb29th=ignore_Feb29th,
+        netcdf_version=netcdf_version,
+        logs_verbosity=logs_verbosity,
+        date_event=date_event,
     )
 
 

--- a/icclim/_generated_api.py
+++ b/icclim/_generated_api.py
@@ -7383,6 +7383,7 @@ def gsl(
         netcdf_version=netcdf_version,
         logs_verbosity=logs_verbosity,
         date_event=date_event,
+        out_unit="day",
     )
 
 
@@ -7477,6 +7478,7 @@ def spi6(
         netcdf_version=netcdf_version,
         logs_verbosity=logs_verbosity,
         date_event=date_event,
+        out_unit="",
     )
 
 
@@ -7571,6 +7573,7 @@ def spi3(
         netcdf_version=netcdf_version,
         logs_verbosity=logs_verbosity,
         date_event=date_event,
+        out_unit="",
     )
 
 

--- a/icclim/_generated_api.py
+++ b/icclim/_generated_api.py
@@ -100,6 +100,7 @@ __all__ = [
     "ddwest",
     "gsl",
     "spi6",
+    "spi3",
     "custom_index",
 ]
 
@@ -7391,13 +7392,14 @@ def spi6(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[datetime | str] | None = None,
     out_file: str | None = None,
+    base_period_time_range: Sequence[datetime] | Sequence[str] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
     date_event: bool = False,
 ) -> Dataset:
     """
-    SPI6: 6-Month Standardized Precipitation Inde
+    SPI6: 6-Month Standardized Precipitation Index
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
     Parameters
@@ -7432,6 +7434,20 @@ def spi6(
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
+    base_period_time_range: list[datetime ] | list[str]  | tuple[str, str] | None
+        ``optional`` Temporal range of the reference period.
+        The dates can either be given as instance of datetime.datetime or as string
+        values.
+        It is used either:
+        #. to compute percentiles if threshold is filled.
+        When missing, the studied period is used to compute percentiles.
+        The study period is either the dataset filtered by `time_range` or the whole
+        dataset if `time_range` is missing.
+        For day of year percentiles (doy_per), on extreme percentiles the
+        overlapping period between `base_period_time_range` and the study period is
+        bootstrapped.
+        #. to compute a reference period for indices such as difference_of_mean
+        (a.k.a anomaly) if a single variable is given in input.
     ignore_Feb29th: bool
         ``optional`` Ignoring or not February 29th (default: False).
     netcdf_version: str | NetcdfVersion
@@ -7456,6 +7472,101 @@ def spi6(
         slice_mode=slice_mode,
         time_range=time_range,
         out_file=out_file,
+        base_period_time_range=base_period_time_range,
+        ignore_Feb29th=ignore_Feb29th,
+        netcdf_version=netcdf_version,
+        logs_verbosity=logs_verbosity,
+        date_event=date_event,
+    )
+
+
+def spi3(
+    in_files: InFileLike,
+    var_name: str | Sequence[str] | None = None,
+    slice_mode: FrequencyLike | Frequency = "year",
+    time_range: Sequence[datetime | str] | None = None,
+    out_file: str | None = None,
+    base_period_time_range: Sequence[datetime] | Sequence[str] | None = None,
+    ignore_Feb29th: bool = False,
+    netcdf_version: str | NetcdfVersion = "NETCDF4",
+    logs_verbosity: Verbosity | str = "LOW",
+    date_event: bool = False,
+) -> Dataset:
+    """
+    SPI3: 3-Month Standardized Precipitation Index
+    Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
+
+    Parameters
+    ----------
+
+    in_files: str | list[str] | Dataset | DataArray | InputDictionary
+        Absolute path(s) to NetCDF dataset(s), including OPeNDAP URLs,
+        or path to zarr store, or xarray.Dataset or xarray.DataArray.
+    var_name: str | list[str] | None
+        ``optional`` Target variable name to process corresponding to ``in_files``.
+        If None (default) on ECA&D index, the variable is guessed based on the climate
+        index wanted.
+        Mandatory for a user index.
+    slice_mode: SliceMode
+        Type of temporal aggregation:
+        The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
+        "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
+        (where season and month lists can be customized) or any valid pandas frequency.
+        A season can also be defined between two exact dates:
+        ``("season", ("19 july", "14 august"))``.
+        Default is "year".
+        See :ref:`slice_mode` for details.
+    time_range: list[datetime ] | list[str]  | tuple[str, str] | None
+        ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
+        If ``None``, whole period of input files will be processed.
+        The dates can either be given as instance of datetime.datetime or as string
+        values. For strings, many format are accepted.
+        Default is ``None``.
+    out_file: str | None
+        Output NetCDF file name (default: "icclim_out.nc" in the current directory).
+        Default is "icclim_out.nc".
+        If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
+        Use the function returned value instead to retrieve the computed value.
+        If ``out_file`` already exists, icclim will overwrite it!
+    base_period_time_range: list[datetime ] | list[str]  | tuple[str, str] | None
+        ``optional`` Temporal range of the reference period.
+        The dates can either be given as instance of datetime.datetime or as string
+        values.
+        It is used either:
+        #. to compute percentiles if threshold is filled.
+        When missing, the studied period is used to compute percentiles.
+        The study period is either the dataset filtered by `time_range` or the whole
+        dataset if `time_range` is missing.
+        For day of year percentiles (doy_per), on extreme percentiles the
+        overlapping period between `base_period_time_range` and the study period is
+        bootstrapped.
+        #. to compute a reference period for indices such as difference_of_mean
+        (a.k.a anomaly) if a single variable is given in input.
+    ignore_Feb29th: bool
+        ``optional`` Ignoring or not February 29th (default: False).
+    netcdf_version: str | NetcdfVersion
+        ``optional`` NetCDF version to create (default: "NETCDF3_CLASSIC").
+    logs_verbosity: str | Verbosity
+        ``optional`` Configure how verbose icclim is.
+        Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
+    date_event: bool
+        When True the date of the event (such as when a maximum is reached) will be
+        stored in coordinates variables.
+        **warning** This option may significantly slow down computation.
+
+    Notes
+    -----
+    This function has been auto-generated.
+
+    """
+    return icclim.index(
+        index_name="SPI3",
+        in_files=in_files,
+        var_name=var_name,
+        slice_mode=slice_mode,
+        time_range=time_range,
+        out_file=out_file,
+        base_period_time_range=base_period_time_range,
         ignore_Feb29th=ignore_Feb29th,
         netcdf_version=netcdf_version,
         logs_verbosity=logs_verbosity,

--- a/icclim/ecad/ecad_indices.py
+++ b/icclim/ecad/ecad_indices.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-from ecad.xclim_binding import XCLIM_BINDING
-
+from icclim.ecad.xclim_binding import XCLIM_BINDING
 from icclim.generic_indices.generic_indicators import GenericIndicatorRegistry
 from icclim.generic_indices.standard_variable import StandardVariableRegistry
 from icclim.generic_indices.threshold import build_threshold

--- a/icclim/ecad/ecad_indices.py
+++ b/icclim/ecad/ecad_indices.py
@@ -741,6 +741,7 @@ class EcadIndexRegistry(Registry[StandardIndex]):
         short_name="GSL",
         group=IndexGroupRegistry.COLD,
         input_variables=[StandardVariableRegistry.TAS],
+        output_unit="day",
     )
     SPI6 = StandardIndex(
         reference=ECAD_REFERENCE,
@@ -751,6 +752,7 @@ class EcadIndexRegistry(Registry[StandardIndex]):
         group=IndexGroupRegistry.RAIN,
         input_variables=[StandardVariableRegistry.TAS],
         qualifiers=[REFERENCE_PERIOD_INDEX],
+        output_unit="",
     )
     SPI3 = StandardIndex(
         reference=ECAD_REFERENCE,
@@ -761,4 +763,5 @@ class EcadIndexRegistry(Registry[StandardIndex]):
         group=IndexGroupRegistry.RAIN,
         input_variables=[StandardVariableRegistry.TAS],
         qualifiers=[REFERENCE_PERIOD_INDEX],
+        output_unit="",
     )

--- a/icclim/ecad/ecad_indices.py
+++ b/icclim/ecad/ecad_indices.py
@@ -5,7 +5,7 @@ from ecad.xclim_binding import XCLIM_BINDING
 from icclim.generic_indices.generic_indicators import GenericIndicatorRegistry
 from icclim.generic_indices.standard_variable import StandardVariableRegistry
 from icclim.generic_indices.threshold import build_threshold
-from icclim.models.constants import ECAD_ATBD, QUANTILE_BASED
+from icclim.models.constants import ECAD_ATBD, QUANTILE_BASED, REFERENCE_PERIOD_INDEX
 from icclim.models.index_group import IndexGroupRegistry
 from icclim.models.registry import Registry
 from icclim.models.standard_index import StandardIndex
@@ -736,7 +736,7 @@ class EcadIndexRegistry(Registry[StandardIndex]):
     )
     GSL = StandardIndex(
         reference=ECAD_REFERENCE,
-        indicator=XCLIM_BINDING.growing_season_length(),
+        indicator=XCLIM_BINDING.GrowingSeasonLength(),
         definition="Growing season length",
         source=ECAD_ATBD,
         short_name="GSL",
@@ -745,10 +745,21 @@ class EcadIndexRegistry(Registry[StandardIndex]):
     )
     SPI6 = StandardIndex(
         reference=ECAD_REFERENCE,
-        indicator=XCLIM_BINDING.standardized_precipitation_index_6,
-        definition="6-Month Standardized Precipitation Inde",
+        indicator=XCLIM_BINDING.StandardizedPrecipitationIndex6(),
+        definition="6-Month Standardized Precipitation Index",
         source=ECAD_ATBD,
         short_name="SPI6",
         group=IndexGroupRegistry.RAIN,
         input_variables=[StandardVariableRegistry.TAS],
+        qualifiers=[REFERENCE_PERIOD_INDEX],
+    )
+    SPI3 = StandardIndex(
+        reference=ECAD_REFERENCE,
+        indicator=XCLIM_BINDING.StandardizedPrecipitationIndex3(),
+        definition="3-Month Standardized Precipitation Index",
+        source=ECAD_ATBD,
+        short_name="SPI3",
+        group=IndexGroupRegistry.RAIN,
+        input_variables=[StandardVariableRegistry.TAS],
+        qualifiers=[REFERENCE_PERIOD_INDEX],
     )

--- a/icclim/ecad/ecad_indices.py
+++ b/icclim/ecad/ecad_indices.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from ecad.xclim_binding import XCLIM_BINDING
+
 from icclim.generic_indices.generic_indicators import GenericIndicatorRegistry
 from icclim.generic_indices.standard_variable import StandardVariableRegistry
 from icclim.generic_indices.threshold import build_threshold
@@ -731,4 +733,22 @@ class EcadIndexRegistry(Registry[StandardIndex]):
         short_name="DDwest",
         group=IndexGroupRegistry.WIND,
         input_variables=[StandardVariableRegistry.WIND_TO_DIRECTION],
+    )
+    GSL = StandardIndex(
+        reference=ECAD_REFERENCE,
+        indicator=XCLIM_BINDING.growing_season_length(),
+        definition="Growing season length",
+        source=ECAD_ATBD,
+        short_name="GSL",
+        group=IndexGroupRegistry.COLD,
+        input_variables=[StandardVariableRegistry.TAS],
+    )
+    SPI6 = StandardIndex(
+        reference=ECAD_REFERENCE,
+        indicator=XCLIM_BINDING.standardized_precipitation_index_6,
+        definition="6-Month Standardized Precipitation Inde",
+        source=ECAD_ATBD,
+        short_name="SPI6",
+        group=IndexGroupRegistry.RAIN,
+        input_variables=[StandardVariableRegistry.TAS],
     )

--- a/icclim/ecad/xclim_binding.py
+++ b/icclim/ecad/xclim_binding.py
@@ -8,6 +8,8 @@ from icclim.generic_indices.generic_indicators import (
     get_couple_of_var,
     get_single_var,
 )
+from icclim.icclim_exceptions import InvalidIcclimArgumentError
+from icclim.models.frequency import FrequencyRegistry
 from icclim.models.index_config import IndexConfig
 
 
@@ -52,9 +54,11 @@ class XCLIM_BINDING:
         cell_methods = ""
 
         def __call__(self, config: IndexConfig) -> xarray.DataArray:
+            if config.frequency is not FrequencyRegistry.YEAR:  # year is default freq
+                raise InvalidIcclimArgumentError(
+                    "`slice_mode` cannot be configured when computing SPI3"
+                )
             study, ref = get_couple_of_var(config.climate_variables, "SPI")
-            print(study)
-            print(ref)
             return xclim.atmos.standardized_precipitation_index(
                 pr=study, pr_cal=ref, freq="MS", window=3, dist="gamma", method="APP"
             )
@@ -79,6 +83,10 @@ class XCLIM_BINDING:
         cell_methods = ""
 
         def __call__(self, config: IndexConfig) -> xarray.DataArray:
+            if config.frequency is not FrequencyRegistry.YEAR:  # year is default freq
+                raise InvalidIcclimArgumentError(
+                    "`slice_mode` cannot be configured when computing SPI6"
+                )
             study, ref = get_couple_of_var(config.climate_variables, "SPI")
             return xclim.atmos.standardized_precipitation_index(
                 pr=study, pr_cal=ref, freq="MS", window=6, dist="gamma", method="APP"

--- a/icclim/ecad/xclim_binding.py
+++ b/icclim/ecad/xclim_binding.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import xarray
 import xclim
 

--- a/icclim/ecad/xclim_binding.py
+++ b/icclim/ecad/xclim_binding.py
@@ -1,17 +1,20 @@
-from collections.abc import Sequence
-
 import xarray
 import xclim
-from icclim_exceptions import InvalidIcclimArgumentError
 
-from icclim.generic_indices.generic_indicators import _get_couple_of_var, get_single_var
-from icclim.generic_indices.standard_variable import StandardVariableRegistry
-from icclim.models.climate_variable import ClimateVariable
+from icclim.generic_indices.generic_indicators import (
+    Indicator,
+    get_couple_of_var,
+    get_single_var,
+)
 from icclim.models.index_config import IndexConfig
 
 
 class XCLIM_BINDING:
-    class growing_season_length:
+    class GrowingSeasonLength(Indicator):
+        """
+        Fake icclim indicator that redirect to xclim `growing_season_length` indicator.
+        """
+
         name = "growing_season_length"
         standard_name = xclim.atmos.growing_season_length.standard_name
         long_name = "ECAD Growing Season Length (Tmean > 5 degree_Celsius)"
@@ -27,47 +30,62 @@ class XCLIM_BINDING:
                 freq=config.frequency.pandas_freq,
             )
 
-    @staticmethod
-    def standardized_precipitation_index_3(config: IndexConfig) -> xarray.DataArray:
-        study, ref = _get_couple_of_var(config.climate_variables, "SPI")
-        return xclim.atmos.standardized_precipitation_index(
-            pr=study, pr_cal=ref, freq="MS", window=3, dist="gamma", method="APP"
-        )
+        def preprocess(self, *args, **kwargs) -> list[xarray.DataArray]:
+            """Not implemented as xclim indicator already handle pre/post processing"""
+            raise NotImplementedError()
 
-    @staticmethod
-    def standardized_precipitation_index_6(config: IndexConfig) -> xarray.DataArray:
-        study, ref = _get_couple_of_var(config.climate_variables, "SPI")
-        return xclim.atmos.standardized_precipitation_index(
-            pr=study, pr_cal=ref, freq="MS", window=6, dist="gamma", method="APP"
-        )
+        def postprocess(self, *args, **kwargs) -> xarray.DataArray:
+            """Not implemented as xclim indicator already handle pre/post processing"""
+            raise NotImplementedError()
 
-    @staticmethod
-    def potential_evapotranspiration(config: IndexConfig) -> xarray.DataArray:
-        return xclim.atmos.potential_evapotranspiration(
-            tasmin=get_specific_var(config.climate_variables, "tasmin"),
-            tasmax=get_specific_var(config.climate_variables, "tasmax"),
-            hurs=get_specific_var(config.climate_variables, "hurs"),
-            rsds=get_specific_var(config.climate_variables, "rsds"),
-            rsus=get_specific_var(config.climate_variables, "rsus"),
-            rlds=get_specific_var(config.climate_variables, "rlds"),
-            rlus=get_specific_var(config.climate_variables, "rlus"),
-            sfcwind=get_specific_var(config.climate_variables, "sfcwind"),
-            method="FAO_PM98",
-        )
+    class StandardizedPrecipitationIndex3(Indicator):
+        """
+        Fake icclim indicator that redirect to xclim `standardized_precipitation_index`
+        indicator, with 3 MS configured.
+        """
 
+        name = "standardized_precipitation_index_3"
+        standard_name = xclim.atmos.standardized_precipitation_index.standard_name
+        long_name = "3-Month Standardized Precipitation Index (SPI3)"
+        cell_methods = ""
 
-def get_specific_var(
-    climate_variables: Sequence[ClimateVariable], var_alias: str
-) -> ClimateVariable:
-    standardized_var = StandardVariableRegistry.lookup(var_alias)
-    for climate_var in climate_variables:
-        if climate_var.standard_var == standardized_var:
-            return climate_var
-    climate_variables_display = list(
-        map(lambda x: x.standard_var.short_name, climate_variables)
-    )
-    raise InvalidIcclimArgumentError(
-        f"Could not find {var_alias} or equivalent "
-        f"in the available climate variables:"
-        f" {climate_variables_display}."
-    )
+        def __call__(self, config: IndexConfig) -> xarray.DataArray:
+            study, ref = get_couple_of_var(config.climate_variables, "SPI")
+            print(study)
+            print(ref)
+            return xclim.atmos.standardized_precipitation_index(
+                pr=study, pr_cal=ref, freq="MS", window=3, dist="gamma", method="APP"
+            )
+
+        def preprocess(self, *args, **kwargs) -> list[xarray.DataArray]:
+            """Not implemented as xclim indicator already handle pre/post processing"""
+            raise NotImplementedError()
+
+        def postprocess(self, *args, **kwargs) -> xarray.DataArray:
+            """Not implemented as xclim indicator already handle pre/post processing"""
+            raise NotImplementedError()
+
+    class StandardizedPrecipitationIndex6(Indicator):
+        """
+        Fake icclim indicator that redirect to xclim `standardized_precipitation_index`
+        indicator, with 6 MS configured.
+        """
+
+        name = "standardized_precipitation_index_6"
+        standard_name = xclim.atmos.standardized_precipitation_index.standard_name
+        long_name = "6-Month Standardized Precipitation Index (SPI6)"
+        cell_methods = ""
+
+        def __call__(self, config: IndexConfig) -> xarray.DataArray:
+            study, ref = get_couple_of_var(config.climate_variables, "SPI")
+            return xclim.atmos.standardized_precipitation_index(
+                pr=study, pr_cal=ref, freq="MS", window=6, dist="gamma", method="APP"
+            )
+
+        def preprocess(self, *args, **kwargs) -> list[xarray.DataArray]:
+            """Not implemented as xclim indicator already handle pre/post processing"""
+            raise NotImplementedError()
+
+        def postprocess(self, *args, **kwargs) -> xarray.DataArray:
+            """Not implemented as xclim indicator already handle pre/post processing"""
+            raise NotImplementedError()

--- a/icclim/ecad/xclim_binding.py
+++ b/icclim/ecad/xclim_binding.py
@@ -1,0 +1,73 @@
+from collections.abc import Sequence
+
+import xarray
+import xclim
+from icclim_exceptions import InvalidIcclimArgumentError
+
+from icclim.generic_indices.generic_indicators import _get_couple_of_var, get_single_var
+from icclim.generic_indices.standard_variable import StandardVariableRegistry
+from icclim.models.climate_variable import ClimateVariable
+from icclim.models.index_config import IndexConfig
+
+
+class XCLIM_BINDING:
+    class growing_season_length:
+        name = "growing_season_length"
+        standard_name = xclim.atmos.growing_season_length.standard_name
+        long_name = "ECAD Growing Season Length (Tmean > 5 degree_Celsius)"
+        cell_methods = ""
+
+        def __call__(self, config: IndexConfig) -> xarray.DataArray:
+            study, threshold = get_single_var(config.climate_variables)
+            return xclim.atmos.growing_season_length(
+                tas=study,
+                thresh="5 degree_Celsius",
+                window=6,
+                mid_date="07-01",
+                freq=config.frequency.pandas_freq,
+            )
+
+    @staticmethod
+    def standardized_precipitation_index_3(config: IndexConfig) -> xarray.DataArray:
+        study, ref = _get_couple_of_var(config.climate_variables, "SPI")
+        return xclim.atmos.standardized_precipitation_index(
+            pr=study, pr_cal=ref, freq="MS", window=3, dist="gamma", method="APP"
+        )
+
+    @staticmethod
+    def standardized_precipitation_index_6(config: IndexConfig) -> xarray.DataArray:
+        study, ref = _get_couple_of_var(config.climate_variables, "SPI")
+        return xclim.atmos.standardized_precipitation_index(
+            pr=study, pr_cal=ref, freq="MS", window=6, dist="gamma", method="APP"
+        )
+
+    @staticmethod
+    def potential_evapotranspiration(config: IndexConfig) -> xarray.DataArray:
+        return xclim.atmos.potential_evapotranspiration(
+            tasmin=get_specific_var(config.climate_variables, "tasmin"),
+            tasmax=get_specific_var(config.climate_variables, "tasmax"),
+            hurs=get_specific_var(config.climate_variables, "hurs"),
+            rsds=get_specific_var(config.climate_variables, "rsds"),
+            rsus=get_specific_var(config.climate_variables, "rsus"),
+            rlds=get_specific_var(config.climate_variables, "rlds"),
+            rlus=get_specific_var(config.climate_variables, "rlus"),
+            sfcwind=get_specific_var(config.climate_variables, "sfcwind"),
+            method="FAO_PM98",
+        )
+
+
+def get_specific_var(
+    climate_variables: Sequence[ClimateVariable], var_alias: str
+) -> ClimateVariable:
+    standardized_var = StandardVariableRegistry.lookup(var_alias)
+    for climate_var in climate_variables:
+        if climate_var.standard_var == standardized_var:
+            return climate_var
+    climate_variables_display = list(
+        map(lambda x: x.standard_var.short_name, climate_variables)
+    )
+    raise InvalidIcclimArgumentError(
+        f"Could not find {var_alias} or equivalent "
+        f"in the available climate variables:"
+        f" {climate_variables_display}."
+    )

--- a/icclim/generic_indices/generic_indicators.py
+++ b/icclim/generic_indices/generic_indicators.py
@@ -227,13 +227,6 @@ class GenericIndicator(ResamplingIndicator):
                 f"{self.name} can only be computed with the following"
                 f" sampling_method(s): {self.sampling_methods}"
             )
-        if is_compared_to_reference and sampling_method == RESAMPLE_METHOD:
-            raise InvalidIcclimArgumentError(
-                "It does not make sense to resample the reference variable if it is"
-                " already a subsample of the studied variable. Try setting"
-                f" `sampling_method='{GROUP_BY_REF_AND_RESAMPLE_STUDY_METHOD}'`"
-                f" instead."
-            )
         if output_unit is not None and _is_amount_unit(output_unit):
             for climate_var in climate_vars:
                 current_unit = climate_var.studied_data.attrs.get(UNITS_KEY, None)
@@ -638,8 +631,16 @@ def difference_of_means(
     to_percent: bool,
     resample_freq: Frequency,
     sampling_method: str,
+    is_compared_to_reference: bool,
     **kwargs,  # noqa
 ):
+    if is_compared_to_reference and sampling_method == RESAMPLE_METHOD:
+        raise InvalidIcclimArgumentError(
+            "It does not make sense to resample the reference variable if it is"
+            " already a subsample of the studied variable. Try setting"
+            f" `sampling_method='{GROUP_BY_REF_AND_RESAMPLE_STUDY_METHOD}'`"
+            f" instead."
+        )
     study, ref = get_couple_of_var(climate_vars, "difference_of_means")
     if sampling_method == GROUP_BY_METHOD:
         if resample_freq.group_by_key == RUN_INDEXER:
@@ -711,7 +712,7 @@ def _diff_of_means_of_resampled_x_by_groupedby_y(
 def _check_single_var(climate_vars: list[ClimateVariable], indicator: GenericIndicator):
     if len(climate_vars) > 1:
         raise InvalidIcclimArgumentError(
-            f"{indicator.name} can only be computed on a" f" single variable."
+            f"{indicator.name} can only be computed on a single variable."
         )
 
 
@@ -893,7 +894,7 @@ def get_couple_of_var(
 ) -> tuple[DataArray, DataArray]:
     if len(climate_vars) != 2:
         raise InvalidIcclimArgumentError(
-            f"{indicator} needs two variable **or** one variable and a "
+            f"{indicator} needs two variables **or** one variable and a "
             f"`base_period_time_range` period to extract a reference variable."
         )
     if climate_vars[0].threshold or climate_vars[1].threshold:

--- a/icclim/generic_indices/generic_indicators.py
+++ b/icclim/generic_indices/generic_indicators.py
@@ -583,7 +583,7 @@ def mean_of_difference(
     resample_freq: Frequency,
     **kwargs,  # noqa
 ):
-    study, ref = _get_couple_of_var(climate_vars, "mean_of_difference")
+    study, ref = get_couple_of_var(climate_vars, "mean_of_difference")
     mean_of_diff = (study - ref).resample(time=resample_freq.pandas_freq).mean()
     mean_of_diff.attrs["units"] = study.attrs["units"]
     return mean_of_diff
@@ -594,7 +594,7 @@ def difference_of_extremes(
     resample_freq: Frequency,
     **kwargs,  # noqa
 ):
-    study, ref = _get_couple_of_var(climate_vars, "difference_of_extremes")
+    study, ref = get_couple_of_var(climate_vars, "difference_of_extremes")
     max_study = study.resample(time=resample_freq.pandas_freq).max()
     min_ref = ref.resample(time=resample_freq.pandas_freq).min()
     diff_of_extremes = max_study - min_ref
@@ -624,7 +624,7 @@ def mean_of_absolute_one_time_step_difference(
     DataArray
     mean_of_absolute_one_time_step_difference as a xarray.DataArray
     """
-    study, ref = _get_couple_of_var(
+    study, ref = get_couple_of_var(
         climate_vars, "mean_of_absolute_one_time_step_difference"
     )
     one_time_step_diff = (study - ref).diff(dim="time")
@@ -640,7 +640,7 @@ def difference_of_means(
     sampling_method: str,
     **kwargs,  # noqa
 ):
-    study, ref = _get_couple_of_var(climate_vars, "difference_of_means")
+    study, ref = get_couple_of_var(climate_vars, "difference_of_means")
     if sampling_method == GROUP_BY_METHOD:
         if resample_freq.group_by_key == RUN_INDEXER:
             mean_study = study.mean(dim="time")
@@ -888,9 +888,14 @@ def _compute_exceedance(
     return exceedances
 
 
-def _get_couple_of_var(
+def get_couple_of_var(
     climate_vars: list[ClimateVariable], indicator: str
 ) -> tuple[DataArray, DataArray]:
+    if len(climate_vars) != 2:
+        raise InvalidIcclimArgumentError(
+            f"{indicator} needs two variable **or** one variable and a "
+            f"`base_period_time_range` period to extract a reference variable."
+        )
     if climate_vars[0].threshold or climate_vars[1].threshold:
         raise InvalidIcclimArgumentError(
             f"{indicator} cannot be computed with thresholds."

--- a/icclim/generic_indices/generic_indicators.py
+++ b/icclim/generic_indices/generic_indicators.py
@@ -381,7 +381,7 @@ def excess(
     resample_freq: Frequency,
     **kwargs,  # noqa
 ) -> DataArray:
-    study, threshold = _get_single_var(climate_vars)
+    study, threshold = get_single_var(climate_vars)
     if threshold.operator is not OperatorRegistry.REACH:
         raise InvalidIcclimArgumentError("")
     excesses = threshold.compute(study, override_op=lambda da, th: da - th)
@@ -396,7 +396,7 @@ def deficit(
     resample_freq: Frequency,
     **kwargs,  # noqa
 ) -> DataArray:
-    study, threshold = _get_single_var(climate_vars)
+    study, threshold = get_single_var(climate_vars)
     deficit = threshold.compute(study, override_op=lambda da, th: th - da)
     res = deficit.clip(min=0).resample(time=resample_freq.pandas_freq).sum(dim="time")
     return to_agg_units(res, study, "delta_prod")
@@ -408,7 +408,7 @@ def fraction_of_total(
     to_percent: bool,
     **kwargs,  # noqa
 ) -> DataArray:
-    study, threshold = _get_single_var(climate_vars)
+    study, threshold = get_single_var(climate_vars)
     if threshold.threshold_min_value is not None:
         total = (
             study.where(threshold.operator(study, threshold.threshold_min_value.m))
@@ -910,7 +910,7 @@ def _run_rolling_reducer(
     date_event: bool,
     source_freq_delta: timedelta,
 ) -> DataArray:
-    study, threshold = _get_single_var(climate_vars)
+    study, threshold = get_single_var(climate_vars)
     if threshold:
         exceedance = _compute_exceedance(
             study=study,
@@ -939,7 +939,7 @@ def _run_simple_reducer(
     date_event: bool,
     must_convert_rate: bool = False,
 ):
-    study, threshold = _get_single_var(climate_vars)
+    study, threshold = get_single_var(climate_vars)
     if threshold is not None:
         exceedance = _compute_exceedance(
             study=study,
@@ -981,7 +981,7 @@ def _compute_exceedances(
     return logical_link(exceedances)
 
 
-def _get_single_var(
+def get_single_var(
     climate_vars: list[ClimateVariable],
 ) -> tuple[DataArray, Threshold | None]:
     if climate_vars[0].threshold:

--- a/icclim/generic_indices/standard_variable.py
+++ b/icclim/generic_indices/standard_variable.py
@@ -65,7 +65,7 @@ class StandardVariableRegistry(Registry[StandardVariable]):
             "meanT",
             "tasmidpoint",
         ],
-        default_units="degC",
+        default_units="degree_Celsius",
     )
     TAS_MIN = StandardVariable(
         short_name="tn",
@@ -83,7 +83,7 @@ class StandardVariableRegistry(Registry[StandardVariable]):
             "MINT",
             "minT",
         ],
-        default_units="degC",
+        default_units="degree_Celsius",
     )
     TAS_MAX = StandardVariable(
         short_name="tx",
@@ -101,7 +101,7 @@ class StandardVariableRegistry(Registry[StandardVariable]):
             "MAXT",
             "maxT",
         ],
-        default_units="degC",
+        default_units="degree_Celsius",
     )
     HURS = StandardVariable(
         short_name="hurs",
@@ -206,6 +206,20 @@ class StandardVariableRegistry(Registry[StandardVariable]):
         standard_name="surface_downwelling_longwave_flux_in_air",
         long_name="Surface Downwelling Longwave Radiation",
         aliases=["rlds", "surface_downwelling_longwave_flux"],
+        default_units="W m-2",
+    )
+    RSUS = StandardVariable(
+        short_name="rsds",
+        standard_name="surface_upwelling_shortwave_flux_in_air",
+        long_name="Surface Upwelling Shortwave Radiation",
+        aliases=["rsus", "surface_upwelling_shortwave_flux"],
+        default_units="W m-2",
+    )
+    RLUS = StandardVariable(
+        short_name="rlds",
+        standard_name="surface_upwelling_longwave_flux_in_air",
+        long_name="Surface Upwelling Longwave Radiation",
+        aliases=["rlus", "surface_upwelling_longwave_flux"],
         default_units="W m-2",
     )
     OROG = StandardVariable(

--- a/icclim/models/climate_variable.py
+++ b/icclim/models/climate_variable.py
@@ -15,7 +15,7 @@ from icclim.generic_indices.threshold import (
 )
 from icclim.icclim_exceptions import InvalidIcclimArgumentError
 from icclim.icclim_types import InFileBaseType, InFileLike
-from icclim.models.constants import UNITS_KEY
+from icclim.models.constants import REFERENCE_PERIOD_INDEX, UNITS_KEY
 from icclim.models.frequency import Frequency, FrequencyRegistry
 from icclim.models.global_metadata import GlobalMetadata
 from icclim.models.standard_index import StandardIndex
@@ -120,7 +120,9 @@ def build_climate_vars(
                 standard_var=standard_var,
             )
         )
-    if is_compared_to_reference:
+    if _standard_index_needs_ref(
+        standard_index, is_compared_to_reference
+    ) or _generic_index_needs_ref(standard_index, is_compared_to_reference):
         standard_var = (
             standard_index.input_variables[0] if standard_index is not None else None
         )
@@ -131,6 +133,19 @@ def build_climate_vars(
         )
         acc.append(added_var)
     return acc
+
+
+def _standard_index_needs_ref(standard_index, is_compared_to_reference):
+    return (
+        standard_index
+        and standard_index.qualifiers
+        and REFERENCE_PERIOD_INDEX in standard_index.qualifiers
+        and is_compared_to_reference
+    )
+
+
+def _generic_index_needs_ref(standard_index, is_compared_to_reference):
+    return standard_index is None and is_compared_to_reference
 
 
 def _build_reference_variable(

--- a/icclim/models/constants.py
+++ b/icclim/models/constants.py
@@ -29,8 +29,9 @@ VALID_PERCENTILE_DIMENSION = ["quantile", "percentile", "per", "centile"]
 ECAD_ATBD = "ECA&D, Algorithm Theoretical Basis Document (ATBD) v11"
 
 # Index qualifiers (needed to generate the API)
-QUANTILE_BASED = "QUANTILE_BASED"  # fields: QUANTILE_INDEX_FIELDS
-MODIFIABLE_UNIT = "MODIFIABLE_UNIT"  # fields: out_unit
+QUANTILE_BASED = "QUANTILE_BASED"
+REFERENCE_PERIOD_INDEX = "REFERENCE_PERIOD_INDEX"
+
 
 # Map of months index to their short name, used to get a pandas frequency anchor
 MONTHS_MAP = {1:"JAN",  2:"FEB", 3:"MAR", 4:"APR", 5:"MAY", 6:"JUN", 7:"JUL", 8:"AUG", 9:"SEP", 10:"OCT", 11:"NOV", 12:"DEC" }

--- a/icclim/tests/test_generated_api.py
+++ b/icclim/tests/test_generated_api.py
@@ -12,7 +12,7 @@ from icclim.generic_indices.generic_indicators import GenericIndicatorRegistry
 from icclim.generic_indices.threshold import build_threshold
 from icclim.icclim_exceptions import InvalidIcclimArgumentError
 from icclim.icclim_logger import VerbosityRegistry
-from icclim.models.constants import QUANTILE_BASED
+from icclim.models.constants import QUANTILE_BASED, REFERENCE_PERIOD_INDEX
 from icclim.models.frequency import FrequencyRegistry
 from icclim.models.netcdf_version import NetcdfVersionRegistry
 from icclim.models.quantile_interpolation import QuantileInterpolationRegistry
@@ -44,6 +44,12 @@ def build_expected_args(index: StandardIndex):
                 "only_leap_years": False,
                 "interpolation": QuantileInterpolationRegistry.MEDIAN_UNBIASED.name,
                 "save_thresholds": False,
+            }
+        )
+    elif REFERENCE_PERIOD_INDEX in qualifiers:
+        expected_call_args.update(
+            {
+                "base_period_time_range": None,
             }
         )
     if index.threshold is not None:

--- a/icclim/utils.py
+++ b/icclim/utils.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import re
+import warnings
 from datetime import datetime
 
 import dateparser
@@ -27,6 +29,12 @@ def read_date(in_date: str | datetime) -> datetime:
 
 def get_date_to_iso_format(in_date: str | datetime) -> str:
     if isinstance(in_date, str):
+        if re.match(r"^\d{4}$", in_date):
+            warnings.warn(f"{in_date} is transformed into {in_date}-01-01")
+            in_date += "-01-01"
+        if re.match(r"^\d{4}-\d{2}$", in_date):
+            warnings.warn(f"{in_date} is transformed into {in_date}-01")
+            in_date += "-01"
         in_date = read_date(in_date)
     return in_date.strftime("%Y-%m-%d")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ fsspec
 jinja2
 netCDF4~=1.5.7
 numpy
-pandas
 pandas>=1.3
 pint<0.20
 psutil

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,7 +7,6 @@ flake8-rst-docstrings
 isort
 netCDF4~=1.5.7
 numpy~=1.22
-pandas~=1.3.1
 pandas>=1.3
 pint<0.20
 pip
@@ -24,6 +23,6 @@ sphinx_codeautolink
 sphinx_copybutton
 sphinx_lfs_content
 twine
-xarray~=0.19.0
+xarray>=2022.6
 xclim~=0.38.0
 zarr

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -25,5 +25,5 @@ sphinx_copybutton
 sphinx_lfs_content
 twine
 xarray~=0.19.0
-xclim~=0.37.0
+xclim~=0.38.0
 zarr


### PR DESCRIPTION
<!--
The following checklist points should all be checked before merging the PR.

Please replace xxx by your issue number (leave the prefixing '#').
-->

Draft how we should bind existing xclim indices into icclim v6 to complete the ECAD list.

### Pull Request to resolve #203 
- [x] Unit tests cover the changes.
- [x] These changes were tested on real data.
- [x] The relevant documentation has been added or updated.
- [x] A short description of the changes has been added to `doc/source/references/release_notes.rst`.

### Describe the changes you made
- Add some ECAD indices that can be easily bind to xclim's indicators.
This includes `{GSL, SPI3, SPI6}`.
The same approach could be used for other missing indices that **can't** be generified and that are available within xclim.
- Add some documentation for generic indices.

This PR is also related to #204 but does not fully resolve it.
