### PR TITLE
MAINT: Upgrade to xclim 0.43

### DIFF
--- a/doc/source/references/release_notes.rst
+++ b/doc/source/references/release_notes.rst
@@ -1,14 +1,19 @@
 Release history
 ===============
 
+6.4.0.dev
+---------
+
+* [maint] Upgrade to xclim 0.43 (released on 04/04/2023).
+* [maint] Change how xclim is pinned to allow patch changes.
+
+
 6.3.0
 -----
 * [maint] Upgrade to xclim 0.42 (released on 04/04/2023).
-
 * [fix] **BREAKING CHANGE** The indicators based on the difference between two variables (ecad: DTR, ETR, vDTR and anomaly) gave wrong values due to a bad unit conversion of the output.
   This was for example the case when the input variables are in Kelvin, the difference between the two variables is still in Kelvin but it cannot be converted to degree Celsius with the ususal `+273.15`.
   To workaround this issue, we first convert inputs to the expected output unit and then we compute the index.
-
 * [fix] **BREAKING CHANGE** Indices based on both a percentile threshold and a `threshold_min_value` (for ecad: r75p, r75pTOT, r95p, r95pTOT, r99p, r99pTOT)
   are now computing the exceedance rate on values above `threshold_min_value` as well. Previously this `threshold_min_value` was used to compute the percentile and the total (for rxxpTOT indices)
   but not the exceedance rate.
@@ -18,7 +23,6 @@ Release history
 * [maint] Upgrade and adapt to xclim 0.40.
   Moved PercentileDataArray from xclim to icclim.
   Adapted the unit cenversion to use the hydro context.
-
 * [fix] Pin xclim to exact 0.40 to avoid breaking changes.
 
 

--- a/doc/source/references/release_notes.rst
+++ b/doc/source/references/release_notes.rst
@@ -4,7 +4,7 @@ Release history
 6.4.0.dev
 ---------
 
-* [maint] Upgrade to xclim 0.43 (released on 04/04/2023).
+* [maint] Upgrade to xclim 0.43 (released on 09/05/2023).
 * [maint] Change how xclim is pinned to allow patch changes.
 
 

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
 # Core dependencies
  - python>=3.8
- - xclim==0.42
+ - xclim==0.43
  - numpy
  - xarray>=2022.6
  - cf_xarray>=0.7.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,5 +18,5 @@ sphinx_codeautolink
 sphinx_copybutton
 sphinx_lfs_content
 xarray>=2022.6
-xclim==0.42
+xclim==0.43
 zarr

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -25,5 +25,5 @@ sphinx_copybutton
 sphinx_lfs_content
 twine
 xarray>=2022.6
-xclim==0.42
+xclim==0.43
 zarr

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 MINIMAL_REQUIREMENTS = [
     "numpy>=1.16",
     "xarray>=2022.6",
-    "xclim==0.42",
+    "xclim>=0.43, <0.44",
     "cf_xarray>=0.7.4",
     "cftime>=1.4.1",
     "dask[array]",


### PR DESCRIPTION
Also pin xclim to any 0.43.x instead of `0.43.0`

<!--
The following checklist points should all be checked before merging the PR.

Please replace xxx by your issue number (leave the prefixing '#').
-->

### Pull Request to resolve #261 
- [ ] Unit tests cover the changes.
- [ ] These changes were tested on real data.
- [ ] The relevant documentation has been added or updated.
- [x] A short description of the changes has been added to `doc/source/references/release_notes.rst`.

### Describe the changes you made

Upgrade to latest xclim version
