### PR TITLE
DOC: Remove orphaned `create_optimized_zarr_store` API documentation

### DIFF
--- a/doc/source/references/api/icclim/index.rst
+++ b/doc/source/references/api/icclim/index.rst
@@ -196,68 +196,6 @@ Package Contents
    file, which will contain all the index results of this group.
 
 
-.. py:function:: create_optimized_zarr_store(in_files: str | list[str] | xarray.core.dataset.Dataset | xarray.core.dataarray.DataArray, var_names: str | list[str], target_zarr_store_name: str = 'icclim-target-store.zarr', keep_target_store: bool = False, chunking: dict[str, int] | None = None, filesystem: str | fsspec.AbstractFileSystem = LOCAL_FILE_SYSTEM) -> collections.abc.Generator[xarray.core.dataset.Dataset]
-
-   Context manager to create an zarr store given an input netcdf or xarray structure.
-
-   -- EXPERIMENTAL FEATURE --
-   API may changes without deprecation warning!
-
-   The execution may take a long time.
-
-   The result is rechunked according to `chunking` schema provided.
-   By default, when leaving `chunking` to None, the resulting zarr store is NOT chunked
-   on time dimension.
-   This kind of chunking will significantly speed up the bootstrapping of
-   percentiles for indices such as Tx90p, Tx10p, TN90p...
-   But such chunking will most likely result in suboptimal performances for other
-   indices.
-   Actually, when computing indices where no bootstrap is needed,
-   you should first try the computation without using `create_optimized_zarr_store`.
-   If there are performance issues, you may want to use `create_optimized_zarr_store`
-   with a dictionary of a better chunking schema than your current storage chunking.
-
-   By default, `keep_target_store` being False, the resulting zarr store is destroyed
-   when the context manager is exit.
-   To keep the zarr store for futur uses set `keep_target_store` to True.
-
-   The output is the resulting zarr store as a xarray Dataset.
-
-   :param in_files: Absolute path(s) to NetCDF dataset(s), including OPeNDAP URLs,
-                    or path to zarr store, or xarray.Dataset or xarray.DataArray.
-   :type in_files: str | list[str] | Dataset | DataArray
-   :param var_names: List of data variable to include in the target zarr store.
-                     All other data variable are dropped.
-                     The coordinate variable are untouched and are part of the target zarr store.
-   :type var_names: str | list[str]
-   :param target_zarr_store_name: Name of the target zarr store.
-                                  Used to avoid overriding an existing zarr store.
-   :type target_zarr_store_name: str
-   :param chunking: The target chunking schema.
-   :type chunking: dict
-   :param keep_target_store: Set to True to keep the target zarr store after the execution of the context
-                             manager.
-                             Set to False to remove the target zarr store once execution is finished.
-                             Default is False.
-   :type keep_target_store: bool
-   :param filesystem: A fsspec filesystem where the zarr store will be created.
-
-   :rtype: returns Dataset opened on the newly created target zarr store.
-
-   .. rubric:: Examples
-
-   .. code-block:: python
-
-       import icclim
-
-       with icclim.create_optimized_zarr_store(
-           in_files="tasmax.nc",
-           var_names="tasmax",
-           target_zarr_store_name="tasmax-store.zarr",
-           chunking={"time": 42, "lat": 42, "lon": 42},
-       ) as tasmax_opti:
-           su_out = icclim.index(in_files=tasmax_opti, index_name="su")
-
 
 .. py:function:: build_threshold(query: str | None = None, *, operator: icclim._core.model.operator.Operator | str | None = None, value: icclim._core.model.threshold.ThresholdValueType = None, unit: str | None = None, threshold_min_value: str | float | pint.Quantity | None = None, thresholds: collections.abc.Sequence[icclim._core.model.threshold.Threshold | str] | None = None, logical_link: str | icclim._core.model.logical_link.LogicalLink | None = None, offset: str | float | pint.Quantity | None = None, **kwargs) -> icclim._core.generic.threshold.bounded.BoundedThreshold | icclim._core.generic.threshold.percentile.PercentileThreshold | icclim._core.generic.threshold.basic.BasicThreshold
 

--- a/doc/source/references/release_notes.rst
+++ b/doc/source/references/release_notes.rst
@@ -25,6 +25,7 @@ Details
 -  [maint] Add ``typing-extensions>=4.0`` to dependencies for Python 3.10/3.11 compatibility.
 -  [maint] Add ``CI`` URL to ``pyproject.toml`` project URLs for PyPI badge display.
 -  [enh] Add inline doctests to CI test suite and expand test coverage for generic reducers (#109).
+-  [doc] Remove deprecated ``create_optimized_zarr_store`` from API documentation (#138).
 
 ******
 7.0.5


### PR DESCRIPTION
## Description

**Context:**
This PR closes issue #138. The feature `create_optimized_zarr_store` was removed from the codebase in version `v7.0.5` (commit `0273e26`), rendering the request for a tutorial notebook and additional documentation chapters obsolete.
However, the signature was left lingering inside `doc/source/references/api/icclim/index.rst`, causing it to appear as active functionality in the Sphinx documentation generation.

**Proposed Changes:**
- Removed the `create_optimized_zarr_store` function block from `doc/source/references/api/icclim/index.rst` to clean up the API reference and prevent user confusion.

### Pull Request to resolve #138
- [x] Unit tests cover the changes.
- [x] These changes were tested on real data.
- [x] The relevant documentation has been added or updated.
- [x] A short description of the changes has been added to `doc/source/references/release_notes.rst`.