### PR TITLE
Bump to placeholder version

### DIFF
--- a/doc/source/references/release_notes.rst
+++ b/doc/source/references/release_notes.rst
@@ -1,6 +1,10 @@
 Release history
 ===============
 
+6.3.1 (unreleased)
+------------------
+
+
 6.3.0
 -----
 * [maint] Upgrade to xclim 0.42 (released on 04/04/2023).

--- a/icclim/models/constants.py
+++ b/icclim/models/constants.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 # fmt: off
 # flake8: noqa
 
-ICCLIM_VERSION = "6.3.0"
+ICCLIM_VERSION = "6.3.1.dev"
 
 # placeholders for user_index
 PERCENTILE_THRESHOLD_STAMP = "p"

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ MINIMAL_REQUIREMENTS = [
 
 setup(
     name="icclim",
-    version="6.3.0",
+    version="6.3.1.dev",
     packages=find_packages(),
     author="Christian P.",
     author_email="christian.page@cerfacs.fr",


### PR DESCRIPTION
This should make it more obvious that the version displayed on master branch README and documentation is not yet released.

Depending on the upcoming changes the version number could be updated to 6.4 (or even 7.0) directly instead of 6.3.1.