### PR TITLE
FIX: Pin xclim to 0.39

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
     -   id: requirements-txt-fixer
         language_version: python3
 -   repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: 23.1.0
     hooks:
     -   id: black
         language_version: python3

--- a/doc/source/references/release_notes.rst
+++ b/doc/source/references/release_notes.rst
@@ -1,11 +1,13 @@
 Release history
 ===============
 
-6.2.0 (unreleased)
-------------------
+6.2.0
+-----
 * [maint] Upgrade and adapt to xclim 0.40.
   Moved PercentileDataArray from xclim to icclim.
   Adapted the unit cenversion to use the hydro context.
+
+* [fix] Pin xclim to exact 0.40 to avoid breaking changes.
 
 
 6.1.5

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
 # Core dependencies
  - python>=3.8
- - xclim>=0.40
+ - xclim==0.40
  - numpy
  - xarray>=2022.6
  - cf_xarray>=0.7.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,5 +18,5 @@ sphinx_codeautolink
 sphinx_copybutton
 sphinx_lfs_content
 xarray>=2022.6
-xclim~=0.40
+xclim==0.40
 zarr

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -25,5 +25,5 @@ sphinx_copybutton
 sphinx_lfs_content
 twine
 xarray>=2022.6
-xclim~=0.40
+xclim==0.40
 zarr

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 MINIMAL_REQUIREMENTS = [
     "numpy>=1.16",
     "xarray>=2022.6",
-    "xclim>=0.40",
+    "xclim==0.40",
     "cf_xarray>=0.7.4",
     "cftime>=1.4.1",
     "dask[array]",


### PR DESCRIPTION
Pin xclim to 0.39

Fixes:
- installation of icclim on pipy (no issue opened yet)
- https://github.com/Ouranosinc/xclim/issues/1294

This Pr should **not** be merged into the main trunk (master).
The fixing commit will be tagged 6.1.6 and be published to pipy and conda-forge
