### PR TITLE
Fix seasonal sum conversion on filtered rate data

### DIFF
--- a/doc/source/dev/climpact_comparison_protocol.rst
+++ b/doc/source/dev/climpact_comparison_protocol.rst
@@ -1,0 +1,99 @@
+#############################
+ Climpact Comparison Protocol
+#############################
+
+Use this protocol when a user reports a discrepancy and can provide both the NetCDF
+file and the exact ``icclim`` command they used.
+
+Why this protocol exists
+------------------------
+
+Climpact is an external reference implementation for ET-SCI style indices, and its
+official guidance is based on **daily** temperature and rainfall data. See:
+
+- https://climpact-sci.org/
+- https://climpact-sci.org/assets/climpact2-user-guide.pdf
+- https://github.com/ARCCSS-extremes/climpact
+
+For ``icclim``, the most useful verification chain is:
+
+1. confirm the source data frequency and units,
+2. compare ``icclim`` against a direct xarray manual calculation,
+3. when the index is Climpact-compatible, export a point subset and compare against Climpact.
+
+Assessment checklist
+--------------------
+
+Before comparing outputs, record:
+
+- ``icclim`` version
+- ``xclim`` version
+- the full user command
+- the input variable name and units
+- the inferred source frequency
+- whether the user is supplying daily data or already aggregated monthly/seasonal data
+
+Important constraint
+--------------------
+
+Climpact's reference workflow is defined for **daily** rainfall data. If the source
+dataset is already monthly or seasonal, do not treat a Climpact mismatch as evidence
+of an ``icclim`` bug. In that case, first reduce the report to a daily-input
+reproduction, or classify it as a non-daily-input limitation.
+
+Repo workflow
+-------------
+
+Run the helper script with the user dataset and the same ``index_name`` and
+``slice_mode`` used in their report.
+
+Example:
+
+.. code-block:: bash
+
+   PYTHONPATH=src python scripts/verify_index_against_reference.py \
+     --in-file /path/to/user.nc \
+     --var-name pr \
+     --index-name PRCPTOT \
+     --slice-mode 'JJA' \
+     --isel lat=10 \
+     --isel lon=12 \
+     --output-dir /tmp/icclim-climpact-check
+
+The script writes:
+
+- ``summary.json``: metadata, ``icclim`` values, manual xarray values, and max absolute difference
+- ``reference_subset.nc``: a reduced NetCDF file that can be used for the external Climpact run when relevant
+
+Supported manual comparators
+----------------------------
+
+The helper currently includes simple reference calculations for these common cases:
+
+- precipitation: ``RR``, ``PRCPTOT``, ``RR1``, ``R10mm``, ``R20mm``
+- temperature occurrence counts: ``SU``, ``TR``
+- means: ``TG``, ``TX``, ``TN``
+- extrema: ``TXx``, ``TNx``, ``TXn``, ``TNn``
+
+This is intentionally conservative. If a new report lands outside this set, add the
+manual comparator first, then use the same workflow.
+
+How to interpret the result
+---------------------------
+
+- If ``icclim`` matches the manual xarray reference on daily input, the reducer is
+  behaving as expected in ``icclim``.
+- If both differ from Climpact, inspect calendar handling, wet-day threshold
+  semantics, and Climpact input preparation.
+- If ``icclim`` differs from manual xarray on daily input, treat that as a likely
+  ``icclim`` bug and add a regression test before fixing it.
+
+Recommended regression coverage
+-------------------------------
+
+Any confirmed bug report should add at least one test covering:
+
+- a named season such as ``JJA`` or ``DJF``
+- a custom season via ``("season", ...)``
+- the reported index on daily input
+- a manual xarray reference used as the expected value

--- a/doc/source/dev/index.rst
+++ b/doc/source/dev/index.rst
@@ -14,3 +14,4 @@ development.
    release_process
    ci
    contributing
+   climpact_comparison_protocol

--- a/scripts/verify_index_against_reference.py
+++ b/scripts/verify_index_against_reference.py
@@ -81,9 +81,11 @@ def _manual_prcptot(da: DataArray, slice_mode: Any) -> DataArray:
         from xclim.core.units import rate2amount
 
         subset = rate2amount(subset)
-    return subset.where(subset >= WET_DAY_THRESHOLD, 0).resample(
-        time=freq.pandas_freq
-    ).sum(dim="time")
+    return (
+        subset.where(subset >= WET_DAY_THRESHOLD, 0)
+        .resample(time=freq.pandas_freq)
+        .sum(dim="time")
+    )
 
 
 def _manual_mean(da: DataArray, slice_mode: Any) -> DataArray:

--- a/scripts/verify_index_against_reference.py
+++ b/scripts/verify_index_against_reference.py
@@ -5,20 +5,21 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
-from typing import Any
 
 import xarray as xr
 from xarray import DataArray, Dataset
+from xclim.core.calendar import select_time
+from xclim.core.units import rate2amount
 
 import icclim
 from icclim._core.constants import UNITS_KEY
 from icclim._core.generic.functions import _is_rate, check_freq
-from icclim.frequency import FrequencyRegistry
+from icclim.frequency import Frequency, FrequencyRegistry
 
 WET_DAY_THRESHOLD = 1.0
 
 
-def _parse_slice_mode(raw: str) -> Any:
+def _parse_slice_mode(raw: str) -> object:
     try:
         return json.loads(raw)
     except json.JSONDecodeError:
@@ -38,18 +39,18 @@ def _reduce_to_point(ds: Dataset, isel_specs: list[str]) -> Dataset:
     return ds.isel(indexers, drop=True)
 
 
-def _subset_for_slice_mode(da: DataArray, slice_mode: Any) -> tuple[DataArray, Any]:
+def _subset_for_slice_mode(
+    da: DataArray, slice_mode: object
+) -> tuple[DataArray, Frequency]:
     freq = FrequencyRegistry.lookup(slice_mode)
     if freq.indexer:
-        from xclim.core.calendar import select_time
-
         da = select_time(da, **freq.indexer, drop=True)
     return da, freq
 
 
 def _threshold_count(
     da: DataArray,
-    slice_mode: Any,
+    slice_mode: object,
     threshold: float,
     op: str,
 ) -> DataArray:
@@ -66,20 +67,16 @@ def _threshold_count(
     return out
 
 
-def _manual_rr(da: DataArray, slice_mode: Any) -> DataArray:
+def _manual_rr(da: DataArray, slice_mode: object) -> DataArray:
     subset, freq = _subset_for_slice_mode(da, slice_mode)
     if _is_rate(subset):
-        from xclim.core.units import rate2amount
-
         subset = rate2amount(subset)
     return subset.resample(time=freq.pandas_freq).sum(dim="time")
 
 
-def _manual_prcptot(da: DataArray, slice_mode: Any) -> DataArray:
+def _manual_prcptot(da: DataArray, slice_mode: object) -> DataArray:
     subset, freq = _subset_for_slice_mode(da, slice_mode)
     if _is_rate(subset):
-        from xclim.core.units import rate2amount
-
         subset = rate2amount(subset)
     return (
         subset.where(subset >= WET_DAY_THRESHOLD, 0)
@@ -88,17 +85,17 @@ def _manual_prcptot(da: DataArray, slice_mode: Any) -> DataArray:
     )
 
 
-def _manual_mean(da: DataArray, slice_mode: Any) -> DataArray:
+def _manual_mean(da: DataArray, slice_mode: object) -> DataArray:
     subset, freq = _subset_for_slice_mode(da, slice_mode)
     return subset.resample(time=freq.pandas_freq).mean(dim="time")
 
 
-def _manual_max(da: DataArray, slice_mode: Any) -> DataArray:
+def _manual_max(da: DataArray, slice_mode: object) -> DataArray:
     subset, freq = _subset_for_slice_mode(da, slice_mode)
     return subset.resample(time=freq.pandas_freq).max(dim="time")
 
 
-def _manual_min(da: DataArray, slice_mode: Any) -> DataArray:
+def _manual_min(da: DataArray, slice_mode: object) -> DataArray:
     subset, freq = _subset_for_slice_mode(da, slice_mode)
     return subset.resample(time=freq.pandas_freq).min(dim="time")
 
@@ -128,7 +125,7 @@ def _data_var_name(ds: Dataset) -> str:
     return next(iter(ds.data_vars))
 
 
-def _summarize_result(icclim_da: DataArray, manual_da: DataArray) -> dict[str, Any]:
+def _summarize_result(icclim_da: DataArray, manual_da: DataArray) -> dict[str, object]:
     if "time" in icclim_da.dims and "time" in manual_da.dims:
         if icclim_da.sizes["time"] != manual_da.sizes["time"]:
             msg = (
@@ -154,6 +151,7 @@ def _summarize_result(icclim_da: DataArray, manual_da: DataArray) -> dict[str, A
 
 
 def build_parser() -> argparse.ArgumentParser:
+    """Build the CLI argument parser."""
     parser = argparse.ArgumentParser(
         description=(
             "Compare an icclim index against a simple manual reference "
@@ -187,6 +185,7 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main() -> None:
+    """Run the reference comparison CLI."""
     parser = build_parser()
     args = parser.parse_args()
 

--- a/scripts/verify_index_against_reference.py
+++ b/scripts/verify_index_against_reference.py
@@ -1,0 +1,240 @@
+"""Assess icclim outputs against manual reference computations."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+import xarray as xr
+from xarray import DataArray, Dataset
+
+import icclim
+from icclim._core.constants import UNITS_KEY
+from icclim._core.generic.functions import _is_rate, check_freq
+from icclim.frequency import FrequencyRegistry
+
+WET_DAY_THRESHOLD = 1.0
+
+
+def _parse_slice_mode(raw: str) -> Any:
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return raw
+
+
+def _reduce_to_point(ds: Dataset, isel_specs: list[str]) -> Dataset:
+    if not isel_specs:
+        return ds
+    indexers: dict[str, int] = {}
+    for spec in isel_specs:
+        if "=" not in spec:
+            msg = f"Invalid --isel value {spec!r}, expected DIM=INDEX."
+            raise ValueError(msg)
+        dim, raw_index = spec.split("=", 1)
+        indexers[dim] = int(raw_index)
+    return ds.isel(indexers, drop=True)
+
+
+def _subset_for_slice_mode(da: DataArray, slice_mode: Any) -> tuple[DataArray, Any]:
+    freq = FrequencyRegistry.lookup(slice_mode)
+    if freq.indexer:
+        from xclim.core.calendar import select_time
+
+        da = select_time(da, **freq.indexer, drop=True)
+    return da, freq
+
+
+def _threshold_count(
+    da: DataArray,
+    slice_mode: Any,
+    threshold: float,
+    op: str,
+) -> DataArray:
+    subset, freq = _subset_for_slice_mode(da, slice_mode)
+    if op == ">":
+        hits = subset > threshold
+    elif op == ">=":
+        hits = subset >= threshold
+    else:
+        msg = f"Unsupported threshold operator {op!r}."
+        raise ValueError(msg)
+    out = hits.resample(time=freq.pandas_freq).sum(dim="time")
+    out.attrs[UNITS_KEY] = "day"
+    return out
+
+
+def _manual_rr(da: DataArray, slice_mode: Any) -> DataArray:
+    subset, freq = _subset_for_slice_mode(da, slice_mode)
+    if _is_rate(subset):
+        from xclim.core.units import rate2amount
+
+        subset = rate2amount(subset)
+    return subset.resample(time=freq.pandas_freq).sum(dim="time")
+
+
+def _manual_prcptot(da: DataArray, slice_mode: Any) -> DataArray:
+    subset, freq = _subset_for_slice_mode(da, slice_mode)
+    if _is_rate(subset):
+        from xclim.core.units import rate2amount
+
+        subset = rate2amount(subset)
+    return subset.where(subset >= WET_DAY_THRESHOLD, 0).resample(
+        time=freq.pandas_freq
+    ).sum(dim="time")
+
+
+def _manual_mean(da: DataArray, slice_mode: Any) -> DataArray:
+    subset, freq = _subset_for_slice_mode(da, slice_mode)
+    return subset.resample(time=freq.pandas_freq).mean(dim="time")
+
+
+def _manual_max(da: DataArray, slice_mode: Any) -> DataArray:
+    subset, freq = _subset_for_slice_mode(da, slice_mode)
+    return subset.resample(time=freq.pandas_freq).max(dim="time")
+
+
+def _manual_min(da: DataArray, slice_mode: Any) -> DataArray:
+    subset, freq = _subset_for_slice_mode(da, slice_mode)
+    return subset.resample(time=freq.pandas_freq).min(dim="time")
+
+
+MANUAL_COMPARATORS = {
+    "PRCPTOT": _manual_prcptot,
+    "R10MM": lambda da, slice_mode: _threshold_count(da, slice_mode, 10.0, ">="),
+    "R20MM": lambda da, slice_mode: _threshold_count(da, slice_mode, 20.0, ">="),
+    "RR": _manual_rr,
+    "RR1": lambda da, slice_mode: _threshold_count(da, slice_mode, 1.0, ">="),
+    "SU": lambda da, slice_mode: _threshold_count(da, slice_mode, 25.0, ">"),
+    "TG": _manual_mean,
+    "TN": _manual_mean,
+    "TNN": _manual_min,
+    "TNX": _manual_max,
+    "TR": lambda da, slice_mode: _threshold_count(da, slice_mode, 20.0, ">"),
+    "TX": _manual_mean,
+    "TXN": _manual_min,
+    "TXX": _manual_max,
+}
+
+
+def _data_var_name(ds: Dataset) -> str:
+    if len(ds.data_vars) != 1:
+        msg = f"Expected exactly one data variable, found {list(ds.data_vars)}."
+        raise ValueError(msg)
+    return next(iter(ds.data_vars))
+
+
+def _summarize_result(icclim_da: DataArray, manual_da: DataArray) -> dict[str, Any]:
+    if "time" in icclim_da.dims and "time" in manual_da.dims:
+        if icclim_da.sizes["time"] != manual_da.sizes["time"]:
+            msg = (
+                "Manual reference and icclim result have different numbers of periods: "
+                f"{manual_da.sizes['time']} vs {icclim_da.sizes['time']}."
+            )
+            raise ValueError(msg)
+        aligned_icclim = icclim_da
+        aligned_manual = manual_da.assign_coords(time=icclim_da.time)
+    else:
+        aligned_icclim, aligned_manual = xr.align(icclim_da, manual_da, join="inner")
+    abs_diff = abs(aligned_icclim - aligned_manual)
+    max_abs_diff = float(abs_diff.max().compute().item())
+    return {
+        "period_count": int(aligned_icclim.sizes.get("time", 1)),
+        "icclim_units": icclim_da.attrs.get(UNITS_KEY),
+        "manual_units": manual_da.attrs.get(UNITS_KEY),
+        "max_abs_diff": max_abs_diff,
+        "icclim_values": aligned_icclim.values.tolist(),
+        "manual_values": aligned_manual.values.tolist(),
+        "time": [str(t) for t in aligned_icclim.time.values],
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Compare an icclim index against a simple manual reference "
+            "computation and export a reduced subset for external tools."
+        )
+    )
+    parser.add_argument("--in-file", required=True, help="Input NetCDF file path.")
+    parser.add_argument("--var-name", required=True, help="Target variable name.")
+    parser.add_argument(
+        "--index-name",
+        required=True,
+        help="icclim index name, for example RR, PRCPTOT, SU, TG, TXx.",
+    )
+    parser.add_argument(
+        "--slice-mode",
+        required=True,
+        help='icclim slice_mode, for example "JJA" or ["season", [6, 7, 8]].',
+    )
+    parser.add_argument(
+        "--output-dir",
+        required=True,
+        help="Directory where reports and optional subsets will be written.",
+    )
+    parser.add_argument(
+        "--isel",
+        action="append",
+        default=[],
+        help="Optional point extraction before comparison, repeated as DIM=INDEX.",
+    )
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    index_name = args.index_name.upper()
+    if index_name not in MANUAL_COMPARATORS:
+        msg = (
+            f"Unsupported index {args.index_name!r}. "
+            f"Supported indices: {sorted(MANUAL_COMPARATORS)}."
+        )
+        raise ValueError(msg)
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    slice_mode = _parse_slice_mode(args.slice_mode)
+    source_ds = xr.open_dataset(args.in_file)
+    source_ds = _reduce_to_point(source_ds, args.isel)
+    da = source_ds[args.var_name]
+
+    inferred_freq = check_freq(da, strict=False)
+    icclim_res = icclim.index(
+        index_name=args.index_name,
+        in_files=source_ds,
+        var_name=args.var_name,
+        slice_mode=slice_mode,
+        logs_verbosity="silent",
+    )
+    icclim_var_name = _data_var_name(icclim_res)
+    icclim_da = icclim_res[icclim_var_name].load()
+    manual_da = MANUAL_COMPARATORS[index_name](da, slice_mode).load()
+
+    summary = {
+        "input_file": str(Path(args.in_file).resolve()),
+        "var_name": args.var_name,
+        "index_name": args.index_name,
+        "slice_mode": slice_mode,
+        "input_units": da.attrs.get(UNITS_KEY),
+        "input_frequency": inferred_freq,
+        "assessment": _summarize_result(icclim_da, manual_da),
+    }
+
+    summary_path = output_dir / "summary.json"
+    summary_path.write_text(json.dumps(summary, indent=2))
+
+    subset_path = output_dir / "reference_subset.nc"
+    source_ds[[args.var_name]].to_netcdf(subset_path)
+
+    print(f"Wrote assessment to {summary_path}")
+    print(f"Wrote reduced subset to {subset_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/verify_precip_against_climpact.py
+++ b/scripts/verify_precip_against_climpact.py
@@ -9,6 +9,5 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from verify_index_against_reference import main
 
-
 if __name__ == "__main__":
     main()

--- a/scripts/verify_precip_against_climpact.py
+++ b/scripts/verify_precip_against_climpact.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from verify_index_against_reference import main
-
 if __name__ == "__main__":
+    from verify_index_against_reference import main
+
     main()

--- a/scripts/verify_precip_against_climpact.py
+++ b/scripts/verify_precip_against_climpact.py
@@ -1,0 +1,14 @@
+"""Backward-compatible entry point for precipitation reference checks."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from verify_index_against_reference import main
+
+
+if __name__ == "__main__":
+    main()

--- a/src/icclim/_core/generic/functions.py
+++ b/src/icclim/_core/generic/functions.py
@@ -1333,7 +1333,13 @@ def _run_simple_reducer(
     if must_convert_rate and _is_rate(filtered_study):
         from xclim.core.units import rate2amount  # noqa: PLC0415
 
-        filtered_study = rate2amount(filtered_study)
+        src_freq = check_freq(filtered_study, dim="time", strict=False)
+        if src_freq == "D":
+            filtered_study = _rate_to_amount_for_daily_subseries(filtered_study)
+        else:
+            if src_freq is not None:
+                filtered_study = filtered_study.resample(time=src_freq).asfreq()
+            filtered_study = rate2amount(filtered_study)
     if date_event:
         return _reduce_with_date_event(
             resampled=filtered_study.resample(time=resample_freq.pandas_freq),
@@ -1368,6 +1374,30 @@ def get_single_var(
             climate_vars[0].threshold,
         )
     return climate_vars[0].studied_data, None
+
+
+def _rate_to_amount_for_daily_subseries(filtered_study: DataArray) -> DataArray:
+    from xclim.core.units import rate2amount  # noqa: PLC0415
+
+    original_time = filtered_study.time
+    first_time = original_time.values[0]
+    if hasattr(first_time, "calendar"):
+        synthetic_time = xr.date_range(
+            start="2000-01-01",
+            periods=filtered_study.sizes["time"],
+            freq="D",
+            use_cftime=True,
+            calendar=first_time.calendar,
+        )
+    else:
+        synthetic_time = date_range(
+            start="2000-01-01",
+            periods=filtered_study.sizes["time"],
+            freq="D",
+        )
+    synthetic = filtered_study.assign_coords(time=synthetic_time)
+    converted = rate2amount(synthetic)
+    return converted.assign_coords(time=original_time)
 
 
 def _compute_exceedances(

--- a/tests/test_seasonal_precipitation.py
+++ b/tests/test_seasonal_precipitation.py
@@ -79,9 +79,7 @@ def test_prcptot_custom_season_matches_manual_wet_day_sum() -> None:
     ).PRCPTOT.load()
 
     season_mask = (
-        (pr.time.dt.month == 11)
-        | (pr.time.dt.month == 12)
-        | (pr.time.dt.month <= 3)
+        (pr.time.dt.month == 11) | (pr.time.dt.month == 12) | (pr.time.dt.month <= 3)
     )
     expected = (
         pr.where(season_mask)

--- a/tests/test_seasonal_precipitation.py
+++ b/tests/test_seasonal_precipitation.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+import icclim
+
+
+def test_rr_jja_matches_manual_daily_sum() -> None:
+    time = pd.date_range("2001-01-01", "2001-12-31", freq="D")
+    values = np.linspace(0.0, 9.0, len(time))
+    pr = xr.DataArray(
+        values,
+        coords={"time": time},
+        dims=["time"],
+        name="pr",
+        attrs={"units": "mm/day"},
+    )
+
+    result = icclim.rr(
+        in_files=pr,
+        var_name="pr",
+        slice_mode="JJA",
+        logs_verbosity="silent",
+    ).RR
+    expected = pr.sel(time=pr.time.dt.month.isin([6, 7, 8])).sum(dim="time")
+
+    np.testing.assert_allclose(result.values, [expected.item()])
+    assert result.attrs["units"] == "mm"
+
+
+def test_generic_sum_multi_year_mam_matches_manual_daily_sum() -> None:
+    time = pd.date_range("2001-01-01", "2002-12-31", freq="D")
+    pr = xr.DataArray(
+        np.full(len(time), 1.0),
+        coords={"time": time},
+        dims=["time"],
+        name="pr",
+        attrs={"units": "mm/day"},
+    )
+
+    result = icclim.sum(
+        in_files=pr,
+        var_name="pr",
+        slice_mode="MAM",
+        logs_verbosity="silent",
+    )["sum"].load()
+    expected = (
+        pr.sel(time=pr.time.dt.month.isin([3, 4, 5]))
+        .resample(time="YS-MAR")
+        .sum(dim="time")
+        .assign_coords(time=result.time)
+    )
+
+    np.testing.assert_allclose(result.values, expected.values)
+    assert result.attrs["units"] == "mm"
+
+
+def test_prcptot_custom_season_matches_manual_wet_day_sum() -> None:
+    time = pd.date_range("2020-01-01", "2021-12-31", freq="D")
+    values = np.full(len(time), 2.0)
+    values[10:20] = 0.5
+    values[380:390] = 0.25
+    pr = xr.DataArray(
+        values,
+        coords={"time": time},
+        dims=["time"],
+        name="pr",
+        attrs={"units": "mm/day"},
+    )
+
+    slice_mode = ("season", ("1 november", "31 march"))
+    result = icclim.prcptot(
+        in_files=pr,
+        var_name="pr",
+        slice_mode=slice_mode,
+        logs_verbosity="silent",
+    ).PRCPTOT.load()
+
+    season_mask = (
+        (pr.time.dt.month == 11)
+        | (pr.time.dt.month == 12)
+        | (pr.time.dt.month <= 3)
+    )
+    expected = (
+        pr.where(season_mask)
+        .where(pr >= 1, 0)
+        .resample(time="YS-NOV")
+        .sum(dim="time")
+        .dropna(dim="time", how="all")
+    )
+
+    np.testing.assert_allclose(result.isel(time=1).item(), expected.isel(time=1).item())
+    assert np.isnan(result.isel(time=0).item())
+    assert np.isnan(result.isel(time=2).item())
+
+
+def test_su_jja_matches_manual_count() -> None:
+    time = pd.date_range("2001-01-01", "2001-12-31", freq="D")
+    tasmax = xr.DataArray(
+        np.full(len(time), 20.0),
+        coords={"time": time},
+        dims=["time"],
+        name="tasmax",
+        attrs={"units": "degree_Celsius"},
+    )
+    tasmax.loc[{"time": slice("2001-06-01", "2001-08-31")}] = 30.0
+
+    result = icclim.su(
+        in_files=tasmax,
+        var_name="tasmax",
+        slice_mode="JJA",
+        logs_verbosity="silent",
+    ).SU.load()
+    expected = (tasmax.sel(time=tasmax.time.dt.month.isin([6, 7, 8])) > 25).sum()
+
+    np.testing.assert_allclose(result.values, [expected.item()])
+    assert result.attrs["units"] in {"d", "day"}


### PR DESCRIPTION
## Summary
- fix inflated seasonal sums when `icclim.sum(...)` converts filtered daily rate data such as `mm/day`
- add a fast daily-source conversion path that avoids integrating across inter-season gaps
- add regression coverage for multi-year seasonal sums and document the new verification protocol

## Root cause
`generic_sum` converted rate data to amount after seasonal filtering. For daily data filtered to a season like `MAM`, the remaining time axis contains large gaps between one season and the next. `rate2amount` interpreted those gaps as sampling intervals and inflated some seasonal totals.

## Verification
- `PYTHONPATH=src pytest tests/test_seasonal_precipitation.py tests/test_main.py tests/test_generated_api.py tests/test_generic_functions.py -q`
- reproduced the De Bilt example around 1979 and confirmed the bad `4228.6` result now returns the correct `310.4` with zero diff against a direct xarray seasonal sum
- exercised the generalized reference verifier added in this branch for both precipitation and non-precipitation seasonal cases

## Notes
The example dataset also exposes a separate metadata ambiguity: variable name `RH` is commonly interpreted as relative humidity in `icclim`, while the file metadata describe precipitation. That does not cause the numeric inflation bug fixed here, but it can still lead to confusing output metadata.
