### PR TITLE
Enh/add auto release process

### DIFF
--- a/.github/workflows/publish-to-pipy.yml
+++ b/.github/workflows/publish-to-pipy.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           python-version: 3.9
       - name: Install tools
-        uses: python -m pip install --upgrade pip flit
+        run: python -m pip install --upgrade pip flit
       - name: Install icclim for prod
         run: python -m flit install --deps production
       - name: build package

--- a/.github/workflows/publish-to-pipy.yml
+++ b/.github/workflows/publish-to-pipy.yml
@@ -1,0 +1,27 @@
+name: Publish icclim to pypi
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  deployment:
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+        id-token: write # needed for trusted publishing
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Install tools
+        uses: python -m pip install --upgrade pip flit
+      - name: Install icclim for prod
+        run: python -m flit install --deps production
+      - name: build package
+        run: python -m flit build
+      - name: Publish to pypi
+        uses: pypa/gh-action-pypi-publish@v1.8.11

--- a/doc/source/dev/release_process.rst
+++ b/doc/source/dev/release_process.rst
@@ -1,6 +1,33 @@
 Release process
 ===============
 
+Automatic Release
++++++++++++++++++
+
+As of icclim 6.6.0, a github action (`.github/workflows/publish-to-pypi.yml`) publishes
+icclim to pypi whenever a (github release)[https://github.com/cerfacs-globc/icclim/releases]
+is published.
+This github action requires a manual approuval.
+A dedicated `release` github environment has been created to manage the permission for this
+github action.
+
+Then an automatic process on conda-forge pick the new release from pypi,
+create a pull request on icclim-feedstock and wait for our review and approval to
+publish the release to conda-forge.
+
+Hence, the process is as follow:
+
+#. Merge everything on icclim master branch
+#. Create a (github release)[https://github.com/cerfacs-globc/icclim/releases]
+#. Wait for the github action to build the package
+#. Approve the github action to release to pypi
+#. Wait for conda-forge to create a PR on icclim-feedstock
+#. Edit and approve PR on icclim-feedstock
+
+Manual release (outdated)
++++++++++++++++++++++++++
+
+The Automatic approach
 
 #. Make sure all tests pass.
 #. Create and checkout a release branch.

--- a/doc/source/references/release_notes.rst
+++ b/doc/source/references/release_notes.rst
@@ -11,10 +11,12 @@ Release history
 * [maint] Update architecture to have a `src/` and a `tests/` directory at root level
 * [maint] Migrate build toolchain from setuptools to flit
 * [maint] Remove version number from `constants` module as it was causing the build process to import icclim.
-          The version number is now statically set in src/icclim/__init__.py
+  The version number is now statically set in src/icclim/__init__.py
 * [maint] Lint code using the more restrictive rules from ruff
-* [fix]   Force xarray to read dataset sequentially to avoid a netcdf-c threading issue causing seg faults.
-
+* [fix] Force xarray to read dataset sequentially to avoid a netcdf-c threading issue causing seg faults.
+* [enh] Add `publish-to-pypi.yml` github action to automatically build and publish icclim to pypi.
+  This action is triggered by a github release being published.
+  This action requires a manual approval on github.
 
 6.5.0
 -----


### PR DESCRIPTION
<!--
The following checklist points should all be checked before merging the PR.

Please replace xxx by your issue number (leave the prefixing '#').
-->

### Pull Request to resolve #272 
- [ ] Unit tests cover the changes.
- [ ] These changes were tested on real data.
- [x] The relevant documentation has been added or updated.
- [x] A short description of the changes has been added to `doc/source/references/release_notes.rst`.

### Describe the changes you made

Add a github action to release icclim on pypi whenever a github release is published.
Shamelessly inspired by xclim's github action that serve the same purpose.

Beside this PR, a dedicated `release` github environment has been create to enable trusted release to pypi.
This environment can be managed at the repository level by the admins @pagecp and @bzah here : https://github.com/cerfacs-globc/icclim/settings/environments 


References
----------------
- To add a trusted publisher: https://docs.pypi.org/trusted-publishers/adding-a-publisher/
- The underlying github action used: https://github.com/pypa/gh-action-pypi-publish
- Xclim's own version of the same process: https://github.com/Ouranosinc/xclim/blob/master/.github/workflows/publish-pypi.yml