### PR TITLE
bootstrap: revert prepared DOY state reuse

### DIFF
--- a/src/icclim/_core/climate_variable.py
+++ b/src/icclim/_core/climate_variable.py
@@ -72,6 +72,7 @@ class ClimateVariable:
     threshold: Threshold | None = None
     reference_period: Sequence[datetime | str] | None = None
     is_reference: bool = False
+    bootstrap: bool | None = None
 
     def build_indicator_metadata(
         self,
@@ -131,6 +132,7 @@ def build_climate_vars(
     base_period: Sequence[str] | None,
     standard_index: StandardIndex | None,
     is_compared_to_reference: bool,
+    bootstrap: bool | None = None,
 ) -> list[ClimateVariable]:
     """
     Build a list of ClimateVariable from a dictionary of input files.
@@ -193,6 +195,7 @@ def build_climate_vars(
             time_range=time_range,
             standard_var=standard_var,
             reference_period=reference_period,
+            bootstrap=bootstrap,
         )
 
         acc.append(cv)
@@ -214,6 +217,7 @@ def build_climate_vars(
                 base_period,
                 climate_vars_dict,
                 standard_var=standard_var,  # type: ignore[arg-type]
+                bootstrap=bootstrap,
             )
             acc.append(added_var)
 
@@ -227,6 +231,7 @@ def build_climate_var(
     time_range: Sequence[datetime | str] | None,
     standard_var: StandardVariable | None,
     reference_period: Sequence[datetime | str] | None = None,
+    bootstrap: bool | None = None,
 ) -> ClimateVariable:
     """
     Build a ClimateVariable object.
@@ -324,10 +329,13 @@ def build_climate_var(
         source_frequency=FrequencyRegistry.lookup(  # type: ignore[arg-type]
             studied_data.time.attrs.get("freq", DEFAULT_INPUT_FREQUENCY)
         ),
+        bootstrap=bootstrap,
     )
 
 
-def must_run_bootstrap(da: DataArray, threshold: Threshold | None) -> bool:
+def must_run_bootstrap(
+    da: DataArray, threshold: Threshold | None, bootstrap: bool | None = None
+) -> bool:
     """
     Determine whether to run the bootstrap method.
 
@@ -361,6 +369,8 @@ def must_run_bootstrap(da: DataArray, threshold: Threshold | None) -> bool:
         )
     ):
         return False
+    if bootstrap is not None:
+        return bootstrap
     reference = threshold.value
     time_index = da.indexes.get("time")
     if time_index is None:
@@ -394,6 +404,7 @@ def _build_reference_variable(
     reference_period: Sequence[str] | None,
     in_files: dict[str, InFileDictionary],
     standard_var: StandardVariable,
+    bootstrap: bool | None = None,
 ) -> ClimateVariable:
     """
     Add a secondary variable for indices such as anomaly.
@@ -438,6 +449,7 @@ def _build_reference_variable(
             xarray.infer_freq(studied_data.time) or DEFAULT_INPUT_FREQUENCY,
         ),
         is_reference=True,
+        bootstrap=bootstrap,
     )
 
 

--- a/src/icclim/_core/generic/functions.py
+++ b/src/icclim/_core/generic/functions.py
@@ -1646,12 +1646,19 @@ def check_freq(da: xr.DataArray, dim: str = "time", strict: bool = True) -> str 
 
 
 def _safe_to_agg_units(*args, **kwargs) -> DataArray:
+    import inspect  # noqa: PLC0415
+
     from xclim.core.units import to_agg_units  # noqa: PLC0415
 
+    supported_kwargs = {
+        key: value
+        for key, value in kwargs.items()
+        if key in inspect.signature(to_agg_units).parameters
+    }
     with warnings.catch_warnings():
         warnings.filterwarnings(
             "ignore",
             category=UserWarning,
             message=".*Unable to find the sampling frequency.*",
         )
-        return to_agg_units(*args, **kwargs)
+        return to_agg_units(*args, **supported_kwargs)

--- a/src/icclim/_core/generic/functions.py
+++ b/src/icclim/_core/generic/functions.py
@@ -411,7 +411,7 @@ def fraction_of_total(
         study=study,
         threshold=threshold,
         freq=resample_freq.pandas_freq,
-        bootstrap=must_run_bootstrap(study, threshold),
+        bootstrap=must_run_bootstrap(study, threshold, climate_vars[0].bootstrap),
     ).squeeze()
     over = (
         study.where(ex_da, 0).resample(time=resample_freq.pandas_freq).sum(dim="time")
@@ -1272,7 +1272,7 @@ def _run_rolling_reducer(
             study=study,
             freq=resample_freq.pandas_freq,
             threshold=threshold,
-            bootstrap=must_run_bootstrap(study, threshold),
+            bootstrap=must_run_bootstrap(study, threshold, climate_vars[0].bootstrap),
         ).squeeze()
         study = study.where(exceedance)
     study = rolling_op(study.rolling(time=rolling_window_width))
@@ -1325,7 +1325,7 @@ def _run_simple_reducer(
             study=study,
             freq=resample_freq.pandas_freq,
             threshold=threshold,
-            bootstrap=must_run_bootstrap(study, threshold),
+            bootstrap=must_run_bootstrap(study, threshold, climate_vars[0].bootstrap),
         ).squeeze()
         filtered_study = study.where(exceedance)
     else:
@@ -1418,6 +1418,7 @@ def _compute_exceedances(
                 bootstrap=must_run_bootstrap(
                     climate_var.studied_data,
                     climate_var.threshold,
+                    climate_var.bootstrap,
                 ),
             ).squeeze()
         )

--- a/src/icclim/_core/generic/indicator.py
+++ b/src/icclim/_core/generic/indicator.py
@@ -605,7 +605,7 @@ def _get_climate_vars_metadata(
     return [
         c_var.build_indicator_metadata(
             resample_freq,
-            must_run_bootstrap(c_var.studied_data, c_var.threshold),
+            must_run_bootstrap(c_var.studied_data, c_var.threshold, c_var.bootstrap),
             jinja_scope,
             jinja_env,
         )

--- a/src/icclim/_core/generic/threshold/percentile.py
+++ b/src/icclim/_core/generic/threshold/percentile.py
@@ -443,6 +443,8 @@ class PercentileThreshold(Threshold):
         op: Callable[[DataArray, DataArray], DataArray],
         freq: str,
     ) -> DataArray:
+        from xclim.core.calendar import percentile_doy  # noqa: PLC0415
+
         clim = per.attrs["climatology_bounds"]
         overlap_da = comparison_data.sel(time=slice(*clim))
         if len(overlap_da.time) == 0 or len(overlap_da.time) == len(comparison_data.time):
@@ -460,10 +462,6 @@ class PercentileThreshold(Threshold):
         per_values = per.percentiles.data.tolist()
         if not isinstance(per_values, list):
             per_values = [per_values]
-        prepared_state = _prepare_doy_percentile_state(
-            arr=overlap_da,
-            window=per.attrs["window"],
-        )
 
         acc: list[DataArray] = []
         for year_key, year_slice in da_groups.items():
@@ -483,13 +481,15 @@ class PercentileThreshold(Threshold):
             for donor_key in overlap_groups:
                 if donor_key == year_key:
                     continue
-                donor_per = _compute_doy_percentile_from_state(
-                    state=_build_single_bootstrap_state(
-                        prepared_state,
-                        target_year=_get_group_year(year_key),
-                        donor_year=_get_group_year(donor_key),
-                    ),
-                    source=overlap_da,
+                boot_ref = _build_single_bootstrap_reference(
+                    overlap_da,
+                    overlap_groups,
+                    year_key,
+                    donor_key,
+                )
+                donor_per = percentile_doy(
+                    arr=boot_ref,
+                    window=per.attrs["window"],
                     per=per_values,
                     alpha=per.attrs["alpha"],
                     beta=per.attrs["beta"],
@@ -608,93 +608,6 @@ def _build_doy_per(
         alpha=interpolation.alpha,
         beta=interpolation.beta,
     )
-
-
-def _prepare_doy_percentile_state(arr: DataArray, window: int) -> DataArray:
-    import pandas as pd  # noqa: PLC0415
-
-    rr = arr.rolling(min_periods=1, center=True, time=window).construct("window")
-    crd = xr.Coordinates.from_pandas_multiindex(
-        pd.MultiIndex.from_arrays(
-            (rr.time.dt.year.values, rr.time.dt.dayofyear.values),
-            names=("year", "dayofyear"),
-        ),
-        "time",
-    )
-    rr = rr.drop_vars("time").assign_coords(crd)
-    return rr.unstack("time")
-
-
-def _compute_doy_percentile_from_state(
-    state: DataArray,
-    source: DataArray,
-    per: float | Sequence[float],
-    alpha: float,
-    beta: float,
-    copy: bool,
-) -> DataArray:
-    from collections.abc import Sequence  # noqa: PLC0415
-
-    from xclim.core.calendar import adjust_doy_calendar, build_climatology_bounds  # noqa: PLC0415
-    from xclim.core.utils import calc_perc  # noqa: PLC0415
-
-    rrr = state.stack(stack_dim=("year", "window"))
-    if rrr.chunks is not None and len(rrr.chunks[rrr.get_axis_num("stack_dim")]) > 1:
-        time_chunks_count = len(source.chunks[source.get_axis_num("time")])
-        doy_chunk_size = np.ceil(len(rrr.dayofyear) / (state.sizes["window"] * time_chunks_count))
-        rrr = rrr.chunk({"stack_dim": -1, "dayofyear": doy_chunk_size})
-
-    if np.isscalar(per):
-        per = [per]
-
-    p = xr.apply_ufunc(
-        calc_perc,
-        rrr,
-        input_core_dims=[["stack_dim"]],
-        output_core_dims=[["percentiles"]],
-        keep_attrs=True,
-        kwargs={"percentiles": per, "alpha": alpha, "beta": beta, "copy": copy},
-        dask="parallelized",
-        output_dtypes=[rrr.dtype],
-        dask_gufunc_kwargs={
-            "output_sizes": {"percentiles": len(per) if isinstance(per, Sequence) else 1}
-        },
-    )
-    p = p.assign_coords(percentiles=xr.DataArray(per, dims=("percentiles",)))
-
-    if p.dayofyear.max() == 366:
-        p = adjust_doy_calendar(p.sel(dayofyear=(p.dayofyear < 366)), source)
-
-    p.attrs.update(source.attrs.copy())
-    p.attrs["climatology_bounds"] = build_climatology_bounds(source)
-    p.attrs["window"] = state.sizes["window"]
-    p.attrs["alpha"] = alpha
-    p.attrs["beta"] = beta
-    return p.rename("per")
-
-
-def _build_single_bootstrap_state(
-    state: DataArray,
-    target_year: int,
-    donor_year: int,
-) -> DataArray:
-    donor_state = state.sel(year=donor_year)
-    donor_state = donor_state.expand_dims(year=[target_year])
-    prefix = state.sel(year=slice(None, target_year - 1))
-    suffix = state.sel(year=slice(target_year + 1, None))
-    out = xr.concat([prefix, donor_state, suffix], dim="year")
-    out.attrs.update(state.attrs)
-    return out.sortby("year")
-
-
-def _get_group_year(label: Any) -> int:
-    year = getattr(label, "year", None)
-    if year is not None:
-        return int(year)
-    if isinstance(label, np.datetime64):
-        return int(label.astype("datetime64[Y]").astype(int) + 1970)
-    msg = f"Unsupported bootstrap group label {label!r}."
-    raise TypeError(msg)
 
 
 def _get_bootstrap_freq(freq: str) -> str:

--- a/src/icclim/_core/generic/threshold/percentile.py
+++ b/src/icclim/_core/generic/threshold/percentile.py
@@ -627,23 +627,30 @@ def _build_single_bootstrap_reference(
     donor_label: Any,
     dim: str = "time",
 ) -> DataArray:
-    target = da[dim][groups[target_label]]
-    source = da.isel({dim: groups[donor_label]})
-    out = da.copy(deep=True)
+    target_slice = groups[target_label]
+    donor_slice = groups[donor_label]
+    target_start = target_slice.start or 0
+    target_stop = target_slice.stop or da.sizes[dim]
+    target = da[dim][target_slice]
+    source = da.isel({dim: donor_slice})
     if len(source[dim]) < 360 and len(source[dim]) < len(target):
-        return out
+        return da
     if len(source[dim]) == len(target):
-        replacement = source.data
+        replacement = source
     elif len(target) == 365:
-        replacement = source.convert_calendar("noleap").data
+        replacement = source.convert_calendar("noleap")
     elif len(target) == 366:
-        replacement = source.convert_calendar("366_day", missing=np.nan).data
+        replacement = source.convert_calendar("366_day", missing=np.nan)
     elif len(target) < 365:
-        replacement = source.data[: len(target)]
+        replacement = source.isel({dim: slice(0, len(target))})
     else:
         msg = "Unsupported bootstrap year replacement shape."
         raise NotImplementedError(msg)
-    out.loc[{dim: target}] = replacement
+    replacement = replacement.assign_coords({dim: target})
+    prefix = da.isel({dim: slice(None, target_start)})
+    suffix = da.isel({dim: slice(target_stop, None)})
+    out = xr.concat([prefix, replacement, suffix], dim=dim)
+    out.attrs.update(da.attrs)
     return out
 
 

--- a/src/icclim/_core/generic/threshold/percentile.py
+++ b/src/icclim/_core/generic/threshold/percentile.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, cast
 
+import numpy as np
 import xarray as xr
 from xarray import DataArray, Dataset
 
@@ -399,40 +400,133 @@ class PercentileThreshold(Threshold):
         freq: str,
         bootstrap: bool,
     ) -> DataArray:
-        from xclim.core.bootstrapping import percentile_bootstrap  # noqa: PLC0415
-
-        @percentile_bootstrap
-        def __per_compute(
-            da: xr.DataArray,
-            per: xr.DataArray,
-            op: Callable[[DataArray, DataArray], DataArray],
-            is_doy_per_threshold: bool,
-            freq: str,  # noqa: ARG001
-            bootstrap: bool,  # noqa: ARG001
-        ) -> DataArray:
-            if self.threshold_min_value is not None:
-                # there is only a threshold_min_value when we are computing > or >=
-                thresh = self.threshold_min_value
-                from xclim.core.units import convert_units_to  # noqa: PLC0415
-
-                thresh = convert_units_to(thresh, per, context="hydro")
-                per = per.where(per > thresh, thresh)
-            if is_doy_per_threshold:
-                from xclim.core.calendar import resample_doy  # noqa: PLC0415
-
-                threshold_value = resample_doy(per, da)
-            else:
-                threshold_value = per
-            return op(da, threshold_value)
-
-        return __per_compute(
-            comparison_data,
-            per,
-            op,
-            is_doy_per_threshold,
-            freq,
-            bootstrap,
+        if bootstrap and is_doy_per_threshold:
+            return self._bootstrap_per_compute(
+                comparison_data=comparison_data,
+                per=per,
+                op=op,
+                freq=freq,
+            )
+        return self._apply_percentile_op(
+            da=comparison_data,
+            per=per,
+            op=op,
+            is_doy_per_threshold=is_doy_per_threshold,
         )
+
+    def _apply_percentile_op(
+        self,
+        da: xr.DataArray,
+        per: xr.DataArray,
+        op: Callable[[DataArray, DataArray], DataArray],
+        is_doy_per_threshold: bool,
+    ) -> DataArray:
+        if self.threshold_min_value is not None:
+            # there is only a threshold_min_value when we are computing > or >=
+            thresh = self.threshold_min_value
+            from xclim.core.units import convert_units_to  # noqa: PLC0415
+
+            thresh = convert_units_to(thresh, per, context="hydro")
+            per = per.where(per > thresh, thresh)
+        if is_doy_per_threshold:
+            from xclim.core.calendar import resample_doy  # noqa: PLC0415
+
+            threshold_value = resample_doy(per, da)
+        else:
+            threshold_value = per
+        return op(da, threshold_value)
+
+    def _bootstrap_per_compute(
+        self,
+        comparison_data: xr.DataArray,
+        per: PercentileDataArray,
+        op: Callable[[DataArray, DataArray], DataArray],
+        freq: str,
+    ) -> DataArray:
+        from xclim.core.calendar import percentile_doy  # noqa: PLC0415
+
+        clim = per.attrs["climatology_bounds"]
+        overlap_da = comparison_data.sel(time=slice(*clim))
+        if len(overlap_da.time) == 0 or len(overlap_da.time) == len(comparison_data.time):
+            return self._apply_percentile_op(
+                da=comparison_data,
+                per=per,
+                op=op,
+                is_doy_per_threshold=True,
+            )
+
+        bfreq = _get_bootstrap_freq(freq)
+        overlap_groups = overlap_da.resample(time=bfreq).groups
+        da_groups = comparison_data.resample(time=bfreq).groups
+        overlap_labels = set(overlap_groups)
+        per_values = per.percentiles.data.tolist()
+        if not isinstance(per_values, list):
+            per_values = [per_values]
+
+        acc: list[DataArray] = []
+        for year_key, year_slice in da_groups.items():
+            year_da = comparison_data.isel(time=year_slice)
+            if year_key not in overlap_labels:
+                acc.append(
+                    self._apply_percentile_op(
+                        da=year_da,
+                        per=per,
+                        op=op,
+                        is_doy_per_threshold=True,
+                    )
+                )
+                continue
+
+            donor_results: list[DataArray] = []
+            for donor_key in overlap_groups:
+                if donor_key == year_key:
+                    continue
+                boot_ref = _build_single_bootstrap_reference(
+                    overlap_da,
+                    overlap_groups,
+                    year_key,
+                    donor_key,
+                )
+                donor_per = percentile_doy(
+                    arr=boot_ref,
+                    window=per.attrs["window"],
+                    per=per_values,
+                    alpha=per.attrs["alpha"],
+                    beta=per.attrs["beta"],
+                    copy=False,
+                )
+                donor_per = PercentileDataArray.from_da(
+                    donor_per,
+                    climatology_bounds=per.attrs["climatology_bounds"],
+                )
+                if "percentiles" not in per.dims:
+                    donor_per = donor_per.squeeze("percentiles")
+                donor_results.append(
+                    self._apply_percentile_op(
+                        da=year_da,
+                        per=donor_per,
+                        op=op,
+                        is_doy_per_threshold=True,
+                    )
+                )
+            if donor_results:
+                acc.append(
+                    xr.concat(donor_results, dim="_bootstrap")
+                    .mean(dim="_bootstrap", keep_attrs=True)
+                )
+            else:
+                acc.append(
+                    self._apply_percentile_op(
+                        da=year_da,
+                        per=per,
+                        op=op,
+                        is_doy_per_threshold=True,
+                    )
+                )
+
+        result = xr.concat(acc, dim="time")
+        result.attrs.update(acc[-1].attrs)
+        return result
 
 
 def _compute_per(
@@ -514,6 +608,43 @@ def _build_doy_per(
         alpha=interpolation.alpha,
         beta=interpolation.beta,
     )
+
+
+def _get_bootstrap_freq(freq: str) -> str:
+    from xclim.core.calendar import parse_offset  # noqa: PLC0415
+
+    _, base, start_anchor, anchor = parse_offset(freq)
+    bfreq = "YS" if start_anchor else "YE"
+    if base in ["A", "Y", "Q"] and anchor is not None:
+        bfreq = f"{bfreq}-{anchor}"
+    return bfreq
+
+
+def _build_single_bootstrap_reference(
+    da: DataArray,
+    groups: dict[Any, slice],
+    target_label: Any,
+    donor_label: Any,
+    dim: str = "time",
+) -> DataArray:
+    target = da[dim][groups[target_label]]
+    source = da.isel({dim: groups[donor_label]})
+    out = da.copy(deep=True)
+    if len(source[dim]) < 360 and len(source[dim]) < len(target):
+        return out
+    if len(source[dim]) == len(target):
+        replacement = source.data
+    elif len(target) == 365:
+        replacement = source.convert_calendar("noleap").data
+    elif len(target) == 366:
+        replacement = source.convert_calendar("366_day", missing=np.nan).data
+    elif len(target) < 365:
+        replacement = source.data[: len(target)]
+    else:
+        msg = "Unsupported bootstrap year replacement shape."
+        raise NotImplementedError(msg)
+    out.loc[{dim: target}] = replacement
+    return out
 
 
 def _build_per_thresh_from_dataset(

--- a/src/icclim/_core/generic/threshold/percentile.py
+++ b/src/icclim/_core/generic/threshold/percentile.py
@@ -443,8 +443,6 @@ class PercentileThreshold(Threshold):
         op: Callable[[DataArray, DataArray], DataArray],
         freq: str,
     ) -> DataArray:
-        from xclim.core.calendar import percentile_doy  # noqa: PLC0415
-
         clim = per.attrs["climatology_bounds"]
         overlap_da = comparison_data.sel(time=slice(*clim))
         if len(overlap_da.time) == 0 or len(overlap_da.time) == len(comparison_data.time):
@@ -462,6 +460,10 @@ class PercentileThreshold(Threshold):
         per_values = per.percentiles.data.tolist()
         if not isinstance(per_values, list):
             per_values = [per_values]
+        prepared_state = _prepare_doy_percentile_state(
+            arr=overlap_da,
+            window=per.attrs["window"],
+        )
 
         acc: list[DataArray] = []
         for year_key, year_slice in da_groups.items():
@@ -481,15 +483,13 @@ class PercentileThreshold(Threshold):
             for donor_key in overlap_groups:
                 if donor_key == year_key:
                     continue
-                boot_ref = _build_single_bootstrap_reference(
-                    overlap_da,
-                    overlap_groups,
-                    year_key,
-                    donor_key,
-                )
-                donor_per = percentile_doy(
-                    arr=boot_ref,
-                    window=per.attrs["window"],
+                donor_per = _compute_doy_percentile_from_state(
+                    state=_build_single_bootstrap_state(
+                        prepared_state,
+                        target_year=_get_group_year(year_key),
+                        donor_year=_get_group_year(donor_key),
+                    ),
+                    source=overlap_da,
                     per=per_values,
                     alpha=per.attrs["alpha"],
                     beta=per.attrs["beta"],
@@ -608,6 +608,93 @@ def _build_doy_per(
         alpha=interpolation.alpha,
         beta=interpolation.beta,
     )
+
+
+def _prepare_doy_percentile_state(arr: DataArray, window: int) -> DataArray:
+    import pandas as pd  # noqa: PLC0415
+
+    rr = arr.rolling(min_periods=1, center=True, time=window).construct("window")
+    crd = xr.Coordinates.from_pandas_multiindex(
+        pd.MultiIndex.from_arrays(
+            (rr.time.dt.year.values, rr.time.dt.dayofyear.values),
+            names=("year", "dayofyear"),
+        ),
+        "time",
+    )
+    rr = rr.drop_vars("time").assign_coords(crd)
+    return rr.unstack("time")
+
+
+def _compute_doy_percentile_from_state(
+    state: DataArray,
+    source: DataArray,
+    per: float | Sequence[float],
+    alpha: float,
+    beta: float,
+    copy: bool,
+) -> DataArray:
+    from collections.abc import Sequence  # noqa: PLC0415
+
+    from xclim.core.calendar import adjust_doy_calendar, build_climatology_bounds  # noqa: PLC0415
+    from xclim.core.utils import calc_perc  # noqa: PLC0415
+
+    rrr = state.stack(stack_dim=("year", "window"))
+    if rrr.chunks is not None and len(rrr.chunks[rrr.get_axis_num("stack_dim")]) > 1:
+        time_chunks_count = len(source.chunks[source.get_axis_num("time")])
+        doy_chunk_size = np.ceil(len(rrr.dayofyear) / (state.sizes["window"] * time_chunks_count))
+        rrr = rrr.chunk({"stack_dim": -1, "dayofyear": doy_chunk_size})
+
+    if np.isscalar(per):
+        per = [per]
+
+    p = xr.apply_ufunc(
+        calc_perc,
+        rrr,
+        input_core_dims=[["stack_dim"]],
+        output_core_dims=[["percentiles"]],
+        keep_attrs=True,
+        kwargs={"percentiles": per, "alpha": alpha, "beta": beta, "copy": copy},
+        dask="parallelized",
+        output_dtypes=[rrr.dtype],
+        dask_gufunc_kwargs={
+            "output_sizes": {"percentiles": len(per) if isinstance(per, Sequence) else 1}
+        },
+    )
+    p = p.assign_coords(percentiles=xr.DataArray(per, dims=("percentiles",)))
+
+    if p.dayofyear.max() == 366:
+        p = adjust_doy_calendar(p.sel(dayofyear=(p.dayofyear < 366)), source)
+
+    p.attrs.update(source.attrs.copy())
+    p.attrs["climatology_bounds"] = build_climatology_bounds(source)
+    p.attrs["window"] = state.sizes["window"]
+    p.attrs["alpha"] = alpha
+    p.attrs["beta"] = beta
+    return p.rename("per")
+
+
+def _build_single_bootstrap_state(
+    state: DataArray,
+    target_year: int,
+    donor_year: int,
+) -> DataArray:
+    donor_state = state.sel(year=donor_year)
+    donor_state = donor_state.expand_dims(year=[target_year])
+    prefix = state.sel(year=slice(None, target_year - 1))
+    suffix = state.sel(year=slice(target_year + 1, None))
+    out = xr.concat([prefix, donor_state, suffix], dim="year")
+    out.attrs.update(state.attrs)
+    return out.sortby("year")
+
+
+def _get_group_year(label: Any) -> int:
+    year = getattr(label, "year", None)
+    if year is not None:
+        return int(year)
+    if isinstance(label, np.datetime64):
+        return int(label.astype("datetime64[Y]").astype(int) + 1970)
+    msg = f"Unsupported bootstrap group label {label!r}."
+    raise TypeError(msg)
 
 
 def _get_bootstrap_freq(freq: str) -> str:

--- a/src/icclim/_core/generic/threshold/percentile.py
+++ b/src/icclim/_core/generic/threshold/percentile.py
@@ -447,7 +447,9 @@ class PercentileThreshold(Threshold):
 
         clim = per.attrs["climatology_bounds"]
         overlap_da = comparison_data.sel(time=slice(*clim))
-        if len(overlap_da.time) == 0 or len(overlap_da.time) == len(comparison_data.time):
+        if len(overlap_da.time) == 0 or len(overlap_da.time) == len(
+            comparison_data.time
+        ):
             return self._apply_percentile_op(
                 da=comparison_data,
                 per=per,
@@ -511,8 +513,9 @@ class PercentileThreshold(Threshold):
                 )
             if donor_results:
                 acc.append(
-                    xr.concat(donor_results, dim="_bootstrap")
-                    .mean(dim="_bootstrap", keep_attrs=True)
+                    xr.concat(donor_results, dim="_bootstrap").mean(
+                        dim="_bootstrap", keep_attrs=True
+                    )
                 )
             else:
                 acc.append(

--- a/src/icclim/main.py
+++ b/src/icclim/main.py
@@ -230,6 +230,7 @@ def index(
     callback_percentage_start_value: int = 0,
     callback_percentage_total: int = 100,
     base_period_time_range: Sequence[dt.datetime] | Sequence[str] | None = None,
+    bootstrap: bool | None = None,
     doy_window_width: int = 5,
     only_leap_years: bool = False,
     ignore_Feb29th: bool = False,
@@ -329,6 +330,11 @@ def index(
         bootstrapped.
         #. to compute a reference period for indices such as difference_of_mean
         (a.k.a anomaly) if a single variable is given in input.
+    bootstrap: bool | None
+        ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
+        Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
+        ``False`` to disable bootstrap, or ``True`` to force it when supported by the
+        threshold type.
     doy_window_width: int
         ``optional`` Window width used to aggreagte day of year values when computing
         day of year percentiles (doy_per)
@@ -490,6 +496,7 @@ def index(
         threshold=threshold,
         callback=callback,
         base_period_time_range=base_period_time_range,
+        bootstrap=bootstrap,
         doy_window_width=doy_window_width,
         only_leap_years=only_leap_years,
         ignore_feb29th=ignore_Feb29th,
@@ -534,6 +541,7 @@ def _build_config(
     threshold: str | Threshold | Sequence[str | Threshold] | None,
     callback: Callable[[int], None],
     base_period_time_range: Sequence[dt.datetime] | Sequence[str] | None,
+    bootstrap: bool | None,
     doy_window_width: int,
     only_leap_years: bool,
     ignore_feb29th: bool,
@@ -559,6 +567,7 @@ def _build_config(
             time_range=time_range,
             callback=callback,
             base_period_time_range=base_period_time_range,
+            bootstrap=bootstrap,
             doy_window_width=doy_window_width,
             only_leap_years=only_leap_years,
             ignore_feb29th=ignore_feb29th,
@@ -583,6 +592,7 @@ def _build_config(
             threshold=threshold,
             callback=callback,
             base_period_time_range=base_period_time_range,
+            bootstrap=bootstrap,
             doy_window_width=doy_window_width,
             only_leap_years=only_leap_years,
             ignore_feb29th=ignore_feb29th,
@@ -651,6 +661,7 @@ def _build_user_index_config(
     time_range: Sequence[dt.datetime | str] | None,
     callback: Callable[[int], None],
     base_period_time_range: Sequence[dt.datetime] | Sequence[str] | None,
+    bootstrap: bool | None,
     doy_window_width: int,
     only_leap_years: bool,
     ignore_feb29th: bool,
@@ -698,6 +709,7 @@ def _build_user_index_config(
         base_period=reference_period,
         standard_index=None,
         is_compared_to_reference=is_compared_to_ref,
+        bootstrap=bootstrap,
     )
     return IndexConfig(
         save_thresholds=save_thresholds,
@@ -733,6 +745,7 @@ def _build_standard_index_config(
     threshold: str | Threshold | Sequence[str | Threshold] | None,
     callback: Callable[[int], None],
     base_period_time_range: Sequence[dt.datetime] | Sequence[str] | None,
+    bootstrap: bool | None,
     doy_window_width: int,
     only_leap_years: bool,
     ignore_feb29th: bool,
@@ -783,6 +796,7 @@ def _build_standard_index_config(
         base_period=reference_period,
         standard_index=standard_index,
         is_compared_to_reference=is_compared_to_ref,
+        bootstrap=bootstrap,
     )
     return IndexConfig(
         save_thresholds=save_thresholds,

--- a/tests/test_generic_functions.py
+++ b/tests/test_generic_functions.py
@@ -1,6 +1,9 @@
+import pytest
+
 from icclim._core.climate_variable import ClimateVariable
 from icclim._core.constants import GROUP_BY_METHOD
 from icclim._core.generic.functions import (
+    _safe_to_agg_units,
     average,
     count_occurrences,
     generic_sum,
@@ -113,3 +116,34 @@ def test_max_consecutive_occurrence() -> None:
         source_freq_delta="1D",
     )
     assert int(result.isel(time=0).values) >= 365
+
+
+def test_safe_to_agg_units_drops_unsupported_kwargs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    received: dict[str, object] = {}
+
+    def fake_to_agg_units(
+        out,
+        orig,
+        op,
+        dim="time",
+    ):
+        received["out"] = out
+        received["orig"] = orig
+        received["op"] = op
+        received["dim"] = dim
+        return out
+
+    monkeypatch.setattr("xclim.core.units.to_agg_units", fake_to_agg_units)
+    da = stub_tas()
+
+    result = _safe_to_agg_units(da, da, "count", dim="time", deffreq="YS")
+
+    assert result is da
+    assert received == {
+        "out": da,
+        "orig": da,
+        "op": "count",
+        "dim": "time",
+    }

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -768,6 +768,23 @@ class TestIntegration:
         )
         assert REFERENCE_PERIOD_ID not in res.TX90p.attrs
 
+    def test_index_tg90p__bootstrap_2_years_with_dask(self) -> None:
+        tas = stub_tas(tas_value=27 + K2C)
+        tas[5:10] = 0
+        tas = tas.chunk({"time": 365, "lat": 1, "lon": 1})
+        res = icclim.index(
+            index_name="tg90p",
+            in_files=tas,
+            doy_window_width=1,
+            time_range=("2042-01-01", "2045-12-31"),
+            base_period_time_range=("2042-01-01", "2043-12-31"),
+            out_file=self.OUTPUT_FILE,
+            slice_mode="ms",
+        ).compute()
+        assert REFERENCE_PERIOD_ID in res.TG90p.attrs
+        assert res.TG90p.sel(time="2042-01") == 0
+        assert res.TG90p.sel(time="2043-01") == 5
+
     def test_index_wsdi__no_bootstrap_because_no_overlap(self) -> None:
         tas = stub_tas(tas_value=27 + K2C)
         tas[0:10] = 0

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -736,6 +736,23 @@ class TestIntegration:
         # 2043 values are compared to 2042's 90th percentile due to bootstrap
         assert res.TX90p.sel(time="2043-01") == 5
 
+    def test_index_tx90p__bootstrap_2_years_with_dask(self) -> None:
+        tas = stub_tas(tas_value=27 + K2C)
+        tas[5:10] = 0
+        tas = tas.chunk({"time": 365, "lat": 1, "lon": 1})
+        res = icclim.index(
+            index_name="tx90p",
+            in_files=tas,
+            doy_window_width=1,
+            time_range=("2042-01-01", "2045-12-31"),
+            base_period_time_range=("2042-01-01", "2043-12-31"),
+            out_file=self.OUTPUT_FILE,
+            slice_mode="ms",
+        ).compute()
+        assert REFERENCE_PERIOD_ID in res.TX90p.attrs
+        assert res.TX90p.sel(time="2042-01") == 0
+        assert res.TX90p.sel(time="2043-01") == 5
+
     def test_index_tx90p__bootstrap_can_be_disabled(self) -> None:
         tas = stub_tas(tas_value=27 + K2C)
         tas[5:10] = 0

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -768,23 +768,6 @@ class TestIntegration:
         )
         assert REFERENCE_PERIOD_ID not in res.TX90p.attrs
 
-    def test_index_tg90p__bootstrap_2_years_with_dask(self) -> None:
-        tas = stub_tas(tas_value=27 + K2C)
-        tas[5:10] = 0
-        tas = tas.chunk({"time": 365, "lat": 1, "lon": 1})
-        res = icclim.index(
-            index_name="tg90p",
-            in_files=tas,
-            doy_window_width=1,
-            time_range=("2042-01-01", "2045-12-31"),
-            base_period_time_range=("2042-01-01", "2043-12-31"),
-            out_file=self.OUTPUT_FILE,
-            slice_mode="ms",
-        ).compute()
-        assert REFERENCE_PERIOD_ID in res.TG90p.attrs
-        assert res.TG90p.sel(time="2042-01") == 0
-        assert res.TG90p.sel(time="2043-01") == 5
-
     def test_index_wsdi__no_bootstrap_because_no_overlap(self) -> None:
         tas = stub_tas(tas_value=27 + K2C)
         tas[0:10] = 0

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -736,6 +736,21 @@ class TestIntegration:
         # 2043 values are compared to 2042's 90th percentile due to bootstrap
         assert res.TX90p.sel(time="2043-01") == 5
 
+    def test_index_tx90p__bootstrap_can_be_disabled(self) -> None:
+        tas = stub_tas(tas_value=27 + K2C)
+        tas[5:10] = 0
+        res = icclim.index(
+            index_name="tx90p",
+            in_files=tas,
+            doy_window_width=1,
+            time_range=("2042-01-01", "2045-12-31"),
+            base_period_time_range=("2042-01-01", "2043-12-31"),
+            bootstrap=False,
+            out_file=self.OUTPUT_FILE,
+            slice_mode="ms",
+        )
+        assert REFERENCE_PERIOD_ID not in res.TX90p.attrs
+
     def test_index_wsdi__no_bootstrap_because_no_overlap(self) -> None:
         tas = stub_tas(tas_value=27 + K2C)
         tas[0:10] = 0


### PR DESCRIPTION
## Summary
- revert the prepared DOY state reuse optimization introduced in `7046c61`
- keep the bootstrap override (`bootstrap=False`) and latest xclim compatibility work untouched
- restore the bootstrap branch to the numerically stable native implementation while follow-up optimization continues

## Why
Kraken diagnostics on Monday, July 20, 2026 showed that the prepared-state reuse changed bootstrap results materially:
- current native vs pre-`7046c61`: `12364 / 38220` changed cells
- max absolute difference: `1.6551724137931032`
- drift is concentrated in overlap years and especially leap years

The same diagnostics showed that the pre-`7046c61` native path is essentially equivalent to the old bootstrap implementation:
- prestate vs old: `1 / 38220` changed cells
- max absolute difference: `0.06896551724138078`
- mean difference: `-1.8044353014711116e-06`

## Testing
- pytest tests/test_main.py -k 'bootstrap or tg90p'
- pytest tests/test_generic_functions.py
