### PR TITLE
FIX: Drop number_of_notnull from grouped indices

### DIFF
--- a/src/icclim/main.py
+++ b/src/icclim/main.py
@@ -76,6 +76,7 @@ log: IcclimLogger = IcclimLogger.get_instance(VerbosityRegistry.LOW)
 
 HISTORY_CF_KEY = "history"
 SOURCE_CF_KEY = "source"
+NUMBER_OF_NOTNULL_VAR = "number_of_notnull"
 
 
 def indices(
@@ -127,13 +128,14 @@ def indices(
         try:
             res = index(**kwargs)
             res = _rename_coords(res, i.short_name)
+            res = _drop_group_auxiliary_vars(res)
             acc.append(res)
         except Exception:
             if ignore_error:
                 warn(f"Could not compute {i.short_name}.", stacklevel=2)
             else:
                 raise
-    ds: Dataset = xr.merge(acc)
+    ds: Dataset = xr.merge(acc, compat="no_conflicts", join="outer")
     if out is not None:
         _write_output_file(
             result_ds=ds,
@@ -1081,6 +1083,10 @@ def _rename_coords(ds: Dataset, short_name: str) -> Dataset:
     if "thresholds" in ds.coords:
         ds = ds.rename({"thresholds": short_name + "_thresholds"})
     return ds
+
+
+def _drop_group_auxiliary_vars(ds: Dataset) -> Dataset:
+    return ds.drop_vars(NUMBER_OF_NOTNULL_VAR, errors="ignore")
 
 
 def _parse_indicator_config(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -34,6 +34,27 @@ def test_deprecated_indice(log_mock: MagicMock, index_mock: MagicMock) -> None:
     index_mock.assert_called_once()
 
 
+@patch("icclim.main.index")
+def test_indices_drops_conflicting_number_of_notnull(index_mock: MagicMock) -> None:
+    def _fake_index(**kwargs: object) -> xr.Dataset:
+        index_name = str(kwargs["index_name"])
+        return xr.Dataset(
+            {
+                index_name: ("time", [1]),
+                "number_of_notnull": ("time", [len(index_name)]),
+            },
+            coords={"time": [np.datetime64("2042-01-01")]},
+        )
+
+    index_mock.side_effect = _fake_index
+
+    res = icclim.indices(index_group=["SU", "TR"], in_files=object())
+
+    assert "SU" in res
+    assert "TR" in res
+    assert "number_of_notnull" not in res
+
+
 HEAT_INDICES = ["SU", "TR", "WSDI", "TG90p", "TN90p", "TX90p", "TXx", "TNx", "CSU"]
 
 


### PR DESCRIPTION
## Summary

Drop the auxiliary `number_of_notnull` variable from grouped `indices()` outputs before merging individual index datasets.

## Why

Automated PR CI started failing in the `ci-build` test job because newer dependency resolution can produce multiple `number_of_notnull` variables with the same name but different values. When `indices(index_group="all", ...)` merges those per-index datasets, `xarray` raises a `MergeError` instead of choosing one conflicting helper value.

This variable is a diagnostic/helper output from the underlying stack, not an icclim climate index result, so grouped output should not keep one arbitrary copy.

## Changes

- Drop `number_of_notnull` in the grouped `indices()` path before the final merge.
- Make the grouped merge behavior explicit with `compat="no_conflicts"` and `join="outer"`.
- Add a regression test for conflicting `number_of_notnull` values across grouped index outputs.

## Validation

- `.venv-icclim-705/bin/python -m pytest tests/test_main.py::test_indices_drops_conflicting_number_of_notnull`
- `.venv-icclim-705/bin/python -m pytest tests/test_main.py::TestIntegration::test_indices__on_var_names tests/test_main.py::TestIntegration::test_indices_all_from_dataset`
- `python -m py_compile src/icclim/main.py tests/test_main.py`