### PR TITLE
doc: clarify bootstrap guidance for percentile indices

### DIFF
--- a/doc/source/how_to/dask.rst
+++ b/doc/source/how_to/dask.rst
@@ -580,6 +580,12 @@ Disk read and write analysis - Dashboard
       put everything in the same Client constructor call.
    -  Beware, as of icclim 5.0.0, the bootstrapping of percentiles is
       known to produce **a lot** of i/o.
+   -  This bootstrap is scientifically important when percentile thresholds are
+      computed on a reference period that overlaps the study period, especially
+      for ETCCDI-style percentile-based extreme indices such as the 10th and
+      90th percentile temperature indices. If the exact overlap treatment is
+      too expensive for your dask setup, ``bootstrap=False`` can be used as a
+      pragmatic performance workaround.
 
 Worker chatterbox syndrome - Dashboard
 ======================================

--- a/doc/source/references/api/icclim/index.rst
+++ b/doc/source/references/api/icclim/index.rst
@@ -106,7 +106,13 @@ Package Contents
    :param bootstrap: ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
                      Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
                      ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-                     threshold type.
+                     threshold type. This overlap-based bootstrap is part of the standard
+                     treatment for percentile-based extreme indices when the reference period
+                     overlaps the study period. In practice it matters for common ETCCDI-style
+                     thresholds such as the 10th and 90th percentiles, and can be even more
+                     consequential for stronger percentile thresholds. Because it is
+                     computationally expensive, ``bootstrap=False`` can still be a useful
+                     pragmatic workaround on large dask-backed datasets.
    :type bootstrap: bool | None
    :param doy_window_width: ``optional`` Window width used to aggreagte day of year values when computing
                             day of year percentiles (doy_per)

--- a/doc/source/references/thresholds.rst
+++ b/doc/source/references/thresholds.rst
@@ -130,7 +130,12 @@ Two flavours exist, selected by the unit string:
 
    When ``base_period_time_range`` overlaps with the study period (in-base years),
    icclim applies the **bootstrapping** procedure described in ETCCDI guidelines to
-   avoid artificially inflated counts.
+   avoid artificially inflated counts. This is relevant for standard
+   percentile-based extreme indices, including the classic 10th and 90th
+   percentile temperature indices, and can be even more important for stronger
+   percentile thresholds. On very large dask-backed datasets, users may still
+   choose ``bootstrap=False`` as a pragmatic workaround when the full
+   bootstrapping procedure is too expensive.
 
 BoundedThreshold
 ================


### PR DESCRIPTION
## Summary
- clarify when overlap-based bootstrap matters scientifically for percentile-based indices
- note that this includes standard ETCCDI-style 10th and 90th percentile temperature indices
- explain that `bootstrap=False` remains a pragmatic workaround on large dask-backed datasets

## Testing
- reviewed touched RST files locally
