### PR TITLE
Adapt to xclim 0.40

### DIFF
--- a/icclim/generic_indices/threshold.py
+++ b/icclim/generic_indices/threshold.py
@@ -37,6 +37,7 @@ from icclim.models.quantile_interpolation import (
     QuantileInterpolationRegistry,
 )
 from icclim.pre_processing.input_parsing import (
+    PercentileDataArray,
     build_reference_da,
     find_standard_vars,
     get_name_of_first_var,
@@ -44,7 +45,6 @@ from icclim.pre_processing.input_parsing import (
     read_clim_bounds,
     read_dataset,
     standardize_percentile_dim_name,
-    PercentileDataArray
 )
 from icclim.utils import is_number_sequence
 

--- a/icclim/generic_indices/threshold.py
+++ b/icclim/generic_indices/threshold.py
@@ -14,7 +14,7 @@ from xclim.core.bootstrapping import percentile_bootstrap
 from xclim.core.calendar import build_climatology_bounds, percentile_doy, resample_doy
 from xclim.core.units import convert_units_to, str2pint
 from xclim.core.units import units as xc_units
-from xclim.core.utils import PercentileDataArray, calc_perc
+from xclim.core.utils import calc_perc
 
 from icclim.generic_indices.threshold_templates import (
     EN_THRESHOLD_TEMPLATE,
@@ -44,6 +44,7 @@ from icclim.pre_processing.input_parsing import (
     read_clim_bounds,
     read_dataset,
     standardize_percentile_dim_name,
+    PercentileDataArray
 )
 from icclim.utils import is_number_sequence
 

--- a/icclim/pre_processing/input_parsing.py
+++ b/icclim/pre_processing/input_parsing.py
@@ -56,7 +56,8 @@ class PercentileDataArray(xr.DataArray):
             It must also have a coordinate variable percentiles or quantile.
         climatology_bounds : list[str]
             Optional. A List of size two which contains the period on which the
-            percentiles were computed. See :py:func:`xclim.core.calendar.build_climatology_bounds`
+            percentiles were computed. See
+            `xclim.core.calendar.build_climatology_bounds`
             to build this list from a DataArray.
 
         Returns

--- a/icclim/pre_processing/input_parsing.py
+++ b/icclim/pre_processing/input_parsing.py
@@ -10,7 +10,6 @@ from pint import Quantity
 from xarray.core.dataarray import DataArray
 from xarray.core.dataset import Dataset
 from xclim.core.units import convert_units_to
-from xclim.core.utils import PercentileDataArray
 
 from icclim.generic_indices.standard_variable import (
     StandardVariable,
@@ -24,6 +23,68 @@ from icclim.models.standard_index import StandardIndex
 from icclim.utils import get_date_to_iso_format, is_precipitation_amount
 
 DEFAULT_INPUT_FREQUENCY = "days"
+
+
+class PercentileDataArray(xr.DataArray):
+    """Wrap xarray DataArray for percentiles values."""
+
+    __slots__ = ()
+
+    @classmethod
+    def is_compatible(cls, source: xr.DataArray) -> bool:
+        """Evaluate whether PecentileDataArray is conformant with expected fields.
+
+        A PercentileDataArray must have climatology_bounds attributes and either a
+        quantile or percentiles coordinate, the window is not mandatory.
+        """
+        return (
+            isinstance(source, xr.DataArray)
+            and source.attrs.get("climatology_bounds", None) is not None
+            and ("quantile" in source.coords or "percentiles" in source.coords)
+        )
+
+    @classmethod
+    def from_da(
+        cls, source: xr.DataArray, climatology_bounds: list[str] = None
+    ) -> PercentileDataArray:
+        """Create a PercentileDataArray from a xarray.DataArray.
+
+        Parameters
+        ----------
+        source : xr.DataArray
+            A DataArray with its content containing percentiles values.
+            It must also have a coordinate variable percentiles or quantile.
+        climatology_bounds : list[str]
+            Optional. A List of size two which contains the period on which the
+            percentiles were computed. See :py:func:`xclim.core.calendar.build_climatology_bounds`
+            to build this list from a DataArray.
+
+        Returns
+        -------
+        PercentileDataArray
+            The initial `source` DataArray but wrap by PercentileDataArray class.
+            The data is unchanged and only climatology_bounds attributes is overridden
+            if q new value is given in inputs.
+        """
+        if (
+            climatology_bounds is None
+            and source.attrs.get("climatology_bounds", None) is None
+        ):
+            raise ValueError("PercentileDataArray needs a climatology_bounds.")
+        per = cls(source)
+        # handle case where da was created with `quantile()` method
+        if "quantile" in source.coords:
+            per = per.rename({"quantile": "percentiles"})
+            per.coords["percentiles"] = per.coords["percentiles"] * 100
+        clim_bounds = source.attrs.get("climatology_bounds", climatology_bounds)
+        per.attrs["climatology_bounds"] = clim_bounds
+        if "percentiles" in per.coords:
+            return per
+        raise ValueError(
+            f"DataArray {source.name} could not be turned into"
+            f" PercentileDataArray. The DataArray must have a"
+            f" 'percentiles' coordinate variable."
+        )
 
 
 def guess_var_names(

--- a/icclim/tests/test_input_parsing.py
+++ b/icclim/tests/test_input_parsing.py
@@ -12,10 +12,10 @@ from icclim.ecad.ecad_indices import EcadIndexRegistry
 from icclim.icclim_exceptions import InvalidIcclimArgumentError
 from icclim.models.constants import UNITS_KEY
 from icclim.pre_processing.input_parsing import (
+    PercentileDataArray,
     guess_var_names,
     read_dataset,
     update_to_standard_coords,
-    PercentileDataArray
 )
 
 

--- a/icclim/tests/test_input_parsing.py
+++ b/icclim/tests/test_input_parsing.py
@@ -7,7 +7,6 @@ import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
-from xclim.core.utils import PercentileDataArray
 
 from icclim.ecad.ecad_indices import EcadIndexRegistry
 from icclim.icclim_exceptions import InvalidIcclimArgumentError
@@ -16,6 +15,7 @@ from icclim.pre_processing.input_parsing import (
     guess_var_names,
     read_dataset,
     update_to_standard_coords,
+    PercentileDataArray
 )
 
 

--- a/icclim/tests/test_threshold.py
+++ b/icclim/tests/test_threshold.py
@@ -21,6 +21,7 @@ from icclim.icclim_exceptions import InvalidIcclimArgumentError
 from icclim.models.constants import UNITS_KEY
 from icclim.models.logical_link import LogicalLinkRegistry
 from icclim.models.operator import OperatorRegistry
+from icclim.pre_processing.input_parsing import PercentileDataArray
 
 
 def test_value_error():
@@ -295,6 +296,7 @@ class Test_FileBased:
 
     def test_build_percentile_threshold__from_file(self):
         doys = percentile_doy(self.data)
+        doys = PercentileDataArray.from_da(doys)
         doys.to_netcdf(path=self.IN_FILE_PATH)
         res = build_threshold(operator=">=", value=self.IN_FILE_PATH)
         assert isinstance(res, PercentileThreshold)


### PR DESCRIPTION
### Pull Request to resolve #xxx
- [x] Unit tests cover the changes.
- [ ] These changes were tested on real data.
- [ ] The relevant documentation has been added or updated.
- [ ] A short description of the changes has been added to `doc/source/references/release_notes.rst`.

### Describe the changes you made
We will soon release xclim 0.40 in which there are some breaking changes for icclim:

- [x] One of them was brought by Ouranosinc/xclim#1236 where `PercentileDataArray` was deprecated. In this PR I simply ported the class to icclim. 

- [ ] Another is from Ouranosinc/xclim#1227 where the "hydro" unit context was deactivated by default. This was mainly used to convert between precipitation rate ( mm /d ) and flux (kg m-2 s-1). With additions from Ouranosinc/xclim#1206, if the inputs of the `convert_units_to` function have valid and compatible standard names, the conversion can still be made automatically, but without these CF attributes, the default is to raise an error. This can be avoided by passing `context='infer'` or `context='hydro'` to `convert_units_to`. With the latter, the rate-to-flux transformations are always possible, while the former only activates them when the standard name of the input refers to water.

I saw the tests failures on my side, but I didn't want to apply a patch without opinions from people here.
