### PR TITLE
BUMP: 6.5.0

### DIFF
--- a/doc/source/_static/logo_icclim_colored__displayed.svg
+++ b/doc/source/_static/logo_icclim_colored__displayed.svg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:90dede8ffd57ef0fe5355101a193bc67aa22624994ff3878d64d6cc72e8221c3
+oid sha256:20c7e02484d6f4fecd789204d6e33c59fd0c7074c1604892cf37c44a79e5ddf8
 size 66296

--- a/doc/source/_static/logo_icclim_grey__displayed.svg
+++ b/doc/source/_static/logo_icclim_grey__displayed.svg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0447e6981593f2d7ba6dffcb65b727e292b7c7812c10519a8e13f5686e07f81f
+oid sha256:2bd223c63c85d4c3bfb2386c44cfa73ae2277027c991fd719592e096ba07057f
 size 63678

--- a/doc/source/_static/logo_icclim_white__displayed.svg
+++ b/doc/source/_static/logo_icclim_white__displayed.svg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2a45a9dc15906f560d263adb89c79a5174496817d8be55c12a6f5ca69e6d5f43
+oid sha256:418125a130bcb58f3642dba907fab1c2b2daf82df7faa8e58e310c449f996cb6
 size 39021

--- a/doc/source/references/release_notes.rst
+++ b/doc/source/references/release_notes.rst
@@ -1,8 +1,8 @@
 Release history
 ===============
 
-6.5.0 (unreleased)
-------------------
+6.5.0
+-----
 
 * [maint] Adapt generic indicators "excess" and "deficit" to xclim 0.45.
 * [maint] Upgrade minimal python version to 3.9

--- a/icclim/models/constants.py
+++ b/icclim/models/constants.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 # fmt: off
 # flake8: noqa
 
-ICCLIM_VERSION = "6.4.0"
+ICCLIM_VERSION = "6.5.0"
 
 # placeholders for user_index
 PERCENTILE_THRESHOLD_STAMP = "p"

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ MINIMAL_REQUIREMENTS = [
 
 setup(
     name="icclim",
-    version="6.4.0",
+    version="6.5.0",
     packages=find_packages(),
     author="Christian P.",
     author_email="christian.page@cerfacs.fr",


### PR DESCRIPTION
Bump icclim to 6.5.0.

This release fixes #256  and #281.
It requires xclim version to be between 0.45 and 0.47 due to breaking changes in `to_agg_unit` utility function in xclim 0.45. 