### PR TITLE
Prepare release 7.1.1

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,14 +8,14 @@ authors:
   - family-names: "Aoun"
     given-names: "Abel"
 title: "icclim: Index Calculation CLIMate"
-version: 7.1.0
+version: 7.1.1
 doi: 10.5281/zenodo.6046052
-date-released: 2026-03-17
+date-released: 2026-06-22
 url: "https://github.com/cerfacs-globc/icclim"
 repository-code: "https://github.com/cerfacs-globc/icclim"
 identifiers:
   - type: url
-    value: "https://github.com/cerfacs-globc/icclim/tree/v7.1.0"
+    value: "https://github.com/cerfacs-globc/icclim/tree/v7.1.1"
     description: "Specific version source code"
 keywords:
   - "climate"

--- a/doc/source/references/release_notes.rst
+++ b/doc/source/references/release_notes.rst
@@ -3,6 +3,20 @@
 #################
 
 ******
+7.1.1
+******
+
+date: 2026-06-22
+
+
+Details
+=======
+
+-  [fix] Fix inflated seasonal totals in ``icclim.sum(...)`` when converting filtered daily rate data such as precipitation in ``mm/day`` to amounts. Seasonal selections like ``MAM`` no longer integrate across inter-season gaps, so reproduced cases such as ``4228.6`` now correctly return ``310.4``.
+-  [enh] Add a faster daily-source conversion path for seasonal rate-to-amount handling, preserving the bug fix without paying the full cost of rebuilding sparse seasonal timelines.
+-  [enh] Add generalized reference-verification scripts and regression tests covering seasonal precipitation and non-precipitation cases, plus a developer protocol for broader Climpact/manual comparisons.
+
+******
 7.1.0
 ******
 

--- a/src/icclim/__init__.py
+++ b/src/icclim/__init__.py
@@ -23,7 +23,7 @@ __all__ = [
     "indices",  # noqa: F405
 ]
 
-__version__ = "7.1.0"
+__version__ = "7.1.1"
 
 
 def __getattr__(name: str) -> Callable:


### PR DESCRIPTION
## Summary
- bump `icclim` version metadata from `7.1.0` to `7.1.1`
- add the `7.1.1` release note entry for the seasonal rate-to-amount fix
- update citation metadata and release date for the new patch release

## Why
`v7.1.1` is the patch release that ships the seasonal `icclim.sum(...)` fix for filtered daily rate data, along with the optimized daily fast path and the new verification tooling.

## Verification
- `PYTHONPATH=src pytest tests/test_seasonal_precipitation.py tests/test_main.py tests/test_generated_api.py tests/test_generic_functions.py -q`
- `PYTHONPATH=src python -c "import icclim; print(icclim.__version__)"`
