### PR TITLE
Fix compatibility with latest xclim to_agg_units API

### DIFF
--- a/src/icclim/_core/generic/functions.py
+++ b/src/icclim/_core/generic/functions.py
@@ -1645,12 +1645,19 @@ def check_freq(da: xr.DataArray, dim: str = "time", strict: bool = True) -> str 
 
 
 def _safe_to_agg_units(*args, **kwargs) -> DataArray:
+    import inspect  # noqa: PLC0415
+
     from xclim.core.units import to_agg_units  # noqa: PLC0415
 
+    supported_kwargs = {
+        key: value
+        for key, value in kwargs.items()
+        if key in inspect.signature(to_agg_units).parameters
+    }
     with warnings.catch_warnings():
         warnings.filterwarnings(
             "ignore",
             category=UserWarning,
             message=".*Unable to find the sampling frequency.*",
         )
-        return to_agg_units(*args, **kwargs)
+        return to_agg_units(*args, **supported_kwargs)

--- a/tests/test_generic_functions.py
+++ b/tests/test_generic_functions.py
@@ -1,6 +1,9 @@
+import pytest
+
 from icclim._core.climate_variable import ClimateVariable
 from icclim._core.constants import GROUP_BY_METHOD
 from icclim._core.generic.functions import (
+    _safe_to_agg_units,
     average,
     count_occurrences,
     generic_sum,
@@ -113,3 +116,34 @@ def test_max_consecutive_occurrence() -> None:
         source_freq_delta="1D",
     )
     assert int(result.isel(time=0).values) >= 365
+
+
+def test_safe_to_agg_units_drops_unsupported_kwargs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    received: dict[str, object] = {}
+
+    def fake_to_agg_units(
+        out,
+        orig,
+        op,
+        dim="time",
+    ):
+        received["out"] = out
+        received["orig"] = orig
+        received["op"] = op
+        received["dim"] = dim
+        return out
+
+    monkeypatch.setattr("xclim.core.units.to_agg_units", fake_to_agg_units)
+    da = stub_tas()
+
+    result = _safe_to_agg_units(da, da, "count", dim="time", deffreq="YS")
+
+    assert result is da
+    assert received == {
+        "out": da,
+        "orig": da,
+        "op": "count",
+        "dim": "time",
+    }


### PR DESCRIPTION
## Summary
- make `_safe_to_agg_units` forward only kwargs supported by the installed xclim version
- preserve compatibility with both the older `deffreq` signature and the newer reduced signature
- add a regression test covering the latest-xclim API shape

## Why
Fresh environments on July 20, 2026 can install an xclim version where `xclim.core.units.to_agg_units` no longer accepts `deffreq`. In that setup, percentile/count-style indices fail immediately before any real computation starts.

## Testing
- `pytest tests/test_generic_functions.py`
