### PR TITLE
ci: bump create-pull-request action to v8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
           git config user.email "<>"
       - name: Create Pull Request for API
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           commit-message: "MAINT: Update generated API"
           branch: automation/api-update
@@ -105,7 +105,7 @@ jobs:
           git config user.email "<>"
       - name: Create Pull Request for coverage
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           commit-message: "[skip ci] DOC: Update coverage"
           branch: automation/coverage-update
@@ -147,7 +147,7 @@ jobs:
           git config user.email "<>"
       - name: Create Pull Request for logos
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           commit-message: "MAINT: Update logos"
           branch: automation/logo-update


### PR DESCRIPTION
## Summary
- bump the create-pull-request workflow action from v7 to v8
- remove the GitHub Actions Node 20 deprecation warning from CI jobs

## Testing
- workflow pin update only