### PR TITLE
Fix/unit for diff based indices

### DIFF
--- a/doc/source/_static/logo_icclim_colored__displayed.svg
+++ b/doc/source/_static/logo_icclim_colored__displayed.svg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cbb3b0dc6978cb3a9b3d72fc9f27d13ceb2f593ac081bb9ff8f687535dd923e5
+oid sha256:02be51c905baba036d5fbc1d622eb8509ee6fa11ac40209e30f4fa28ca72add6
 size 66296

--- a/doc/source/_static/logo_icclim_grey__displayed.svg
+++ b/doc/source/_static/logo_icclim_grey__displayed.svg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:12c01ff2f5def2cc8c950f4f822b869adceadec85f1011ae5769dff33429094a
+oid sha256:4e786640ea61f8e0353a78c0db676e891ad081c4074451951e396ab48234b1f6
 size 63678

--- a/doc/source/_static/logo_icclim_white__displayed.svg
+++ b/doc/source/_static/logo_icclim_white__displayed.svg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c78c30348dce8a5c484e4fcd697fc9b4c00816daa80789e42fb93416bc47a1b4
+oid sha256:041391f619b6a855034ff99d0659d172bbb8f626c2cec7e23351dc7344c2ed59
 size 39021

--- a/doc/source/references/release_notes.rst
+++ b/doc/source/references/release_notes.rst
@@ -1,6 +1,12 @@
 Release history
 ===============
 
+6.3.0 (unreleased)
+------------------
+* [fix] **BREAKING CHANGE** The indicators based on the difference between two variables (ecad: DTR, ETR, vDTR and anomaly) gave wrong values due to a bad unit conversion of the output.
+  This was for example the case when the input variables are in Kelvin, the difference between the two variables is still in Kelvin but it cannot be converted to degree Celsius with the ususal `+273.15`.
+  To workaround this issue, we first convert inputs to the expected output unit and then we compute the index.
+
 6.2.0
 -----
 * [maint] Upgrade and adapt to xclim 0.40.

--- a/icclim/_generated_api.py
+++ b/icclim/_generated_api.py
@@ -6,7 +6,7 @@ This module exposes each climate index as individual functions for convenience.
 # flake8: noqa E501
 from __future__ import annotations
 
-import datetime
+from datetime import datetime
 from typing import Sequence
 
 from xarray.core.dataset import Dataset

--- a/icclim/models/climate_variable.py
+++ b/icclim/models/climate_variable.py
@@ -32,9 +32,10 @@ from icclim.pre_processing.input_parsing import (
 
 @dataclass
 class ClimateVariable:
-    """Internal icclim structure. It groups together the input variable (studied_data),
-    its associated metadata (standard_variable) and the threshold it must be compared
-    to.
+    """Internal icclim structure.
+    It groups together the input variable (studied_data),
+    its associated metadata (standard_var) and, if any,
+    the threshold it must be compared to.
 
     Attributes
     ----------

--- a/icclim/models/constants.py
+++ b/icclim/models/constants.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 # fmt: off
 # flake8: noqa
 
-ICCLIM_VERSION = "6.2.0"
+ICCLIM_VERSION = "6.3.0"
 
 # placeholders for user_index
 PERCENTILE_THRESHOLD_STAMP = "p"

--- a/icclim/tests/test_main.py
+++ b/icclim/tests/test_main.py
@@ -130,7 +130,7 @@ class Test_Integration:
 
     def test_index_DTR(self):
         ds = self.data.to_dataset(name="toto")
-        ds["tutu"] = self.data
+        ds["tutu"] = self.data + 10
         res = icclim.index(
             index_name="DTR",
             in_files=ds,
@@ -138,7 +138,21 @@ class Test_Integration:
             var_name=["toto", "tutu"],
         )
         assert f"icclim version: {ICCLIM_VERSION}" in res.attrs["history"]
-        np.testing.assert_array_equal(0, res.DTR)
+        np.testing.assert_array_equal(-10, res.DTR)
+
+    def test_index_DTR__with_unit_conversion(self):
+        ds = self.data.to_dataset(name="toto")
+        ds["tutu"] = self.data + 10
+        ds["toto"].attrs["units"] = "K"
+        ds["tutu"].attrs["units"] = "K"
+        res = icclim.dtr(
+            in_files=ds,
+            out_file=self.OUTPUT_FILE,
+            var_name=["toto", "tutu"],
+        )
+        assert f"icclim version: {ICCLIM_VERSION}" in res.attrs["history"]
+        np.testing.assert_array_equal(-10, res.DTR)
+        np.testing.assert_array_equal("°C", res.DTR.attrs["units"])
 
     def test_index_CD(self):
         ds = self.data.to_dataset(name="tas")

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ MINIMAL_REQUIREMENTS = [
 
 setup(
     name="icclim",
-    version="6.2.0",
+    version="6.3.0",
     packages=find_packages(),
     author="Christian P.",
     author_email="christian.page@cerfacs.fr",

--- a/tools/extract-icclim-funs.py
+++ b/tools/extract-icclim-funs.py
@@ -87,7 +87,7 @@ This module exposes each climate index as individual functions for convenience.
 # flake8: noqa E501
 from __future__ import annotations
 
-import datetime
+from datetime import datetime
 from typing import Sequence
 
 from xarray.core.dataset import Dataset


### PR DESCRIPTION
<!--
The following checklist points should all be checked before merging the PR.

Please replace xxx by your issue number (leave the prefixing '#').
-->

### Pull Request to resolve #255
- [x] Unit tests cover the changes.
- [ ] These changes were tested on real data.
- [ ] The relevant documentation has been added or updated.
- [x] A short description of the changes has been added to `doc/source/references/release_notes.rst`.

### Describe the changes you made
Indicators computing the difference between two variables must first convert the units of input variables to the expected output unit in order to avoid converting the output which would be a relative "temperature".
In other words: a 15 Kelvin difference *is* equivalent to a 15 degC and *is not* to a -258.15 degC.
