### PR TITLE
Prepare release 7.1.3

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,14 +8,14 @@ authors:
   - family-names: "Aoun"
     given-names: "Abel"
 title: "icclim: Index Calculation CLIMate"
-version: 7.1.2
+version: 7.1.3
 doi: 10.5281/zenodo.6046052
 date-released: 2026-07-20
 url: "https://github.com/cerfacs-globc/icclim"
 repository-code: "https://github.com/cerfacs-globc/icclim"
 identifiers:
   - type: url
-    value: "https://github.com/cerfacs-globc/icclim/tree/v7.1.2"
+    value: "https://github.com/cerfacs-globc/icclim/tree/v7.1.3"
     description: "Specific version source code"
 keywords:
   - "climate"

--- a/doc/source/references/api/icclim/index.rst
+++ b/doc/source/references/api/icclim/index.rst
@@ -103,6 +103,11 @@ Package Contents
                                   #. to compute a reference period for indices such as difference_of_mean
                                   (a.k.a anomaly) if a single variable is given in input.
    :type base_period_time_range: list[datetime.datetime ] | list[str] | tuple[str, str] | None
+   :param bootstrap: ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
+                     Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
+                     ``False`` to disable bootstrap, or ``True`` to force it when supported by the
+                     threshold type.
+   :type bootstrap: bool | None
    :param doy_window_width: ``optional`` Window width used to aggreagte day of year values when computing
                             day of year percentiles (doy_per)
                             Default: 5 (5 days).

--- a/doc/source/references/release_notes.rst
+++ b/doc/source/references/release_notes.rst
@@ -14,6 +14,7 @@ Details
 
 -  [fix] Restore compatibility with latest ``xclim`` releases by adapting ``to_agg_units`` calls to the installed API signature instead of always passing ``deffreq``.
 -  [enh] Add a ``bootstrap`` override to ``icclim.index(...)`` for day-of-year percentile thresholds. Use ``bootstrap=False`` to disable overlap-based bootstrap on large dask-backed datasets when the default path is too expensive.
+-  [maint] Keep the existing bootstrap implementation as the release path while follow-up work continues on a native replacement. The experimental prepared-state optimization is not included in ``v7.1.3``.
 -  [maint] Bump ``peter-evans/create-pull-request`` from ``v7`` to ``v8`` in CI maintenance workflows to avoid GitHub Actions Node 20 deprecation warnings.
 
 ******

--- a/doc/source/references/release_notes.rst
+++ b/doc/source/references/release_notes.rst
@@ -3,6 +3,20 @@
 #################
 
 ******
+7.1.3
+******
+
+date: 2026-07-20
+
+
+Details
+=======
+
+-  [fix] Restore compatibility with latest ``xclim`` releases by adapting ``to_agg_units`` calls to the installed API signature instead of always passing ``deffreq``.
+-  [enh] Add a ``bootstrap`` override to ``icclim.index(...)`` for day-of-year percentile thresholds. Use ``bootstrap=False`` to disable overlap-based bootstrap on large dask-backed datasets when the default path is too expensive.
+-  [maint] Bump ``peter-evans/create-pull-request`` from ``v7`` to ``v8`` in CI maintenance workflows to avoid GitHub Actions Node 20 deprecation warnings.
+
+******
 7.1.2
 ******
 

--- a/src/icclim/__init__.py
+++ b/src/icclim/__init__.py
@@ -23,7 +23,7 @@ __all__ = [
     "indices",  # noqa: F405
 ]
 
-__version__ = "7.1.2"
+__version__ = "7.1.3"
 
 
 def __getattr__(name: str) -> Callable:

--- a/src/icclim/_core/climate_variable.py
+++ b/src/icclim/_core/climate_variable.py
@@ -72,6 +72,7 @@ class ClimateVariable:
     threshold: Threshold | None = None
     reference_period: Sequence[datetime | str] | None = None
     is_reference: bool = False
+    bootstrap: bool | None = None
 
     def build_indicator_metadata(
         self,
@@ -131,6 +132,7 @@ def build_climate_vars(
     base_period: Sequence[str] | None,
     standard_index: StandardIndex | None,
     is_compared_to_reference: bool,
+    bootstrap: bool | None = None,
 ) -> list[ClimateVariable]:
     """
     Build a list of ClimateVariable from a dictionary of input files.
@@ -193,6 +195,7 @@ def build_climate_vars(
             time_range=time_range,
             standard_var=standard_var,
             reference_period=reference_period,
+            bootstrap=bootstrap,
         )
 
         acc.append(cv)
@@ -214,6 +217,7 @@ def build_climate_vars(
                 base_period,
                 climate_vars_dict,
                 standard_var=standard_var,  # type: ignore[arg-type]
+                bootstrap=bootstrap,
             )
             acc.append(added_var)
 
@@ -227,6 +231,7 @@ def build_climate_var(
     time_range: Sequence[datetime | str] | None,
     standard_var: StandardVariable | None,
     reference_period: Sequence[datetime | str] | None = None,
+    bootstrap: bool | None = None,
 ) -> ClimateVariable:
     """
     Build a ClimateVariable object.
@@ -324,10 +329,13 @@ def build_climate_var(
         source_frequency=FrequencyRegistry.lookup(  # type: ignore[arg-type]
             studied_data.time.attrs.get("freq", DEFAULT_INPUT_FREQUENCY)
         ),
+        bootstrap=bootstrap,
     )
 
 
-def must_run_bootstrap(da: DataArray, threshold: Threshold | None) -> bool:
+def must_run_bootstrap(
+    da: DataArray, threshold: Threshold | None, bootstrap: bool | None = None
+) -> bool:
     """
     Determine whether to run the bootstrap method.
 
@@ -361,6 +369,8 @@ def must_run_bootstrap(da: DataArray, threshold: Threshold | None) -> bool:
         )
     ):
         return False
+    if bootstrap is not None:
+        return bootstrap
     reference = threshold.value
     time_index = da.indexes.get("time")
     if time_index is None:
@@ -394,6 +404,7 @@ def _build_reference_variable(
     reference_period: Sequence[str] | None,
     in_files: dict[str, InFileDictionary],
     standard_var: StandardVariable,
+    bootstrap: bool | None = None,
 ) -> ClimateVariable:
     """
     Add a secondary variable for indices such as anomaly.
@@ -438,6 +449,7 @@ def _build_reference_variable(
             xarray.infer_freq(studied_data.time) or DEFAULT_INPUT_FREQUENCY,
         ),
         is_reference=True,
+        bootstrap=bootstrap,
     )
 
 

--- a/src/icclim/_core/generic/functions.py
+++ b/src/icclim/_core/generic/functions.py
@@ -411,7 +411,7 @@ def fraction_of_total(
         study=study,
         threshold=threshold,
         freq=resample_freq.pandas_freq,
-        bootstrap=must_run_bootstrap(study, threshold),
+        bootstrap=must_run_bootstrap(study, threshold, climate_vars[0].bootstrap),
     ).squeeze()
     over = (
         study.where(ex_da, 0).resample(time=resample_freq.pandas_freq).sum(dim="time")
@@ -1272,7 +1272,7 @@ def _run_rolling_reducer(
             study=study,
             freq=resample_freq.pandas_freq,
             threshold=threshold,
-            bootstrap=must_run_bootstrap(study, threshold),
+            bootstrap=must_run_bootstrap(study, threshold, climate_vars[0].bootstrap),
         ).squeeze()
         study = study.where(exceedance)
     study = rolling_op(study.rolling(time=rolling_window_width))
@@ -1325,7 +1325,7 @@ def _run_simple_reducer(
             study=study,
             freq=resample_freq.pandas_freq,
             threshold=threshold,
-            bootstrap=must_run_bootstrap(study, threshold),
+            bootstrap=must_run_bootstrap(study, threshold, climate_vars[0].bootstrap),
         ).squeeze()
         filtered_study = study.where(exceedance)
     else:
@@ -1418,6 +1418,7 @@ def _compute_exceedances(
                 bootstrap=must_run_bootstrap(
                     climate_var.studied_data,
                     climate_var.threshold,
+                    climate_var.bootstrap,
                 ),
             ).squeeze()
         )

--- a/src/icclim/_core/generic/indicator.py
+++ b/src/icclim/_core/generic/indicator.py
@@ -605,7 +605,7 @@ def _get_climate_vars_metadata(
     return [
         c_var.build_indicator_metadata(
             resample_freq,
-            must_run_bootstrap(c_var.studied_data, c_var.threshold),
+            must_run_bootstrap(c_var.studied_data, c_var.threshold, c_var.bootstrap),
             jinja_scope,
             jinja_env,
         )

--- a/src/icclim/main.py
+++ b/src/icclim/main.py
@@ -230,6 +230,7 @@ def index(
     callback_percentage_start_value: int = 0,
     callback_percentage_total: int = 100,
     base_period_time_range: Sequence[dt.datetime] | Sequence[str] | None = None,
+    bootstrap: bool | None = None,
     doy_window_width: int = 5,
     only_leap_years: bool = False,
     ignore_Feb29th: bool = False,
@@ -329,6 +330,11 @@ def index(
         bootstrapped.
         #. to compute a reference period for indices such as difference_of_mean
         (a.k.a anomaly) if a single variable is given in input.
+    bootstrap: bool | None
+        ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
+        Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
+        ``False`` to disable bootstrap, or ``True`` to force it when supported by the
+        threshold type.
     doy_window_width: int
         ``optional`` Window width used to aggreagte day of year values when computing
         day of year percentiles (doy_per)
@@ -490,6 +496,7 @@ def index(
         threshold=threshold,
         callback=callback,
         base_period_time_range=base_period_time_range,
+        bootstrap=bootstrap,
         doy_window_width=doy_window_width,
         only_leap_years=only_leap_years,
         ignore_feb29th=ignore_Feb29th,
@@ -534,6 +541,7 @@ def _build_config(
     threshold: str | Threshold | Sequence[str | Threshold] | None,
     callback: Callable[[int], None],
     base_period_time_range: Sequence[dt.datetime] | Sequence[str] | None,
+    bootstrap: bool | None,
     doy_window_width: int,
     only_leap_years: bool,
     ignore_feb29th: bool,
@@ -559,6 +567,7 @@ def _build_config(
             time_range=time_range,
             callback=callback,
             base_period_time_range=base_period_time_range,
+            bootstrap=bootstrap,
             doy_window_width=doy_window_width,
             only_leap_years=only_leap_years,
             ignore_feb29th=ignore_feb29th,
@@ -583,6 +592,7 @@ def _build_config(
             threshold=threshold,
             callback=callback,
             base_period_time_range=base_period_time_range,
+            bootstrap=bootstrap,
             doy_window_width=doy_window_width,
             only_leap_years=only_leap_years,
             ignore_feb29th=ignore_feb29th,
@@ -651,6 +661,7 @@ def _build_user_index_config(
     time_range: Sequence[dt.datetime | str] | None,
     callback: Callable[[int], None],
     base_period_time_range: Sequence[dt.datetime] | Sequence[str] | None,
+    bootstrap: bool | None,
     doy_window_width: int,
     only_leap_years: bool,
     ignore_feb29th: bool,
@@ -698,6 +709,7 @@ def _build_user_index_config(
         base_period=reference_period,
         standard_index=None,
         is_compared_to_reference=is_compared_to_ref,
+        bootstrap=bootstrap,
     )
     return IndexConfig(
         save_thresholds=save_thresholds,
@@ -733,6 +745,7 @@ def _build_standard_index_config(
     threshold: str | Threshold | Sequence[str | Threshold] | None,
     callback: Callable[[int], None],
     base_period_time_range: Sequence[dt.datetime] | Sequence[str] | None,
+    bootstrap: bool | None,
     doy_window_width: int,
     only_leap_years: bool,
     ignore_feb29th: bool,
@@ -783,6 +796,7 @@ def _build_standard_index_config(
         base_period=reference_period,
         standard_index=standard_index,
         is_compared_to_reference=is_compared_to_ref,
+        bootstrap=bootstrap,
     )
     return IndexConfig(
         save_thresholds=save_thresholds,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -736,6 +736,21 @@ class TestIntegration:
         # 2043 values are compared to 2042's 90th percentile due to bootstrap
         assert res.TX90p.sel(time="2043-01") == 5
 
+    def test_index_tx90p__bootstrap_can_be_disabled(self) -> None:
+        tas = stub_tas(tas_value=27 + K2C)
+        tas[5:10] = 0
+        res = icclim.index(
+            index_name="tx90p",
+            in_files=tas,
+            doy_window_width=1,
+            time_range=("2042-01-01", "2045-12-31"),
+            base_period_time_range=("2042-01-01", "2043-12-31"),
+            bootstrap=False,
+            out_file=self.OUTPUT_FILE,
+            slice_mode="ms",
+        )
+        assert REFERENCE_PERIOD_ID not in res.TX90p.attrs
+
     def test_index_wsdi__no_bootstrap_because_no_overlap(self) -> None:
         tas = stub_tas(tas_value=27 + K2C)
         tas[0:10] = 0


### PR DESCRIPTION
## Summary
- bump release metadata to 7.1.3
- document the latest xclim compatibility fix
- document the bootstrap override for overlap-based percentile runs

## Testing
- pytest tests/test_generic_functions.py
- pytest tests/test_main.py -k 'bootstrap'
