### PR TITLE
MAINT: Ignore some rules for tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,3 +143,10 @@ ignore = [
 
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"
+
+[tool.ruff.per-file-ignores]
+"tests/**/*.py" = [
+  "S101", # Allow asserts allowed in tests.
+  "ARG", # Allow unused function args for tests fixtures.
+  "FBT" # Allow booleans as positional arguments in tests.
+]


### PR DESCRIPTION
<!--
The following checklist points should all be checked before merging the PR.

Please replace xxx by your issue number (leave the prefixing '#').
-->

### Pull Request to resolve #xxx
- [ ] Unit tests cover the changes.
- [ ] These changes were tested on real data.
- [ ] The relevant documentation has been added or updated.
- [ ] A short description of the changes has been added to `doc/source/references/release_notes.rst`.

### Describe the changes you made

Some lint rules of rust are unnecessary for unit and integrations tests.
This PR allows the following rules
-  "S101", # Allow asserts allowed in tests.
- "ARG", # Allow unused function args for tests fixtures.
-  "FBT" # Allow booleans as positional arguments in tests.
 
