### PR TITLE
Improve Dask reliability for percentile bootstrap

### DIFF
--- a/doc/source/archive/bootstrap_performance_plan_2026-07-20.md
+++ b/doc/source/archive/bootstrap_performance_plan_2026-07-20.md
@@ -11,7 +11,8 @@ LLM or a human contributor without requiring reconstruction of previous experime
 ## Branch And Baseline
 
 - Working branch: `fix/bootstrap-next`
-- Current checkpoint commit: `7ef205d`
+- Current branch head (docs/meta): `0a406cf`
+- Current implementation checkpoint: `7ef205d`
 - Baseline upstream behavior: `master` at `9d97cf1` / `origin/master` at `c3dd4e5`
 
 ## What Has Been Done
@@ -57,14 +58,27 @@ Reusable benchmark helpers were added:
 
 ### Current best local implementation
 
-The current branch uses reducer-level orchestration plus bounded donor
-vectorization using a bootstrap dimension per target year.
+The current best implementation is commit `7ef205d`.
+
+It uses reducer-level orchestration plus bounded donor vectorization using a
+bootstrap dimension per target year.
 
 This is the first version that is:
 
 - semantically much closer to the correct bootstrap model
 - numerically aligned with `master`
-- locally competitive enough to justify large-scale testing
+- locally close enough to `master` to justify large-scale testing
+
+Commit `0a406cf` only adds this handoff documentation on top of that code
+checkpoint.
+
+## Current Best Candidate
+
+Treat `7ef205d` as the performance/control candidate on `fix/bootstrap-next`.
+
+Do **not** use the older slow native path (`4dc59d1` or earlier) as the main
+comparison point anymore. Those older checkpoints are useful only as historical
+references for dead ends and regressions.
 
 ## Current Validation Status
 
@@ -140,6 +154,8 @@ Conclusion:
 - current branch is numerically good
 - current branch is architecturally better
 - current branch is not yet a clear performance win over `master`
+- current branch should therefore be treated as an RC for large-scale testing,
+  not as a release-ready optimization win
 
 ## Hard Constraints
 
@@ -165,9 +181,12 @@ a correctness issue is found.
 
 ### Phase 1: Freeze the current baseline
 
-1. Use `7ef205d` as the control implementation.
-2. Always compare against `master` using the benchmark scripts.
-3. Never evaluate a change without both:
+1. Use `7ef205d` as the control implementation on `fix/bootstrap-next`.
+2. Use `master` (`9d97cf1` / `c3dd4e5`) as the upstream comparison baseline.
+3. Compare every new candidate against **both**:
+   - `master`
+   - `7ef205d`
+4. Never evaluate a change without both:
    - reduced benchmark
    - larger laptop benchmark
 
@@ -200,13 +219,19 @@ This is the main algorithmic target.
 
 Idea:
 
-1. Precompute rolling-window views for each overlap year from the raw reference.
+1. Add a helper near the bootstrap code in
+   `src/icclim/_core/generic/functions.py` dedicated to cached percentile
+   preparation.
+2. Precompute rolling-window views for each overlap year from the raw
+   reference.
 2. For bootstrap target year `Y`, only recompute rolling-window views for:
    - `Y - 1`
    - `Y`
    - `Y + 1`
-3. Reuse the unaffected precomputed rolling-window views for all other years.
-4. Only after that, rebuild the `year/dayofyear/window` structure used by
+3. Cache these views in a structure keyed by year label, with each value
+   representing the pre-`percentile_doy` rolling window state for that year.
+4. Reuse the unaffected precomputed rolling-window views for all other years.
+5. Only after that, rebuild the `year/dayofyear/window` structure used by
    `percentile_doy`.
 
 Why this is safe:
@@ -221,6 +246,10 @@ Keep the current structure:
 
 - bootstrap orchestration at reducer level
 - donor vectorization only within one target year
+
+Do **not** spend more time on high-level bootstrap orchestration refactors
+unless a correctness issue is found. The current orchestration layer is now good
+enough; the remaining work is on percentile construction cost.
 
 Do not build one giant all-years bootstrap cube.
 
@@ -277,6 +306,16 @@ python scripts/compare_bootstrap_cached_outputs.py \
   --label-right candidate
 ```
 
+Also compare against the current bounded-path control when appropriate:
+
+```bash
+python scripts/compare_bootstrap_cached_outputs.py \
+  --left /tmp/icclim-laptop-bench/next-auto-laptop-time730.result.nc \
+  --right /tmp/icclim-laptop-bench/candidate-reduced.result.nc \
+  --label-left current_bounded \
+  --label-right candidate
+```
+
 ### Phase 6: Acceptance criteria
 
 A candidate is worth carrying to Kraken only if:
@@ -298,7 +337,8 @@ If a candidate meets the laptop acceptance criteria, run exactly the same
 benchmark family on Kraken and compare:
 
 - `master auto`
-- candidate auto
+- current bounded candidate (`7ef205d`) auto
+- new candidate auto
 - optionally `bootstrap=false` as a lower-bound reference
 
 Kraken should only be used to validate scale, not to do first-pass debugging.

--- a/doc/source/archive/bootstrap_performance_plan_2026-07-20.md
+++ b/doc/source/archive/bootstrap_performance_plan_2026-07-20.md
@@ -11,7 +11,7 @@ LLM or a human contributor without requiring reconstruction of previous experime
 ## Branch And Baseline
 
 - Working branch: `fix/bootstrap-next`
-- Current branch head (docs/meta): `0058873`
+- Current profiling/tooling checkpoint: `c7e1c86`
 - Current implementation checkpoint: `7ef205d`
 - Baseline upstream behavior: `master` at `9d97cf1` / `origin/master` at `c3dd4e5`
 
@@ -55,6 +55,11 @@ Reusable benchmark helpers were added:
 3. Reducer-level orchestration without donor vectorization:
    - architecturally better
    - still much too slow
+4. Splice-based bootstrap-year builder replacing
+   `xclim.core.bootstrapping.build_bootstrap_year_da(...)`:
+   - preserved correctness after chunk/layout fixes
+   - reduced graph task count dramatically
+   - made end-to-end compute slower on laptop benchmarks
 
 ### Current best local implementation
 
@@ -69,8 +74,9 @@ This is the first version that is:
 - numerically aligned with `master`
 - locally close enough to `master` to justify large-scale testing
 
-Commit `0a406cf` added the initial handoff documentation, and `0058873`
-tightened it into the current version on top of that same code checkpoint.
+Commit `0a406cf` added the initial handoff documentation, `0058873`
+tightened it, and `c7e1c86` added phase profiling on top of that same code
+checkpoint.
 
 ## Current Best Candidate
 
@@ -111,10 +117,11 @@ Chunk setting B:
 
 - `time=730, lat=144, lon=192`
 
-Results:
+Refreshed results with the current benchmark harness:
 
-- `master auto`: `22.98s`
-- current branch (`7ef205d`) auto: `25.22s`
+- `master auto`: `30.04s`
+- current branch (`7ef205d` + profiling tooling) auto: `22.30s`
+- splice-builder experiment: `30.49s`
 
 Numerics:
 
@@ -131,18 +138,20 @@ Chunk setting:
 
 - `time=730, lat=144, lon=192`
 
-Results:
+Refreshed results with the current benchmark harness:
 
 - `master auto`
-  - total `51.57s`
-  - compute `47.21s`
+  - total `37.46s`
+  - compute `33.13s`
   - graph tasks `207,827`
-  - max resident set about `6.47 GB`
-- current branch (`7ef205d`) auto
-  - total `52.67s`
-  - compute `48.32s`
+- current branch (`7ef205d` + profiling tooling) auto
+  - total `35.02s`
+  - compute `30.76s`
   - graph tasks `211,920`
-  - max resident set about `7.06 GB`
+- splice-builder experiment
+  - total `36.63s`
+  - compute `32.57s`
+  - graph tasks `31,102`
 
 Numerics:
 
@@ -153,9 +162,11 @@ Conclusion:
 
 - current branch is numerically good
 - current branch is architecturally better
-- current branch is not yet a clear performance win over `master`
-- current branch should therefore be treated as an RC for large-scale testing,
-  not as a release-ready optimization win
+- current branch is now a measured laptop performance win over current `master`
+- the win is clear on the reduced case and modest on the larger laptop case
+- the splice-builder experiment should not be pursued further without a new
+  compute-side hypothesis
+- the current branch is ready for large-scale Kraken validation
 
 ## Hard Constraints
 
@@ -169,7 +180,10 @@ The next optimization must obey all of these:
 
 ## Immediate Optimization Target
 
-The bottleneck is still repeated `percentile_doy(...)` work.
+The measured build-side hotspot is still `build_bootstrap_year_da(...)`, but
+the splice-based replacement did not improve end-to-end runtime. That means the
+remaining cost is primarily compute-side execution over the bootstrap-expanded
+data, not just graph construction.
 
 The next phase should focus on reducing repeated percentile construction while
 keeping reducer-level orchestration.
@@ -186,6 +200,7 @@ a correctness issue is found.
 3. Compare every new candidate against **both**:
    - `master`
    - `7ef205d`
+   - and, when useful, the profiling head `c7e1c86`
 4. Never evaluate a change without both:
    - reduced benchmark
    - larger laptop benchmark
@@ -215,7 +230,8 @@ Expected outcome:
 
 ### Phase 3: Implement cached local rolling-window reuse
 
-This is the main algorithmic target.
+This remains the main algorithmic target after Kraken if more improvement is
+needed.
 
 Idea:
 

--- a/doc/source/archive/bootstrap_performance_plan_2026-07-20.md
+++ b/doc/source/archive/bootstrap_performance_plan_2026-07-20.md
@@ -11,7 +11,7 @@ LLM or a human contributor without requiring reconstruction of previous experime
 ## Branch And Baseline
 
 - Working branch: `fix/bootstrap-next`
-- Current branch head (docs/meta): `0a406cf`
+- Current branch head (docs/meta): `0058873`
 - Current implementation checkpoint: `7ef205d`
 - Baseline upstream behavior: `master` at `9d97cf1` / `origin/master` at `c3dd4e5`
 
@@ -69,8 +69,8 @@ This is the first version that is:
 - numerically aligned with `master`
 - locally close enough to `master` to justify large-scale testing
 
-Commit `0a406cf` only adds this handoff documentation on top of that code
-checkpoint.
+Commit `0a406cf` added the initial handoff documentation, and `0058873`
+tightened it into the current version on top of that same code checkpoint.
 
 ## Current Best Candidate
 

--- a/doc/source/archive/bootstrap_performance_plan_2026-07-20.md
+++ b/doc/source/archive/bootstrap_performance_plan_2026-07-20.md
@@ -1,0 +1,314 @@
+# Bootstrap Performance Plan (2026-07-20)
+
+## Goal
+
+Improve bootstrap performance for bulky percentile-based indices while preserving
+the current semantics and numerical behavior.
+
+This document is a handoff plan intended to be actionable for a medium-capability
+LLM or a human contributor without requiring reconstruction of previous experiments.
+
+## Branch And Baseline
+
+- Working branch: `fix/bootstrap-next`
+- Current checkpoint commit: `7ef205d`
+- Baseline upstream behavior: `master` at `9d97cf1` / `origin/master` at `c3dd4e5`
+
+## What Has Been Done
+
+### Correctness and structure
+
+1. Added `bootstrap=False` support and release-safe docs in `v7.1.3`.
+2. Investigated and rejected the prepared post-DOY-state reuse approach
+   (`7046c61` on older branch history): it was numerically wrong, especially
+   around leap years and overlap years.
+3. Added leap/common-year replacement tests in:
+   - `tests/test_percentile_bootstrap.py`
+4. Moved bootstrap orchestration upward into reducer logic for:
+   - `count_occurrences`
+   - `max_consecutive_occurrence`
+   - `sum_of_spell_lengths`
+5. Added overlap smoke coverage in `tests/test_main.py` for:
+   - `TX90p`
+   - `WSDI`
+   - `CSDI`
+
+### Benchmark tooling
+
+Reusable benchmark helpers were added:
+
+- `scripts/benchmark_bootstrap_tg90p.py`
+- `scripts/compare_bootstrap_cached_outputs.py`
+- `scripts/slurm_benchmark_bootstrap_tg90p.sh`
+
+## What Was Learned
+
+### Dead ends / rejected approaches
+
+1. Threshold-level native bootstrap with donor-by-donor Python loops:
+   - numerically recoverable
+   - too slow
+2. Prepared DOY-state reuse after year/dayofyear/window construction:
+   - scientifically wrong
+   - broke leap-year semantics
+3. Reducer-level orchestration without donor vectorization:
+   - architecturally better
+   - still much too slow
+
+### Current best local implementation
+
+The current branch uses reducer-level orchestration plus bounded donor
+vectorization using a bootstrap dimension per target year.
+
+This is the first version that is:
+
+- semantically much closer to the correct bootstrap model
+- numerically aligned with `master`
+- locally competitive enough to justify large-scale testing
+
+## Current Validation Status
+
+The following local tests were green at the RC checkpoint:
+
+- `pytest tests/test_main.py -k 'bootstrap or wsdi or csdi or tg90p or tx90p'`
+- `pytest tests/test_percentile_bootstrap.py`
+- `pytest tests/test_generic_functions.py`
+
+## Benchmark Summary
+
+### Reduced laptop benchmark
+
+Dataset:
+
+- ACCESS-CM2 historical
+- subset: `lat 45:55`, `lon 0:20`
+
+Chunk setting A:
+
+- `time=365, lat=16, lon=16`
+
+Results:
+
+- `master auto`: `35.87s`
+- early branch native path: `172.58s`
+- reducer engine without bounded donor vectorization: `168.46s`
+
+Chunk setting B:
+
+- `time=730, lat=144, lon=192`
+
+Results:
+
+- `master auto`: `22.98s`
+- current branch (`7ef205d`) auto: `25.22s`
+
+Numerics:
+
+- means agree to near machine tolerance
+
+### Larger laptop benchmark
+
+Dataset:
+
+- ACCESS-CM2 historical
+- subset: `lat 35:70`, `lon 0:40`
+
+Chunk setting:
+
+- `time=730, lat=144, lon=192`
+
+Results:
+
+- `master auto`
+  - total `51.57s`
+  - compute `47.21s`
+  - graph tasks `207,827`
+  - max resident set about `6.47 GB`
+- current branch (`7ef205d`) auto
+  - total `52.67s`
+  - compute `48.32s`
+  - graph tasks `211,920`
+  - max resident set about `7.06 GB`
+
+Numerics:
+
+- `master` mean `45.13441238564401`
+- branch mean `45.13441238419539`
+
+Conclusion:
+
+- current branch is numerically good
+- current branch is architecturally better
+- current branch is not yet a clear performance win over `master`
+
+## Hard Constraints
+
+The next optimization must obey all of these:
+
+1. Do not reintroduce donor replacement after DOY-state construction.
+2. Do not change `bootstrap=False` behavior.
+3. Preserve current `TX90p` 2-year and 3-year overlap behavior.
+4. Preserve overlap behavior for `WSDI/CSDI`.
+5. Do not accept a speedup if it introduces noticeable numeric drift.
+
+## Immediate Optimization Target
+
+The bottleneck is still repeated `percentile_doy(...)` work.
+
+The next phase should focus on reducing repeated percentile construction while
+keeping reducer-level orchestration.
+
+Do **not** spend more time on high-level bootstrap orchestration refactors unless
+a correctness issue is found.
+
+## Precise Plan For A Medium Model
+
+### Phase 1: Freeze the current baseline
+
+1. Use `7ef205d` as the control implementation.
+2. Always compare against `master` using the benchmark scripts.
+3. Never evaluate a change without both:
+   - reduced benchmark
+   - larger laptop benchmark
+
+### Phase 2: Profile the current branch at the right level
+
+Add instrumentation to isolate the cost of:
+
+1. `build_bootstrap_year_da(...)`
+2. `xr.map_blocks(percentile_doy.__wrapped__, ...)`
+3. `threshold._apply_percentile_op(...)`
+4. `compute_from_exceedance(...)`
+5. `donor_result.mean(dim=BOOTSTRAP_DIM, ...)`
+
+Practical rule:
+
+- profile one overlap year at a time
+- do not profile the whole benchmark first
+
+Expected outcome:
+
+- identify whether the dominant cost is:
+  - percentile construction
+  - bootstrap cube construction
+  - exceedance application
+  - final reduction
+
+### Phase 3: Implement cached local rolling-window reuse
+
+This is the main algorithmic target.
+
+Idea:
+
+1. Precompute rolling-window views for each overlap year from the raw reference.
+2. For bootstrap target year `Y`, only recompute rolling-window views for:
+   - `Y - 1`
+   - `Y`
+   - `Y + 1`
+3. Reuse the unaffected precomputed rolling-window views for all other years.
+4. Only after that, rebuild the `year/dayofyear/window` structure used by
+   `percentile_doy`.
+
+Why this is safe:
+
+- centered rolling windows only depend locally on neighboring years
+- this respects the rule “replace raw year before percentile construction”
+- this avoids the invalid post-DOY swap that caused earlier regressions
+
+### Phase 4: Keep bounded donor parallelism
+
+Keep the current structure:
+
+- bootstrap orchestration at reducer level
+- donor vectorization only within one target year
+
+Do not build one giant all-years bootstrap cube.
+
+If concurrency controls are added later, prefer:
+
+- `bootstrap_jobs`
+- `bootstrap_batch_size`
+
+Avoid trying to infer available RAM from the environment.
+
+### Phase 5: Benchmark gates
+
+For every optimization candidate, run:
+
+#### Reduced benchmark
+
+```bash
+python scripts/benchmark_bootstrap_tg90p.py \
+  --repo /Users/page/src/icclim/icclim \
+  --file-glob '/Users/page/src/icclim/icclim_usecase/data/latest/tas_day_ACCESS-CM2_historical_r1i1p1f1_gn_*.nc' \
+  --lat-min 45 --lat-max 55 \
+  --lon-min 0 --lon-max 20 \
+  --time-chunk 730 --lat-chunk 144 --lon-chunk 192 \
+  --scheduler threads \
+  --bootstrap auto \
+  --cache-dir /tmp/icclim-laptop-bench \
+  --cache-key candidate-reduced \
+  --force
+```
+
+#### Larger laptop benchmark
+
+```bash
+/usr/bin/time -l python scripts/benchmark_bootstrap_tg90p.py \
+  --repo /Users/page/src/icclim/icclim \
+  --file-glob '/Users/page/src/icclim/icclim_usecase/data/latest/tas_day_ACCESS-CM2_historical_r1i1p1f1_gn_*.nc' \
+  --lat-min 35 --lat-max 70 \
+  --lon-min 0 --lon-max 40 \
+  --time-chunk 730 --lat-chunk 144 --lon-chunk 192 \
+  --scheduler threads \
+  --bootstrap auto \
+  --cache-dir /tmp/icclim-laptop-bench \
+  --cache-key candidate-large \
+  --force
+```
+
+#### Numeric comparison
+
+```bash
+python scripts/compare_bootstrap_cached_outputs.py \
+  --left /tmp/icclim-laptop-bench/master-auto-laptop.result.nc \
+  --right /tmp/icclim-laptop-bench/candidate-reduced.result.nc \
+  --label-left master_auto \
+  --label-right candidate
+```
+
+### Phase 6: Acceptance criteria
+
+A candidate is worth carrying to Kraken only if:
+
+1. it passes all current bootstrap tests
+2. it keeps reduced-benchmark numeric drift at machine-noise scale
+3. it is at least clearly better on one axis:
+   - faster than `master`, or
+   - lower memory than `master`
+
+Suggested threshold:
+
+- aim for at least `10%` improvement on runtime or memory
+- otherwise treat it as not good enough yet
+
+## Tomorrow's Kraken Step
+
+If a candidate meets the laptop acceptance criteria, run exactly the same
+benchmark family on Kraken and compare:
+
+- `master auto`
+- candidate auto
+- optionally `bootstrap=false` as a lower-bound reference
+
+Kraken should only be used to validate scale, not to do first-pass debugging.
+
+## When To Use A Stronger Model Again
+
+Use a stronger reasoning model only if:
+
+1. cached local rolling-window reuse proves too hard to implement safely, or
+2. the next step becomes a true order-statistics update algorithm
+   (pre-sorted sample replacement for percentile recomputation)
+
+Until then, a medium model should be able to follow this plan.

--- a/doc/source/archive/kraken_workspace_notes_2026-07-21.md
+++ b/doc/source/archive/kraken_workspace_notes_2026-07-21.md
@@ -1,0 +1,47 @@
+# Kraken Workspace Notes (2026-07-21)
+
+## Purpose
+
+Persistent note to avoid losing track of the Kraken bootstrap benchmarking
+workspace layout.
+
+## Source Checkout
+
+Use this as the actual git checkout on Kraken:
+
+- `/scratch/globc/page/src/icclim`
+
+State observed on Tuesday, July 21, 2026:
+
+- branch: `fix/bootstrap-next`
+- head: `8c145f1`
+- remote `origin`: `git@github.com:pagecp/icclim.git`
+
+## Benchmark / Cache Directories
+
+These directories were used on Monday, July 20, 2026 for bootstrap benchmark
+artifacts and cached results:
+
+- `/scratch/globc/page/icclim-bench/current`
+- `/scratch/globc/page/icclim-bench/next`
+- `/scratch/globc/page/icclim-bench/master`
+- `/scratch/globc/page/icclim-bench/prestate`
+- `/scratch/globc/page/icclim-bench/old-bootstrap`
+
+These are benchmark workspaces/artifact directories, not git repositories.
+
+## Important Reminder
+
+Do not confuse:
+
+- `/scratch/globc/page/src/icclim` : real git checkout
+- `/scratch/globc/page/icclim-bench/*` : benchmark outputs / cached runs
+- `/scratch/globc/page/icclim` : old virtualenv-like directory, not the repo
+
+## Conda Environment
+
+Available environment observed on Kraken:
+
+- `/scratch/globc/page/.conda/envs/icclimv7`
+
+Use that interpreter directly in batch jobs when shell activation is unreliable.

--- a/doc/source/how_to/dask.rst
+++ b/doc/source/how_to/dask.rst
@@ -218,10 +218,10 @@ https://docs.dask.org/en/stable/scheduling.html#local-threads
    The bootstrap period is the overlapping years between the period
    where percentile are computed (a.k.a "in base") and the period where
    the climate index is computed (a.k.a "out of base").
-|  If the default bootstrap graph becomes too large to build or execute
-   reliably, use ``bootstrap="safe"``. This computes bootstrap through bounded
-   spatial tiles and returns an eager result. It can be slower, but it avoids
-   leaving users with a very large Dask graph that may never finish.
+|  For dask-backed percentile count indices, icclim automatically uses bounded
+   spatial tiles when bootstrap is needed. This reliability path may be slower,
+   but it avoids leaving users with a very large Dask graph that may never
+   finish. Users can request it explicitly with ``bootstrap="safe"``.
 
 .. note::
 
@@ -587,10 +587,13 @@ Disk read and write analysis - Dashboard
    -  This bootstrap is scientifically important when percentile thresholds are
       computed on a reference period that overlaps the study period, especially
       for ETCCDI-style percentile-based extreme indices such as the 10th and
-      90th percentile temperature indices. If the default dask graph is too
-      large, prefer ``bootstrap="safe"``. If the exact overlap treatment is
-      still operationally impossible, ``bootstrap=False`` can be used as a
-      pragmatic fallback with a scientific tradeoff.
+      90th percentile temperature indices. For dask-backed percentile count
+      indices, icclim automatically uses a tiled reliability path to avoid one
+      huge bootstrap graph. If the exact overlap treatment is still
+      operationally impossible, a user may explicitly choose ``bootstrap=False``
+      only for fast exploratory assessment. This disables the overlap correction,
+      so percentile-based results can be scientifically biased and should not be
+      treated as the corrected final result.
 
 Worker chatterbox syndrome - Dashboard
 ======================================

--- a/doc/source/how_to/dask.rst
+++ b/doc/source/how_to/dask.rst
@@ -218,6 +218,10 @@ https://docs.dask.org/en/stable/scheduling.html#local-threads
    The bootstrap period is the overlapping years between the period
    where percentile are computed (a.k.a "in base") and the period where
    the climate index is computed (a.k.a "out of base").
+|  If the default bootstrap graph becomes too large to build or execute
+   reliably, use ``bootstrap="safe"``. This computes bootstrap through bounded
+   spatial tiles and returns an eager result. It can be slower, but it avoids
+   leaving users with a very large Dask graph that may never finish.
 
 .. note::
 
@@ -583,9 +587,10 @@ Disk read and write analysis - Dashboard
    -  This bootstrap is scientifically important when percentile thresholds are
       computed on a reference period that overlaps the study period, especially
       for ETCCDI-style percentile-based extreme indices such as the 10th and
-      90th percentile temperature indices. If the exact overlap treatment is
-      too expensive for your dask setup, ``bootstrap=False`` can be used as a
-      pragmatic performance workaround.
+      90th percentile temperature indices. If the default dask graph is too
+      large, prefer ``bootstrap="safe"``. If the exact overlap treatment is
+      still operationally impossible, ``bootstrap=False`` can be used as a
+      pragmatic fallback with a scientific tradeoff.
 
 Worker chatterbox syndrome - Dashboard
 ======================================

--- a/doc/source/how_to/dask.rst
+++ b/doc/source/how_to/dask.rst
@@ -221,7 +221,10 @@ https://docs.dask.org/en/stable/scheduling.html#local-threads
 |  For dask-backed percentile count indices, icclim automatically uses bounded
    spatial tiles when bootstrap is needed. This reliability path may be slower,
    but it avoids leaving users with a very large Dask graph that may never
-   finish. Users can request it explicitly with ``bootstrap="safe"``.
+   finish. Users can request it explicitly with ``bootstrap="safe"``. The tile
+   size is derived from ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default:
+   ``2GB``), and can be overridden for diagnostics with
+   ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS``.
 
 .. note::
 
@@ -594,6 +597,10 @@ Disk read and write analysis - Dashboard
       only for fast exploratory assessment. This disables the overlap correction,
       so percentile-based results can be scientifically biased and should not be
       treated as the corrected final result.
+   -  To reduce peak memory further, lower the safe bootstrap budget, for example
+      ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY=512MB``. This will create more spatial
+      tiles and can be slower, but each tile asks dask to keep less bootstrap
+      working data in memory.
 
 Worker chatterbox syndrome - Dashboard
 ======================================

--- a/doc/source/references/api/icclim/index.rst
+++ b/doc/source/references/api/icclim/index.rst
@@ -106,14 +106,18 @@ Package Contents
    :param bootstrap: ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
                      Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
                      ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-                     threshold type. This overlap-based bootstrap is part of the standard
+                     threshold type. Use ``"safe"`` to compute bootstrap one bounded spatial tile
+                     at a time. This mode is intended for large dask-backed datasets where the
+                     default bootstrap graph may become too large to build or execute reliably.
+                     It may be slower, but it avoids returning one large bootstrap graph.
+                     This overlap-based bootstrap is part of the standard
                      treatment for percentile-based extreme indices when the reference period
                      overlaps the study period. In practice it matters for common ETCCDI-style
                      thresholds such as the 10th and 90th percentiles, and can be even more
                      consequential for stronger percentile thresholds. Because it is
                      computationally expensive, ``bootstrap=False`` can still be a useful
                      pragmatic workaround on large dask-backed datasets.
-   :type bootstrap: bool | None
+   :type bootstrap: bool | "safe" | None
    :param doy_window_width: ``optional`` Window width used to aggreagte day of year values when computing
                             day of year percentiles (doy_per)
                             Default: 5 (5 days).

--- a/doc/source/references/api/icclim/index.rst
+++ b/doc/source/references/api/icclim/index.rst
@@ -106,17 +106,19 @@ Package Contents
    :param bootstrap: ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
                      Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
                      ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-                     threshold type. Use ``"safe"`` to compute bootstrap one bounded spatial tile
-                     at a time. This mode is intended for large dask-backed datasets where the
-                     default bootstrap graph may become too large to build or execute reliably.
-                     It may be slower, but it avoids returning one large bootstrap graph.
+                     threshold type. For dask-backed percentile count indices, icclim
+                     automatically computes bootstrap one bounded spatial tile at a time so
+                     users do not have to find a working dask chunking strategy by trial and
+                     error. Use ``"safe"`` to request this reliability mode explicitly, or set
+                     ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask graph path for
+                     diagnostics.
                      This overlap-based bootstrap is part of the standard
                      treatment for percentile-based extreme indices when the reference period
                      overlaps the study period. In practice it matters for common ETCCDI-style
                      thresholds such as the 10th and 90th percentiles, and can be even more
-                     consequential for stronger percentile thresholds. Because it is
-                     computationally expensive, ``bootstrap=False`` can still be a useful
-                     pragmatic workaround on large dask-backed datasets.
+                     consequential for stronger percentile thresholds. ``bootstrap=False`` is
+                     only a user-selected shortcut for fast exploratory assessment: it disables
+                     the overlap correction and can bias percentile-based results.
    :type bootstrap: bool | "safe" | None
    :param doy_window_width: ``optional`` Window width used to aggreagte day of year values when computing
                             day of year percentiles (doy_per)

--- a/doc/source/references/api/icclim/index.rst
+++ b/doc/source/references/api/icclim/index.rst
@@ -111,7 +111,9 @@ Package Contents
                      users do not have to find a working dask chunking strategy by trial and
                      error. Use ``"safe"`` to request this reliability mode explicitly, or set
                      ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask graph path for
-                     diagnostics.
+                     diagnostics. The safe path derives its spatial tile size from
+                     ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+                     ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
                      This overlap-based bootstrap is part of the standard
                      treatment for percentile-based extreme indices when the reference period
                      overlaps the study period. In practice it matters for common ETCCDI-style

--- a/doc/source/references/release_notes.rst
+++ b/doc/source/references/release_notes.rst
@@ -13,7 +13,7 @@ Details
 =======
 
 -  [fix] Restore compatibility with latest ``xclim`` releases by adapting ``to_agg_units`` calls to the installed API signature instead of always passing ``deffreq``.
--  [enh] Add bootstrap controls to ``icclim.index(...)`` for day-of-year percentile thresholds. For dask-backed percentile count indices, icclim now uses a bounded tiled bootstrap path by default to avoid oversized dask graphs. ``bootstrap=False`` remains an explicit user shortcut for fast exploratory assessment only, because it disables the overlap correction and can bias percentile-based results.
+-  [enh] Add bootstrap controls to ``icclim.index(...)`` for day-of-year percentile thresholds. For dask-backed percentile count indices, icclim now uses a memory-budgeted tiled bootstrap path by default to avoid oversized dask graphs and reduce peak memory risk. ``bootstrap=False`` remains an explicit user shortcut for fast exploratory assessment only, because it disables the overlap correction and can bias percentile-based results.
 -  [maint] Keep the existing bootstrap implementation as the release path while follow-up work continues on a native replacement. The experimental prepared-state optimization is not included in ``v7.1.3``.
 -  [maint] Bump ``peter-evans/create-pull-request`` from ``v7`` to ``v8`` in CI maintenance workflows to avoid GitHub Actions Node 20 deprecation warnings.
 

--- a/doc/source/references/release_notes.rst
+++ b/doc/source/references/release_notes.rst
@@ -13,7 +13,7 @@ Details
 =======
 
 -  [fix] Restore compatibility with latest ``xclim`` releases by adapting ``to_agg_units`` calls to the installed API signature instead of always passing ``deffreq``.
--  [enh] Add a ``bootstrap`` override to ``icclim.index(...)`` for day-of-year percentile thresholds. Use ``bootstrap=False`` to disable overlap-based bootstrap on large dask-backed datasets when the default path is too expensive.
+-  [enh] Add bootstrap controls to ``icclim.index(...)`` for day-of-year percentile thresholds. For dask-backed percentile count indices, icclim now uses a bounded tiled bootstrap path by default to avoid oversized dask graphs. ``bootstrap=False`` remains an explicit user shortcut for fast exploratory assessment only, because it disables the overlap correction and can bias percentile-based results.
 -  [maint] Keep the existing bootstrap implementation as the release path while follow-up work continues on a native replacement. The experimental prepared-state optimization is not included in ``v7.1.3``.
 -  [maint] Bump ``peter-evans/create-pull-request`` from ``v7`` to ``v8`` in CI maintenance workflows to avoid GitHub Actions Node 20 deprecation warnings.
 

--- a/doc/source/references/thresholds.rst
+++ b/doc/source/references/thresholds.rst
@@ -133,11 +133,13 @@ Two flavours exist, selected by the unit string:
    avoid artificially inflated counts. This is relevant for standard
    percentile-based extreme indices, including the classic 10th and 90th
    percentile temperature indices, and can be even more important for stronger
-   percentile thresholds. On very large dask-backed datasets, use
-   ``bootstrap="safe"`` when the default bootstrap graph is too large to build
-   or execute reliably. Users may still choose ``bootstrap=False`` as a
-   pragmatic fallback when the full bootstrapping procedure is operationally
-   impossible, but this disables the overlap correction.
+   percentile thresholds. On dask-backed percentile count indices, icclim uses
+   bounded spatial tiles automatically when bootstrap is needed, so users do not
+   have to discover a working dask chunking strategy by trial and error. Users
+   may still choose ``bootstrap=False`` only as a fast exploratory shortcut when
+   the full bootstrapping procedure is operationally impossible. This disables
+   the overlap correction, so percentile-based results can be scientifically
+   biased and should not be treated as the corrected final result.
 
 BoundedThreshold
 ================

--- a/doc/source/references/thresholds.rst
+++ b/doc/source/references/thresholds.rst
@@ -140,6 +140,9 @@ Two flavours exist, selected by the unit string:
    the full bootstrapping procedure is operationally impossible. This disables
    the overlap correction, so percentile-based results can be scientifically
    biased and should not be treated as the corrected final result.
+   The safe path derives its spatial tile size from
+   ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+   ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
 
 BoundedThreshold
 ================

--- a/doc/source/references/thresholds.rst
+++ b/doc/source/references/thresholds.rst
@@ -133,9 +133,11 @@ Two flavours exist, selected by the unit string:
    avoid artificially inflated counts. This is relevant for standard
    percentile-based extreme indices, including the classic 10th and 90th
    percentile temperature indices, and can be even more important for stronger
-   percentile thresholds. On very large dask-backed datasets, users may still
-   choose ``bootstrap=False`` as a pragmatic workaround when the full
-   bootstrapping procedure is too expensive.
+   percentile thresholds. On very large dask-backed datasets, use
+   ``bootstrap="safe"`` when the default bootstrap graph is too large to build
+   or execute reliably. Users may still choose ``bootstrap=False`` as a
+   pragmatic fallback when the full bootstrapping procedure is operationally
+   impossible, but this disables the overlap correction.
 
 BoundedThreshold
 ================

--- a/scripts/benchmark_bootstrap_tg90p.py
+++ b/scripts/benchmark_bootstrap_tg90p.py
@@ -80,13 +80,10 @@ def _git_rev_parse(repo: Path, ref: str) -> str | None:
     if not git_dir.exists():
         return None
     try:
-        return (
-            subprocess.check_output(  # noqa: S603
-                ["git", "-C", str(repo), "rev-parse", ref],  # noqa: S607
-                text=True,
-            )
-            .strip()
-        )
+        return subprocess.check_output(  # noqa: S603
+            ["git", "-C", str(repo), "rev-parse", ref],  # noqa: S607
+            text=True,
+        ).strip()
     except Exception:  # noqa: BLE001
         return None
 
@@ -126,7 +123,11 @@ def main() -> None:
     if cache_dir is not None:
         cache_dir.mkdir(parents=True, exist_ok=True)
         summary_path, result_path = _cached_paths(cache_dir, cache_key)
-        if summary_path.exists() and (not args.save_output or result_path.exists()) and not args.force:
+        if (
+            summary_path.exists()
+            and (not args.save_output or result_path.exists())
+            and not args.force
+        ):
             print(summary_path.read_text())
             return
 

--- a/scripts/benchmark_bootstrap_tg90p.py
+++ b/scripts/benchmark_bootstrap_tg90p.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import dask
+import xarray as xr
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Benchmark TG90p bootstrap performance on daily tas inputs.",
+    )
+    parser.add_argument(
+        "--repo",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+        help="Path to the icclim repository to benchmark.",
+    )
+    parser.add_argument(
+        "--file-glob",
+        required=True,
+        help="Glob pattern for input tas files.",
+    )
+    parser.add_argument("--lat-min", type=float, default=35.0)
+    parser.add_argument("--lat-max", type=float, default=70.0)
+    parser.add_argument("--lon-min", type=float, default=0.0)
+    parser.add_argument("--lon-max", type=float, default=40.0)
+    parser.add_argument("--time-chunk", type=int, default=365)
+    parser.add_argument("--lat-chunk", type=int, default=24)
+    parser.add_argument("--lon-chunk", type=int, default=32)
+    parser.add_argument("--time-range-start", default="1950-01-01")
+    parser.add_argument("--time-range-end", default="2014-12-31")
+    parser.add_argument("--base-period-start", default="1961-01-01")
+    parser.add_argument("--base-period-end", default="1990-12-31")
+    parser.add_argument(
+        "--scheduler",
+        default="threads",
+        choices=["threads", "single-threaded", "synchronous", "processes"],
+    )
+    parser.add_argument(
+        "--bootstrap",
+        default="auto",
+        choices=["auto", "true", "false"],
+        help="Override bootstrap behavior when supported by the checked out code.",
+    )
+    parser.add_argument(
+        "--cache-dir",
+        type=Path,
+        default=None,
+        help="Directory where benchmark summaries and outputs are cached.",
+    )
+    parser.add_argument(
+        "--cache-key",
+        default=None,
+        help="Name prefix for cached files. Defaults to repo name plus bootstrap mode.",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Recompute even when cached outputs already exist.",
+    )
+    parser.add_argument(
+        "--save-output",
+        action="store_true",
+        help="Persist the TG90p result to a NetCDF file in the cache directory.",
+    )
+    return parser.parse_args()
+
+
+def _git_rev_parse(repo: Path, ref: str) -> str | None:
+    git_dir = repo / ".git"
+    if not git_dir.exists():
+        return None
+    try:
+        return (
+            subprocess.check_output(
+                ["git", "-C", str(repo), "rev-parse", ref],
+                text=True,
+            )
+            .strip()
+        )
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _resolve_bootstrap_arg(value: str) -> bool | None:
+    if value == "auto":
+        return None
+    return value == "true"
+
+
+def _default_cache_key(repo: Path, bootstrap: str) -> str:
+    return f"{repo.name}-{bootstrap}"
+
+
+def _cached_paths(cache_dir: Path, cache_key: str) -> tuple[Path, Path]:
+    return (
+        cache_dir / f"{cache_key}.summary.json",
+        cache_dir / f"{cache_key}.result.nc",
+    )
+
+
+def main() -> None:
+    args = _parse_args()
+    repo = args.repo.resolve()
+    sys.path.insert(0, str(repo / "src"))
+
+    import icclim  # noqa: PLC0415
+
+    cache_dir = args.cache_dir.resolve() if args.cache_dir else None
+    cache_key = args.cache_key or _default_cache_key(repo, args.bootstrap)
+    summary_path: Path | None = None
+    result_path: Path | None = None
+    if cache_dir is not None:
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        summary_path, result_path = _cached_paths(cache_dir, cache_key)
+        if summary_path.exists() and (not args.save_output or result_path.exists()) and not args.force:
+            print(summary_path.read_text())
+            return
+
+    files = sorted(glob.glob(args.file_glob))
+    if not files:
+        raise FileNotFoundError(f"No files matched {args.file_glob!r}.")
+
+    open_start = time.perf_counter()
+    ds = xr.open_mfdataset(
+        files,
+        combine="by_coords",
+        chunks={
+            "time": args.time_chunk,
+            "lat": args.lat_chunk,
+            "lon": args.lon_chunk,
+        },
+    )
+    da = ds["tas"].sel(
+        lat=slice(args.lat_min, args.lat_max),
+        lon=slice(args.lon_min, args.lon_max),
+    )
+    open_end = time.perf_counter()
+
+    build_start = time.perf_counter()
+    index_kwargs = dict(
+        index_name="tg90p",
+        in_files=da,
+        var_name="tas",
+        slice_mode="year",
+        time_range=(args.time_range_start, args.time_range_end),
+        base_period_time_range=(args.base_period_start, args.base_period_end),
+    )
+    bootstrap = _resolve_bootstrap_arg(args.bootstrap)
+    if bootstrap is not None:
+        index_kwargs["bootstrap"] = bootstrap
+    with dask.config.set(scheduler=args.scheduler):
+        result = icclim.index(**index_kwargs)
+    build_end = time.perf_counter()
+
+    tg90p = result["TG90p"]
+    graph = tg90p.data.__dask_graph__()
+
+    compute_start = time.perf_counter()
+    with dask.config.set(scheduler=args.scheduler):
+        loaded = tg90p.load()
+    compute_end = time.perf_counter()
+
+    summary: dict[str, object] = {
+        "repo": str(repo),
+        "head_commit": _git_rev_parse(repo, "HEAD"),
+        "origin_master_commit": _git_rev_parse(repo, "origin/master"),
+        "icclim_version": icclim.__version__,
+        "n_files": len(files),
+        "subset_sizes": {k: int(v) for k, v in da.sizes.items()},
+        "chunks": {
+            "time": args.time_chunk,
+            "lat": args.lat_chunk,
+            "lon": args.lon_chunk,
+        },
+        "scheduler": args.scheduler,
+        "bootstrap": args.bootstrap,
+        "open_seconds": open_end - open_start,
+        "build_seconds": build_end - build_start,
+        "compute_seconds": compute_end - compute_start,
+        "total_seconds": compute_end - open_start,
+        "graph_tasks": len(graph),
+        "result_shape": tuple(int(x) for x in loaded.shape),
+        "result_mean": float(loaded.mean().item()),
+    }
+
+    if result_path is not None and args.save_output:
+        loaded.to_netcdf(result_path)
+        summary["result_path"] = str(result_path)
+    if summary_path is not None:
+        summary_path.write_text(json.dumps(summary, indent=2, sort_keys=True))
+    print(json.dumps(summary, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmark_bootstrap_tg90p.py
+++ b/scripts/benchmark_bootstrap_tg90p.py
@@ -157,11 +157,24 @@ def main() -> None:
     bootstrap = _resolve_bootstrap_arg(args.bootstrap)
     if bootstrap is not None:
         index_kwargs["bootstrap"] = bootstrap
-    generic_functions.reset_bootstrap_profile()
+    reset_bootstrap_profile = getattr(
+        generic_functions,
+        "reset_bootstrap_profile",
+        None,
+    )
+    get_bootstrap_profile = getattr(
+        generic_functions,
+        "get_bootstrap_profile",
+        None,
+    )
+    if reset_bootstrap_profile is not None:
+        reset_bootstrap_profile()
     with dask.config.set(scheduler=args.scheduler):
         result = icclim.index(**index_kwargs)
     build_end = time.perf_counter()
-    bootstrap_profile = generic_functions.get_bootstrap_profile()
+    bootstrap_profile = (
+        get_bootstrap_profile() if get_bootstrap_profile is not None else {}
+    )
 
     tg90p = result["TG90p"]
     graph = tg90p.data.__dask_graph__()

--- a/scripts/benchmark_bootstrap_tg90p.py
+++ b/scripts/benchmark_bootstrap_tg90p.py
@@ -112,6 +112,7 @@ def main() -> None:
     sys.path.insert(0, str(repo / "src"))
 
     import icclim  # noqa: PLC0415
+    from icclim._core.generic import functions as generic_functions  # noqa: PLC0415
 
     cache_dir = args.cache_dir.resolve() if args.cache_dir else None
     cache_key = args.cache_key or _default_cache_key(repo, args.bootstrap)
@@ -156,9 +157,11 @@ def main() -> None:
     bootstrap = _resolve_bootstrap_arg(args.bootstrap)
     if bootstrap is not None:
         index_kwargs["bootstrap"] = bootstrap
+    generic_functions.reset_bootstrap_profile()
     with dask.config.set(scheduler=args.scheduler):
         result = icclim.index(**index_kwargs)
     build_end = time.perf_counter()
+    bootstrap_profile = generic_functions.get_bootstrap_profile()
 
     tg90p = result["TG90p"]
     graph = tg90p.data.__dask_graph__()
@@ -189,6 +192,7 @@ def main() -> None:
         "graph_tasks": len(graph),
         "result_shape": tuple(int(x) for x in loaded.shape),
         "result_mean": float(loaded.mean().item()),
+        "bootstrap_profile": bootstrap_profile,
     }
 
     if result_path is not None and args.save_output:

--- a/scripts/benchmark_bootstrap_tg90p.py
+++ b/scripts/benchmark_bootstrap_tg90p.py
@@ -1,3 +1,5 @@
+"""Benchmark TG90p bootstrap behavior on realistic NetCDF inputs."""
+
 from __future__ import annotations
 
 import argparse
@@ -79,8 +81,8 @@ def _git_rev_parse(repo: Path, ref: str) -> str | None:
         return None
     try:
         return (
-            subprocess.check_output(
-                ["git", "-C", str(repo), "rev-parse", ref],
+            subprocess.check_output(  # noqa: S603
+                ["git", "-C", str(repo), "rev-parse", ref],  # noqa: S607
                 text=True,
             )
             .strip()
@@ -109,6 +111,7 @@ def _cached_paths(cache_dir: Path, cache_key: str) -> tuple[Path, Path]:
 
 
 def main() -> None:
+    """Run the benchmark and print a JSON summary."""
     args = _parse_args()
     repo = args.repo.resolve()
     sys.path.insert(0, str(repo / "src"))
@@ -127,9 +130,10 @@ def main() -> None:
             print(summary_path.read_text())
             return
 
-    files = sorted(glob.glob(args.file_glob))
+    files = sorted(glob.glob(args.file_glob))  # noqa: PTH207
     if not files:
-        raise FileNotFoundError(f"No files matched {args.file_glob!r}.")
+        msg = f"No files matched {args.file_glob!r}."
+        raise FileNotFoundError(msg)
 
     open_start = time.perf_counter()
     ds = xr.open_mfdataset(
@@ -148,14 +152,14 @@ def main() -> None:
     open_end = time.perf_counter()
 
     build_start = time.perf_counter()
-    index_kwargs = dict(
-        index_name="tg90p",
-        in_files=da,
-        var_name="tas",
-        slice_mode="year",
-        time_range=(args.time_range_start, args.time_range_end),
-        base_period_time_range=(args.base_period_start, args.base_period_end),
-    )
+    index_kwargs = {
+        "index_name": "tg90p",
+        "in_files": da,
+        "var_name": "tas",
+        "slice_mode": "year",
+        "time_range": (args.time_range_start, args.time_range_end),
+        "base_period_time_range": (args.base_period_start, args.base_period_end),
+    }
     bootstrap = _resolve_bootstrap_arg(args.bootstrap)
     if bootstrap is not None:
         index_kwargs["bootstrap"] = bootstrap

--- a/scripts/benchmark_bootstrap_tg90p.py
+++ b/scripts/benchmark_bootstrap_tg90p.py
@@ -46,7 +46,7 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--bootstrap",
         default="auto",
-        choices=["auto", "true", "false"],
+        choices=["auto", "true", "false", "safe"],
         help="Override bootstrap behavior when supported by the checked out code.",
     )
     parser.add_argument(
@@ -89,9 +89,11 @@ def _git_rev_parse(repo: Path, ref: str) -> str | None:
         return None
 
 
-def _resolve_bootstrap_arg(value: str) -> bool | None:
+def _resolve_bootstrap_arg(value: str) -> bool | str | None:
     if value == "auto":
         return None
+    if value == "safe":
+        return "safe"
     return value == "true"
 
 
@@ -177,7 +179,8 @@ def main() -> None:
     )
 
     tg90p = result["TG90p"]
-    graph = tg90p.data.__dask_graph__()
+    graph_getter = getattr(tg90p.data, "__dask_graph__", None)
+    graph = graph_getter() if graph_getter is not None else None
 
     compute_start = time.perf_counter()
     with dask.config.set(scheduler=args.scheduler):
@@ -202,7 +205,7 @@ def main() -> None:
         "build_seconds": build_end - build_start,
         "compute_seconds": compute_end - compute_start,
         "total_seconds": compute_end - open_start,
-        "graph_tasks": len(graph),
+        "graph_tasks": len(graph) if graph is not None else 0,
         "result_shape": tuple(int(x) for x in loaded.shape),
         "result_mean": float(loaded.mean().item()),
         "bootstrap_profile": bootstrap_profile,

--- a/scripts/compare_bootstrap_cached_outputs.py
+++ b/scripts/compare_bootstrap_cached_outputs.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+import xarray as xr
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Compare cached TG90p benchmark outputs.",
+    )
+    parser.add_argument("--left", type=Path, required=True, help="Left NetCDF result.")
+    parser.add_argument("--right", type=Path, required=True, help="Right NetCDF result.")
+    parser.add_argument(
+        "--label-left",
+        default="left",
+        help="Human-readable label for the left result.",
+    )
+    parser.add_argument(
+        "--label-right",
+        default="right",
+        help="Human-readable label for the right result.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+    left = xr.open_dataarray(args.left)
+    right = xr.open_dataarray(args.right)
+    diff = left - right
+    mask = ~np.isclose(diff.values, 0.0, atol=1e-10, rtol=1e-10)
+    per_year = np.abs(diff).mean(dim=("lat", "lon"), skipna=True)
+    top = per_year.to_series().sort_values(ascending=False).head(10)
+    summary = {
+        f"{args.label_left}_mean": float(left.mean().item()),
+        f"{args.label_right}_mean": float(right.mean().item()),
+        "mean_diff": float(diff.mean().item()),
+        "max_abs_diff": float(np.nanmax(np.abs(diff.values))),
+        "changed_cells": int(mask.sum()),
+        "n_cells": int(diff.size),
+        "top_year_mean_abs_diff": {str(k): float(v) for k, v in top.items()},
+    }
+    print(json.dumps(summary, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/compare_bootstrap_cached_outputs.py
+++ b/scripts/compare_bootstrap_cached_outputs.py
@@ -1,3 +1,5 @@
+"""Compare cached TG90p benchmark outputs."""
+
 from __future__ import annotations
 
 import argparse
@@ -30,6 +32,7 @@ def _parse_args() -> argparse.Namespace:
 
 
 def main() -> None:
+    """Print a JSON summary of numerical differences between two outputs."""
     args = _parse_args()
     left = xr.open_dataarray(args.left)
     right = xr.open_dataarray(args.right)

--- a/scripts/compare_bootstrap_cached_outputs.py
+++ b/scripts/compare_bootstrap_cached_outputs.py
@@ -13,7 +13,9 @@ def _parse_args() -> argparse.Namespace:
         description="Compare cached TG90p benchmark outputs.",
     )
     parser.add_argument("--left", type=Path, required=True, help="Left NetCDF result.")
-    parser.add_argument("--right", type=Path, required=True, help="Right NetCDF result.")
+    parser.add_argument(
+        "--right", type=Path, required=True, help="Right NetCDF result."
+    )
     parser.add_argument(
         "--label-left",
         default="left",

--- a/scripts/slurm_benchmark_bootstrap_tg90p.sh
+++ b/scripts/slurm_benchmark_bootstrap_tg90p.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+#SBATCH --job-name=icclim-tg90p-bench
+#SBATCH --output=icclim-tg90p-bench-%j.out
+#SBATCH --error=icclim-tg90p-bench-%j.err
+#SBATCH --time=02:00:00
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=64G
+
+set -euo pipefail
+
+REPO_PATH="${REPO_PATH:-$PWD}"
+FILE_GLOB="${FILE_GLOB:-/path/to/data/tas_day_ACCESS-CM2_historical_*.nc}"
+SCHEDULER="${SCHEDULER:-threads}"
+TIME_CHUNK="${TIME_CHUNK:-365}"
+LAT_CHUNK="${LAT_CHUNK:-24}"
+LON_CHUNK="${LON_CHUNK:-32}"
+BOOTSTRAP="${BOOTSTRAP:-auto}"
+CACHE_DIR="${CACHE_DIR:-}"
+CACHE_KEY="${CACHE_KEY:-}"
+SAVE_OUTPUT="${SAVE_OUTPUT:-true}"
+FORCE="${FORCE:-false}"
+
+cd "$REPO_PATH"
+
+CMD=(
+  python scripts/benchmark_bootstrap_tg90p.py
+  --repo "$REPO_PATH"
+  --file-glob "$FILE_GLOB"
+  --scheduler "$SCHEDULER"
+  --time-chunk "$TIME_CHUNK"
+  --lat-chunk "$LAT_CHUNK"
+  --lon-chunk "$LON_CHUNK"
+  --bootstrap "$BOOTSTRAP"
+)
+
+if [ -n "$CACHE_DIR" ]; then
+  CMD+=(--cache-dir "$CACHE_DIR")
+fi
+
+if [ -n "$CACHE_KEY" ]; then
+  CMD+=(--cache-key "$CACHE_KEY")
+fi
+
+if [ "$SAVE_OUTPUT" = "true" ]; then
+  CMD+=(--save-output)
+fi
+
+if [ "$FORCE" = "true" ]; then
+  CMD+=(--force)
+fi
+
+echo "Running: ${CMD[*]}"
+"${CMD[@]}"

--- a/src/icclim/_core/climate_variable.py
+++ b/src/icclim/_core/climate_variable.py
@@ -72,7 +72,7 @@ class ClimateVariable:
     threshold: Threshold | None = None
     reference_period: Sequence[datetime | str] | None = None
     is_reference: bool = False
-    bootstrap: bool | None = None
+    bootstrap: bool | str | None = None
 
     def build_indicator_metadata(
         self,
@@ -132,7 +132,7 @@ def build_climate_vars(
     base_period: Sequence[str] | None,
     standard_index: StandardIndex | None,
     is_compared_to_reference: bool,
-    bootstrap: bool | None = None,
+    bootstrap: bool | str | None = None,
 ) -> list[ClimateVariable]:
     """
     Build a list of ClimateVariable from a dictionary of input files.
@@ -231,7 +231,7 @@ def build_climate_var(
     time_range: Sequence[datetime | str] | None,
     standard_var: StandardVariable | None,
     reference_period: Sequence[datetime | str] | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | str | None = None,
 ) -> ClimateVariable:
     """
     Build a ClimateVariable object.
@@ -334,7 +334,7 @@ def build_climate_var(
 
 
 def must_run_bootstrap(
-    da: DataArray, threshold: Threshold | None, bootstrap: bool | None = None
+    da: DataArray, threshold: Threshold | None, bootstrap: bool | str | None = None
 ) -> bool:
     """
     Determine whether to run the bootstrap method.
@@ -370,7 +370,7 @@ def must_run_bootstrap(
     ):
         return False
     if bootstrap is not None:
-        return bootstrap
+        return bootstrap is not False
     reference = threshold.value
     time_index = da.indexes.get("time")
     if time_index is None:
@@ -404,7 +404,7 @@ def _build_reference_variable(
     reference_period: Sequence[str] | None,
     in_files: dict[str, InFileDictionary],
     standard_var: StandardVariable,
-    bootstrap: bool | None = None,
+    bootstrap: bool | str | None = None,
 ) -> ClimateVariable:
     """
     Add a secondary variable for indices such as anomaly.

--- a/src/icclim/_core/climate_variable.py
+++ b/src/icclim/_core/climate_variable.py
@@ -369,8 +369,8 @@ def must_run_bootstrap(
         )
     ):
         return False
-    if bootstrap is not None:
-        return bootstrap is not False
+    if bootstrap is False:
+        return False
     reference = threshold.value
     time_index = da.indexes.get("time")
     if time_index is None:

--- a/src/icclim/_core/generic/functions.py
+++ b/src/icclim/_core/generic/functions.py
@@ -18,8 +18,11 @@ The `DataArray` instance is the result of the computation of the generic index.
 from __future__ import annotations
 
 import operator
+import os
 import warnings
 from collections.abc import Callable
+from copy import copy
+from dataclasses import replace
 from functools import partial
 from time import perf_counter
 from typing import TYPE_CHECKING, Any, cast
@@ -139,6 +142,25 @@ def count_occurrences(
     365
     """
     if len(climate_vars) == 1 and not date_event:
+        safe_bootstrapped = _compute_safe_tiled_bootstrapped_percentile_index(
+            climate_vars[0],
+            resample_freq,
+            compute_from_exceedance=lambda _study, exceedance: exceedance.resample(
+                time=resample_freq.pandas_freq
+            ).sum(dim="time"),
+        )
+        if safe_bootstrapped is not None:
+            if to_percent:
+                safe_bootstrapped = _to_percent(safe_bootstrapped, resample_freq)
+                safe_bootstrapped.attrs[UNITS_KEY] = "%"
+                return safe_bootstrapped
+            freq = check_freq(climate_vars[0].studied_data, dim="time")
+            return _safe_to_agg_units(
+                safe_bootstrapped,
+                climate_vars[0].studied_data,
+                "count",
+                deffreq=freq,
+            )
         maybe_bootstrapped = _compute_bootstrapped_percentile_index(
             climate_vars[0],
             resample_freq,
@@ -1295,6 +1317,122 @@ def _compute_exceedance(
         if climatology_bounds is not None:
             exceedances.attrs[REFERENCE_PERIOD_ID] = climatology_bounds
     return exceedances
+
+
+def _compute_safe_tiled_bootstrapped_percentile_index(
+    climate_var: ClimateVariable,
+    resample_freq: Frequency,
+    compute_from_exceedance: Callable[[DataArray, DataArray], DataArray],
+) -> DataArray | None:
+    if not _uses_safe_bootstrap_mode(climate_var.bootstrap):
+        return None
+
+    threshold = climate_var.threshold
+    if threshold is None:
+        return None
+    from icclim._core.generic.threshold.percentile import (  # noqa: PLC0415
+        PercentileThreshold,
+    )
+
+    if not isinstance(threshold, PercentileThreshold) or not threshold.is_doy_per_threshold:
+        return None
+    if not must_run_bootstrap(climate_var.studied_data, threshold, True):
+        return None
+
+    safe_start = perf_counter()
+    max_cells = int(os.environ.get("ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS", "2048"))
+    tile_results: list[DataArray] = []
+    for tile_indexers in _iter_spatial_tiles(climate_var.studied_data, max_cells):
+        tile_start = perf_counter()
+        tile_study = climate_var.studied_data.isel(tile_indexers)
+        tile_threshold = _slice_threshold_for_tile(threshold, tile_indexers)
+        tile_cv = replace(
+            climate_var,
+            studied_data=tile_study,
+            threshold=tile_threshold,
+            bootstrap=True,
+        )
+        tile_result = _compute_bootstrapped_percentile_index(
+            tile_cv,
+            resample_freq,
+            compute_from_exceedance,
+        )
+        if tile_result is None:
+            return None
+        tile_results.append(tile_result.load())
+        _profile_bootstrap_inc("bootstrap_safe_tile_count")
+        _profile_bootstrap_add(
+            "bootstrap_safe_tile_seconds",
+            perf_counter() - tile_start,
+        )
+
+    if len(tile_results) == 1:
+        result = tile_results[0]
+    else:
+        result = xr.combine_by_coords(
+            [tile.to_dataset(name="__icclim_bootstrap_tile") for tile in tile_results],
+            combine_attrs="override",
+        )["__icclim_bootstrap_tile"]
+    result.attrs.update(tile_results[-1].attrs)
+    _profile_bootstrap_add(
+        "bootstrap_safe_total_seconds",
+        perf_counter() - safe_start,
+    )
+    return result
+
+
+def _uses_safe_bootstrap_mode(bootstrap: Any) -> bool:
+    return bootstrap == "safe" or os.environ.get("ICCLIM_BOOTSTRAP_MODE") == "safe"
+
+
+def _iter_spatial_tiles(
+    da: DataArray,
+    max_cells: int,
+) -> list[dict[str, slice]]:
+    spatial_dims = [dim for dim in da.dims if dim != "time"]
+    if not spatial_dims:
+        return [{}]
+
+    tile_lengths = {dim: da.sizes[dim] for dim in spatial_dims}
+    product = 1
+    for dim in spatial_dims:
+        product *= tile_lengths[dim]
+    while product > max_cells:
+        dim = max(tile_lengths, key=tile_lengths.get)
+        old = tile_lengths[dim]
+        tile_lengths[dim] = max(1, old // 2)
+        product = 1
+        for value in tile_lengths.values():
+            product *= value
+        if tile_lengths[dim] == old:
+            break
+
+    tiles: list[dict[str, slice]] = [{}]
+    for dim in spatial_dims:
+        dim_tiles = [
+            slice(start, min(start + tile_lengths[dim], da.sizes[dim]))
+            for start in range(0, da.sizes[dim], tile_lengths[dim])
+        ]
+        tiles = [
+            {**prefix, dim: dim_tile}
+            for prefix in tiles
+            for dim_tile in dim_tiles
+        ]
+    return tiles
+
+
+def _slice_threshold_for_tile(
+    threshold: PercentileThreshold,
+    tile_indexers: dict[str, slice],
+) -> PercentileThreshold:
+    sliced = copy(threshold)
+    value = threshold.value
+    value_indexers = {
+        dim: indexer for dim, indexer in tile_indexers.items() if dim in value.dims
+    }
+    if value_indexers:
+        sliced._prepared_value = value.isel(value_indexers)
+    return sliced
 
 
 def _compute_bootstrapped_percentile_index(

--- a/src/icclim/_core/generic/functions.py
+++ b/src/icclim/_core/generic/functions.py
@@ -21,6 +21,7 @@ import operator
 import warnings
 from collections.abc import Callable
 from functools import partial
+from time import perf_counter
 from typing import TYPE_CHECKING, Any, cast
 from warnings import warn
 
@@ -63,6 +64,25 @@ if TYPE_CHECKING:
     from icclim._core.generic.threshold.percentile import PercentileThreshold
     from icclim._core.model.logical_link import LogicalLink
     from icclim._core.model.threshold import Threshold
+
+
+_BOOTSTRAP_PROFILE: dict[str, float | int] = {}
+
+
+def reset_bootstrap_profile() -> None:
+    _BOOTSTRAP_PROFILE.clear()
+
+
+def get_bootstrap_profile() -> dict[str, float | int]:
+    return dict(_BOOTSTRAP_PROFILE)
+
+
+def _profile_bootstrap_add(name: str, seconds: float) -> None:
+    _BOOTSTRAP_PROFILE[name] = float(_BOOTSTRAP_PROFILE.get(name, 0.0)) + seconds
+
+
+def _profile_bootstrap_inc(name: str, count: int = 1) -> None:
+    _BOOTSTRAP_PROFILE[name] = int(_BOOTSTRAP_PROFILE.get(name, 0)) + count
 
 
 def count_occurrences(
@@ -1282,6 +1302,7 @@ def _compute_bootstrapped_percentile_index(
     resample_freq: Frequency,
     compute_from_exceedance: Callable[[DataArray, DataArray], DataArray],
 ) -> DataArray | None:
+    total_start = perf_counter()
     study = climate_var.studied_data
     threshold = climate_var.threshold
     if threshold is None:
@@ -1316,6 +1337,9 @@ def _compute_bootstrapped_percentile_index(
     overlap_groups = overlap_da.resample(time=bfreq).groups
     study_groups = study.resample(time=bfreq).groups
     overlap_labels = set(overlap_groups)
+    _profile_bootstrap_inc("bootstrap_total_calls")
+    _profile_bootstrap_inc("bootstrap_overlap_years", len(overlap_labels))
+    _profile_bootstrap_inc("bootstrap_study_years", len(study_groups))
     per_values = per.percentiles.data.tolist()
     if not isinstance(per_values, list):
         per_values = [per_values]
@@ -1326,16 +1350,28 @@ def _compute_bootstrapped_percentile_index(
     for year_key, year_slice in study_groups.items():
         year_da = study.isel(time=year_slice)
         if year_key not in overlap_labels:
+            non_overlap_start = perf_counter()
             exceedance = threshold.compute(
                 year_da,
                 freq=resample_freq.pandas_freq,
                 bootstrap=False,
             ).squeeze()
             value = compute_from_exceedance(year_da, exceedance)
+            _profile_bootstrap_add(
+                "bootstrap_non_overlap_seconds",
+                perf_counter() - non_overlap_start,
+            )
+            _profile_bootstrap_inc("bootstrap_non_overlap_year_count")
             acc.append(value)
             continue
 
+        overlap_start = perf_counter()
+        build_ref_start = perf_counter()
         boot_ref = build_bootstrap_year_da(overlap_da, overlap_groups, year_key)
+        _profile_bootstrap_add(
+            "bootstrap_build_boot_ref_seconds",
+            perf_counter() - build_ref_start,
+        )
         if BOOTSTRAP_DIM not in per_template.dims:
             per_template = per_template.expand_dims(
                 {BOOTSTRAP_DIM: boot_ref[BOOTSTRAP_DIM]}
@@ -1347,6 +1383,7 @@ def _compute_bootstrapped_percentile_index(
                 }
                 per_template = per_template.chunk(chunking)
 
+        donor_per_start = perf_counter()
         donor_per = xr.map_blocks(
             percentile_doy.__wrapped__,
             obj=boot_ref,
@@ -1359,25 +1396,40 @@ def _compute_bootstrapped_percentile_index(
             },
             template=per_template,
         )
+        _profile_bootstrap_add(
+            "bootstrap_map_blocks_seconds",
+            perf_counter() - donor_per_start,
+        )
         donor_per = PercentileDataArray.from_da(
             donor_per,
             climatology_bounds=per.attrs["climatology_bounds"],
         )
         if "percentiles" not in per.dims:
             donor_per = donor_per.squeeze("percentiles")
+        apply_op_start = perf_counter()
         donor_exceedance = threshold._apply_percentile_op(
             da=year_da,
             per=donor_per,
             op=op,
             is_doy_per_threshold=True,
         )
+        _profile_bootstrap_add(
+            "bootstrap_apply_percentile_op_seconds",
+            perf_counter() - apply_op_start,
+        )
         if "percentiles" in donor_exceedance.dims:
             donor_exceedance = donor_exceedance.squeeze("percentiles")
+        reduce_start = perf_counter()
         donor_result = compute_from_exceedance(year_da, donor_exceedance).astype(
             "float32"
         )
+        _profile_bootstrap_add(
+            "bootstrap_compute_from_exceedance_seconds",
+            perf_counter() - reduce_start,
+        )
 
         if BOOTSTRAP_DIM not in donor_result.dims:
+            fallback_start = perf_counter()
             value = compute_from_exceedance(
                 year_da,
                 threshold.compute(
@@ -1386,15 +1438,34 @@ def _compute_bootstrapped_percentile_index(
                     bootstrap=False,
                 ).squeeze(),
             )
+            _profile_bootstrap_add(
+                "bootstrap_fallback_seconds",
+                perf_counter() - fallback_start,
+            )
+            _profile_bootstrap_inc("bootstrap_fallback_year_count")
         else:
+            mean_start = perf_counter()
             value = donor_result.mean(dim=BOOTSTRAP_DIM, keep_attrs=True)
+            _profile_bootstrap_add(
+                "bootstrap_donor_mean_seconds",
+                perf_counter() - mean_start,
+            )
         if "percentiles" in value.dims:
             value = value.squeeze("percentiles")
+        _profile_bootstrap_add(
+            "bootstrap_overlap_year_seconds",
+            perf_counter() - overlap_start,
+        )
+        _profile_bootstrap_inc("bootstrap_overlap_year_count")
         acc.append(value)
 
     result = xr.concat(acc, dim="time", coords="minimal", compat="override")
     result.attrs.update(acc[-1].attrs)
     result.attrs[REFERENCE_PERIOD_ID] = clim
+    _profile_bootstrap_add(
+        "bootstrap_total_seconds",
+        perf_counter() - total_start,
+    )
     return result
 
 

--- a/src/icclim/_core/generic/functions.py
+++ b/src/icclim/_core/generic/functions.py
@@ -70,6 +70,8 @@ if TYPE_CHECKING:
 
 
 _BOOTSTRAP_PROFILE: dict[str, float | int] = {}
+_DEFAULT_BOOTSTRAP_SAFE_TILE_MEMORY = "2GB"
+_BOOTSTRAP_SAFE_MEMORY_FACTOR = 12
 
 
 def reset_bootstrap_profile() -> None:
@@ -86,6 +88,10 @@ def _profile_bootstrap_add(name: str, seconds: float) -> None:
 
 def _profile_bootstrap_inc(name: str, count: int = 1) -> None:
     _BOOTSTRAP_PROFILE[name] = int(_BOOTSTRAP_PROFILE.get(name, 0)) + count
+
+
+def _profile_bootstrap_set(name: str, value: float) -> None:
+    _BOOTSTRAP_PROFILE[name] = value
 
 
 def count_occurrences(
@@ -1348,7 +1354,12 @@ def _compute_safe_tiled_bootstrapped_percentile_index(
         return None
 
     safe_start = perf_counter()
-    max_cells = int(os.environ.get("ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS", "2048"))
+    max_cells = _get_safe_bootstrap_max_cells(
+        climate_var.studied_data,
+        threshold,
+        resample_freq,
+    )
+    _profile_bootstrap_set("bootstrap_safe_max_tile_cells", max_cells)
     tile_results: list[DataArray] = []
     for tile_indexers in _iter_spatial_tiles(climate_var.studied_data, max_cells):
         tile_start = perf_counter()
@@ -1400,6 +1411,68 @@ def _should_use_safe_bootstrap_mode(climate_var: ClimateVariable) -> bool:
     from xclim.core.utils import uses_dask  # noqa: PLC0415
 
     return uses_dask(climate_var.studied_data)
+
+
+def _get_safe_bootstrap_max_cells(
+    study: DataArray,
+    threshold: PercentileThreshold,
+    resample_freq: Frequency,
+) -> int:
+    if max_cells := os.environ.get("ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS"):
+        return max(1, int(max_cells))
+    max_mem = _parse_byte_size(
+        os.environ.get(
+            "ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY",
+            _DEFAULT_BOOTSTRAP_SAFE_TILE_MEMORY,
+        )
+    )
+    bytes_per_cell = _estimate_bootstrap_working_bytes_per_cell(
+        study,
+        threshold,
+        resample_freq,
+    )
+    _profile_bootstrap_set("bootstrap_safe_tile_memory_bytes", max_mem)
+    _profile_bootstrap_set("bootstrap_safe_estimated_bytes_per_cell", bytes_per_cell)
+    return max(1, max_mem // bytes_per_cell)
+
+
+def _estimate_bootstrap_working_bytes_per_cell(
+    study: DataArray,
+    threshold: PercentileThreshold,
+    resample_freq: Frequency,
+) -> int:
+    from icclim._core.generic.threshold.percentile import (  # noqa: PLC0415
+        _get_bootstrap_freq,
+    )
+
+    clim = threshold.value.attrs["climatology_bounds"]
+    overlap_da = study.sel(time=slice(*clim))
+    overlap_groups = overlap_da.resample(
+        time=_get_bootstrap_freq(resample_freq.pandas_freq)
+    ).groups
+    n_bootstrap = max(1, len(overlap_groups) - 1)
+    itemsize = getattr(study.dtype, "itemsize", 8)
+    raw_bootstrap_bytes = max(1, overlap_da.sizes["time"]) * n_bootstrap * itemsize
+    return raw_bootstrap_bytes * _BOOTSTRAP_SAFE_MEMORY_FACTOR
+
+
+def _parse_byte_size(value: str) -> int:
+    normalized = value.strip().lower().replace(" ", "")
+    units = {
+        "b": 1,
+        "kb": 1000,
+        "kib": 1024,
+        "mb": 1000**2,
+        "mib": 1024**2,
+        "gb": 1000**3,
+        "gib": 1024**3,
+    }
+    for unit, multiplier in sorted(
+        units.items(), key=lambda item: len(item[0]), reverse=True
+    ):
+        if normalized.endswith(unit):
+            return max(1, int(float(normalized.removesuffix(unit)) * multiplier))
+    return max(1, int(float(normalized)))
 
 
 def _iter_spatial_tiles(

--- a/src/icclim/_core/generic/functions.py
+++ b/src/icclim/_core/generic/functions.py
@@ -260,13 +260,15 @@ def max_consecutive_occurrence(
         maybe_bootstrapped = _compute_bootstrapped_percentile_index(
             climate_vars[0],
             resample_freq,
-            compute_from_exceedance=lambda _study, exceedance: run_length.rle(
-                exceedance,
-                dim="time",
-                index=kwargs.get("run_index", "first"),
-            )
-            .resample(time=resample_freq.pandas_freq)
-            .max(dim="time"),
+            compute_from_exceedance=lambda _study, exceedance: (
+                run_length.rle(
+                    exceedance,
+                    dim="time",
+                    index=kwargs.get("run_index", "first"),
+                )
+                .resample(time=resample_freq.pandas_freq)
+                .max(dim="time")
+            ),
         )
         if maybe_bootstrapped is not None:
             freq = check_freq(climate_vars[0].studied_data, dim="time")
@@ -1334,7 +1336,10 @@ def _compute_safe_tiled_bootstrapped_percentile_index(
         PercentileThreshold,
     )
 
-    if not isinstance(threshold, PercentileThreshold) or not threshold.is_doy_per_threshold:
+    if (
+        not isinstance(threshold, PercentileThreshold)
+        or not threshold.is_doy_per_threshold
+    ):
         return None
     if not must_run_bootstrap(climate_var.studied_data, threshold, True):
         return None
@@ -1414,9 +1419,7 @@ def _iter_spatial_tiles(
             for start in range(0, da.sizes[dim], tile_lengths[dim])
         ]
         tiles = [
-            {**prefix, dim: dim_tile}
-            for prefix in tiles
-            for dim_tile in dim_tiles
+            {**prefix, dim: dim_tile} for prefix in tiles for dim_tile in dim_tiles
         ]
     return tiles
 
@@ -1451,7 +1454,10 @@ def _compute_bootstrapped_percentile_index(  # noqa: C901, PLR0912
         _get_bootstrap_freq,
     )
 
-    if not isinstance(threshold, PercentileThreshold) or not threshold.is_doy_per_threshold:
+    if (
+        not isinstance(threshold, PercentileThreshold)
+        or not threshold.is_doy_per_threshold
+    ):
         return None
 
     bootstrap = must_run_bootstrap(study, threshold, climate_var.bootstrap)

--- a/src/icclim/_core/generic/functions.py
+++ b/src/icclim/_core/generic/functions.py
@@ -118,6 +118,27 @@ def count_occurrences(
     >>> int(result.count_occurrences.isel(time=0).values)
     365
     """
+    if len(climate_vars) == 1 and not date_event:
+        maybe_bootstrapped = _compute_bootstrapped_percentile_index(
+            climate_vars[0],
+            resample_freq,
+            compute_from_exceedance=lambda _study, exceedance: exceedance.resample(
+                time=resample_freq.pandas_freq
+            ).sum(dim="time"),
+        )
+        if maybe_bootstrapped is not None:
+            if to_percent:
+                maybe_bootstrapped = _to_percent(maybe_bootstrapped, resample_freq)
+                maybe_bootstrapped.attrs[UNITS_KEY] = "%"
+                return maybe_bootstrapped
+            freq = check_freq(climate_vars[0].studied_data, dim="time")
+            return _safe_to_agg_units(
+                maybe_bootstrapped,
+                climate_vars[0].studied_data,
+                "count",
+                deffreq=freq,
+            )
+
     if date_event:
         reducer_op = _count_occurrences_with_date
     else:
@@ -191,6 +212,29 @@ def max_consecutive_occurrence(
     >>> int(result.max_consecutive_occurrence.isel(time=0).values)
     365
     """
+    if len(climate_vars) == 1 and not date_event:
+        from xclim.indices import run_length  # noqa: PLC0415
+
+        maybe_bootstrapped = _compute_bootstrapped_percentile_index(
+            climate_vars[0],
+            resample_freq,
+            compute_from_exceedance=lambda _study, exceedance: run_length.rle(
+                exceedance,
+                dim="time",
+                index=kwargs.get("run_index", "first"),
+            )
+            .resample(time=resample_freq.pandas_freq)
+            .max(dim="time"),
+        )
+        if maybe_bootstrapped is not None:
+            freq = check_freq(climate_vars[0].studied_data, dim="time")
+            return _safe_to_agg_units(
+                maybe_bootstrapped,
+                climate_vars[0].studied_data,
+                "count",
+                deffreq=freq,
+            )
+
     merged_exceedances = _compute_exceedances(
         climate_vars,
         resample_freq.pandas_freq,
@@ -245,6 +289,32 @@ def sum_of_spell_lengths(
     DataArray
         The sum of the lengths of all spells in the data.
     """
+    if len(climate_vars) == 1:
+        from xclim.indices import run_length  # noqa: PLC0415
+
+        def _spell_sum(_study: DataArray, exceedance: DataArray) -> DataArray:
+            rle = run_length.rle(
+                exceedance,
+                dim="time",
+                index=kwargs.get("run_index", "first"),
+            )
+            cropped_rle = rle.where(rle >= min_spell_length, other=0)
+            return cropped_rle.resample(time=resample_freq.pandas_freq).sum(dim="time")
+
+        maybe_bootstrapped = _compute_bootstrapped_percentile_index(
+            climate_vars[0],
+            resample_freq,
+            compute_from_exceedance=_spell_sum,
+        )
+        if maybe_bootstrapped is not None:
+            freq = check_freq(climate_vars[0].studied_data, dim="time")
+            return _safe_to_agg_units(
+                maybe_bootstrapped,
+                climate_vars[0].studied_data,
+                "count",
+                deffreq=freq,
+            )
+
     merged_exceedances = _compute_exceedances(
         climate_vars,
         resample_freq.pandas_freq,
@@ -1205,6 +1275,127 @@ def _compute_exceedance(
         if climatology_bounds is not None:
             exceedances.attrs[REFERENCE_PERIOD_ID] = climatology_bounds
     return exceedances
+
+
+def _compute_bootstrapped_percentile_index(
+    climate_var: ClimateVariable,
+    resample_freq: Frequency,
+    compute_from_exceedance: Callable[[DataArray, DataArray], DataArray],
+) -> DataArray | None:
+    study = climate_var.studied_data
+    threshold = climate_var.threshold
+    if threshold is None:
+        return None
+
+    from icclim._core.generic.threshold.percentile import (  # noqa: PLC0415
+        PercentileThreshold,
+        _get_bootstrap_freq,
+    )
+
+    if not isinstance(threshold, PercentileThreshold) or not threshold.is_doy_per_threshold:
+        return None
+
+    bootstrap = must_run_bootstrap(study, threshold, climate_var.bootstrap)
+    if not bootstrap:
+        return None
+
+    from xclim.core.bootstrapping import (  # noqa: PLC0415
+        BOOTSTRAP_DIM,
+        build_bootstrap_year_da,
+    )
+    from xclim.core.calendar import percentile_doy  # noqa: PLC0415
+    from xclim.core.utils import uses_dask  # noqa: PLC0415
+
+    per = threshold.value
+    clim = per.attrs["climatology_bounds"]
+    overlap_da = study.sel(time=slice(*clim))
+    if len(overlap_da.time) == 0 or len(overlap_da.time) == len(study.time):
+        return None
+
+    bfreq = _get_bootstrap_freq(resample_freq.pandas_freq)
+    overlap_groups = overlap_da.resample(time=bfreq).groups
+    study_groups = study.resample(time=bfreq).groups
+    overlap_labels = set(overlap_groups)
+    per_values = per.percentiles.data.tolist()
+    if not isinstance(per_values, list):
+        per_values = [per_values]
+
+    op = cast("Operator", threshold.operator).compute
+    per_template = per.copy(deep=True)
+    acc: list[DataArray] = []
+    for year_key, year_slice in study_groups.items():
+        year_da = study.isel(time=year_slice)
+        if year_key not in overlap_labels:
+            exceedance = threshold.compute(
+                year_da,
+                freq=resample_freq.pandas_freq,
+                bootstrap=False,
+            ).squeeze()
+            value = compute_from_exceedance(year_da, exceedance)
+            acc.append(value)
+            continue
+
+        boot_ref = build_bootstrap_year_da(overlap_da, overlap_groups, year_key)
+        if BOOTSTRAP_DIM not in per_template.dims:
+            per_template = per_template.expand_dims(
+                {BOOTSTRAP_DIM: boot_ref[BOOTSTRAP_DIM]}
+            )
+            if uses_dask(boot_ref):
+                chunking = {
+                    dim: boot_ref.chunks[boot_ref.get_axis_num(dim)]
+                    for dim in set(boot_ref.dims).intersection(per_template.dims)
+                }
+                per_template = per_template.chunk(chunking)
+
+        donor_per = xr.map_blocks(
+            percentile_doy.__wrapped__,
+            obj=boot_ref,
+            kwargs={
+                "window": per.attrs["window"],
+                "per": per_values,
+                "alpha": per.attrs["alpha"],
+                "beta": per.attrs["beta"],
+                "copy": False,
+            },
+            template=per_template,
+        )
+        donor_per = PercentileDataArray.from_da(
+            donor_per,
+            climatology_bounds=per.attrs["climatology_bounds"],
+        )
+        if "percentiles" not in per.dims:
+            donor_per = donor_per.squeeze("percentiles")
+        donor_exceedance = threshold._apply_percentile_op(
+            da=year_da,
+            per=donor_per,
+            op=op,
+            is_doy_per_threshold=True,
+        )
+        if "percentiles" in donor_exceedance.dims:
+            donor_exceedance = donor_exceedance.squeeze("percentiles")
+        donor_result = compute_from_exceedance(year_da, donor_exceedance).astype(
+            "float32"
+        )
+
+        if BOOTSTRAP_DIM not in donor_result.dims:
+            value = compute_from_exceedance(
+                year_da,
+                threshold.compute(
+                    year_da,
+                    freq=resample_freq.pandas_freq,
+                    bootstrap=False,
+                ).squeeze(),
+            )
+        else:
+            value = donor_result.mean(dim=BOOTSTRAP_DIM, keep_attrs=True)
+        if "percentiles" in value.dims:
+            value = value.squeeze("percentiles")
+        acc.append(value)
+
+    result = xr.concat(acc, dim="time", coords="minimal", compat="override")
+    result.attrs.update(acc[-1].attrs)
+    result.attrs[REFERENCE_PERIOD_ID] = clim
+    return result
 
 
 def get_couple_of_var(

--- a/src/icclim/_core/generic/functions.py
+++ b/src/icclim/_core/generic/functions.py
@@ -1360,6 +1360,39 @@ def _compute_safe_tiled_bootstrapped_percentile_index(
         resample_freq,
     )
     _profile_bootstrap_set("bootstrap_safe_max_tile_cells", max_cells)
+    while True:
+        try:
+            return _compute_safe_tiled_bootstrap_with_max_cells(
+                climate_var,
+                threshold,
+                resample_freq,
+                compute_from_exceedance,
+                max_cells,
+                safe_start,
+            )
+        except Exception as err:  # noqa: PERF203
+            if not _is_memory_like_bootstrap_error(err):
+                raise
+            if max_cells <= 1:
+                msg = (
+                    "Percentile bootstrap failed even with one spatial cell per tile. "
+                    "Try reducing the time range, using fewer workers/threads, or "
+                    "running with more memory."
+                )
+                raise MemoryError(msg) from err
+            max_cells = max(1, max_cells // 2)
+            _profile_bootstrap_inc("bootstrap_safe_memory_retry_count")
+            _profile_bootstrap_set("bootstrap_safe_max_tile_cells", max_cells)
+
+
+def _compute_safe_tiled_bootstrap_with_max_cells(
+    climate_var: ClimateVariable,
+    threshold: PercentileThreshold,
+    resample_freq: Frequency,
+    compute_from_exceedance: Callable[[DataArray, DataArray], DataArray],
+    max_cells: int,
+    safe_start: float,
+) -> DataArray | None:
     tile_results: list[DataArray] = []
     for tile_indexers in _iter_spatial_tiles(climate_var.studied_data, max_cells):
         tile_start = perf_counter()
@@ -1398,6 +1431,34 @@ def _compute_safe_tiled_bootstrapped_percentile_index(
         perf_counter() - safe_start,
     )
     return result
+
+
+def _is_memory_like_bootstrap_error(err: BaseException) -> bool:
+    if isinstance(err, MemoryError):
+        return True
+    err_type = type(err).__name__.lower()
+    memory_error_types = {
+        "arraymemoryerror",
+        "killedworker",
+        "nannyrestart",
+        "reschedule",
+        "workerlost",
+        "workerkilled",
+    }
+    if err_type in memory_error_types:
+        return True
+    message = str(err).lower()
+    memory_fragments = (
+        "failed to allocate",
+        "killed worker",
+        "malloc",
+        "memoryerror",
+        "out of memory",
+        "oom",
+        "worker died",
+        "worker exceeded",
+    )
+    return any(fragment in message for fragment in memory_fragments)
 
 
 def _should_use_safe_bootstrap_mode(climate_var: ClimateVariable) -> bool:

--- a/src/icclim/_core/generic/functions.py
+++ b/src/icclim/_core/generic/functions.py
@@ -1381,7 +1381,7 @@ def _compute_safe_tiled_bootstrapped_percentile_index(
     return result
 
 
-def _uses_safe_bootstrap_mode(bootstrap: Any) -> bool:
+def _uses_safe_bootstrap_mode(bootstrap: object) -> bool:
     return bootstrap == "safe" or os.environ.get("ICCLIM_BOOTSTRAP_MODE") == "safe"
 
 
@@ -1431,11 +1431,11 @@ def _slice_threshold_for_tile(
         dim: indexer for dim, indexer in tile_indexers.items() if dim in value.dims
     }
     if value_indexers:
-        sliced._prepared_value = value.isel(value_indexers)
+        sliced._prepared_value = value.isel(value_indexers)  # noqa: SLF001
     return sliced
 
 
-def _compute_bootstrapped_percentile_index(
+def _compute_bootstrapped_percentile_index(  # noqa: C901, PLR0912
     climate_var: ClimateVariable,
     resample_freq: Frequency,
     compute_from_exceedance: Callable[[DataArray, DataArray], DataArray],
@@ -1551,7 +1551,7 @@ def _compute_bootstrapped_percentile_index(
         if "percentiles" not in per.dims:
             donor_per = donor_per.squeeze("percentiles")
         apply_op_start = perf_counter()
-        donor_exceedance = threshold._apply_percentile_op(
+        donor_exceedance = threshold._apply_percentile_op(  # noqa: SLF001
             da=year_da,
             per=donor_per,
             op=op,

--- a/src/icclim/_core/generic/functions.py
+++ b/src/icclim/_core/generic/functions.py
@@ -1346,17 +1346,23 @@ def _compute_bootstrapped_percentile_index(
 
     op = cast("Operator", threshold.operator).compute
     per_template = per.copy(deep=True)
+    baseline_start = perf_counter()
+    baseline_exceedance = threshold.compute(
+        study,
+        freq=resample_freq.pandas_freq,
+        bootstrap=False,
+    ).squeeze()
+    baseline_result = compute_from_exceedance(study, baseline_exceedance)
+    _profile_bootstrap_add(
+        "bootstrap_baseline_result_seconds",
+        perf_counter() - baseline_start,
+    )
     acc: list[DataArray] = []
     for year_key, year_slice in study_groups.items():
         year_da = study.isel(time=year_slice)
         if year_key not in overlap_labels:
             non_overlap_start = perf_counter()
-            exceedance = threshold.compute(
-                year_da,
-                freq=resample_freq.pandas_freq,
-                bootstrap=False,
-            ).squeeze()
-            value = compute_from_exceedance(year_da, exceedance)
+            value = baseline_result.sel(time=[year_key])
             _profile_bootstrap_add(
                 "bootstrap_non_overlap_seconds",
                 perf_counter() - non_overlap_start,
@@ -1430,14 +1436,7 @@ def _compute_bootstrapped_percentile_index(
 
         if BOOTSTRAP_DIM not in donor_result.dims:
             fallback_start = perf_counter()
-            value = compute_from_exceedance(
-                year_da,
-                threshold.compute(
-                    year_da,
-                    freq=resample_freq.pandas_freq,
-                    bootstrap=False,
-                ).squeeze(),
-            )
+            value = baseline_result.sel(time=[year_key])
             _profile_bootstrap_add(
                 "bootstrap_fallback_seconds",
                 perf_counter() - fallback_start,

--- a/src/icclim/_core/generic/functions.py
+++ b/src/icclim/_core/generic/functions.py
@@ -1326,9 +1326,6 @@ def _compute_safe_tiled_bootstrapped_percentile_index(
     resample_freq: Frequency,
     compute_from_exceedance: Callable[[DataArray, DataArray], DataArray],
 ) -> DataArray | None:
-    if not _uses_safe_bootstrap_mode(climate_var.bootstrap):
-        return None
-
     threshold = climate_var.threshold
     if threshold is None:
         return None
@@ -1341,7 +1338,13 @@ def _compute_safe_tiled_bootstrapped_percentile_index(
         or not threshold.is_doy_per_threshold
     ):
         return None
-    if not must_run_bootstrap(climate_var.studied_data, threshold, True):
+    if not _should_use_safe_bootstrap_mode(climate_var):
+        return None
+    if not must_run_bootstrap(
+        climate_var.studied_data,
+        threshold,
+        climate_var.bootstrap,
+    ):
         return None
 
     safe_start = perf_counter()
@@ -1386,8 +1389,17 @@ def _compute_safe_tiled_bootstrapped_percentile_index(
     return result
 
 
-def _uses_safe_bootstrap_mode(bootstrap: object) -> bool:
-    return bootstrap == "safe" or os.environ.get("ICCLIM_BOOTSTRAP_MODE") == "safe"
+def _should_use_safe_bootstrap_mode(climate_var: ClimateVariable) -> bool:
+    if climate_var.bootstrap is False:
+        return False
+    mode = os.environ.get("ICCLIM_BOOTSTRAP_MODE")
+    if climate_var.bootstrap == "safe" or mode == "safe":
+        return True
+    if mode == "default":
+        return False
+    from xclim.core.utils import uses_dask  # noqa: PLC0415
+
+    return uses_dask(climate_var.studied_data)
 
 
 def _iter_spatial_tiles(

--- a/src/icclim/_core/generic/threshold/percentile.py
+++ b/src/icclim/_core/generic/threshold/percentile.py
@@ -627,23 +627,30 @@ def _build_single_bootstrap_reference(
     donor_label: Any,
     dim: str = "time",
 ) -> DataArray:
-    target = da[dim][groups[target_label]]
-    source = da.isel({dim: groups[donor_label]})
-    out = da.copy(deep=True)
+    target_slice = groups[target_label]
+    donor_slice = groups[donor_label]
+    target_start = target_slice.start or 0
+    target_stop = target_slice.stop or da.sizes[dim]
+    target = da[dim][target_slice]
+    source = da.isel({dim: donor_slice})
     if len(source[dim]) < 360 and len(source[dim]) < len(target):
-        return out
+        return da
     if len(source[dim]) == len(target):
-        replacement = source.data
+        replacement = source
     elif len(target) == 365:
-        replacement = source.convert_calendar("noleap").data
+        replacement = source.convert_calendar("noleap")
     elif len(target) == 366:
-        replacement = source.convert_calendar("366_day", missing=np.nan).data
+        replacement = source.convert_calendar("366_day", missing=np.nan)
     elif len(target) < 365:
-        replacement = source.data[: len(target)]
+        replacement = source.isel({dim: slice(0, len(target))})
     else:
         msg = "Unsupported bootstrap year replacement shape."
         raise NotImplementedError(msg)
-    out.loc[{dim: target}] = replacement
+    replacement = replacement.assign_coords({dim: target})
+    prefix = da.isel({dim: slice(None, target_start)})
+    suffix = da.isel({dim: slice(target_stop, None)})
+    out = xr.concat([prefix, replacement, suffix], dim=dim)
+    out.attrs.update(da.attrs)
     return out
 
 

--- a/src/icclim/_core/generic/threshold/percentile.py
+++ b/src/icclim/_core/generic/threshold/percentile.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, cast
 
+import numpy as np
 import xarray as xr
 from xarray import DataArray, Dataset
 
@@ -399,40 +400,133 @@ class PercentileThreshold(Threshold):
         freq: str,
         bootstrap: bool,
     ) -> DataArray:
-        from xclim.core.bootstrapping import percentile_bootstrap  # noqa: PLC0415
-
-        @percentile_bootstrap
-        def __per_compute(
-            da: xr.DataArray,
-            per: xr.DataArray,
-            op: Callable[[DataArray, DataArray], DataArray],
-            is_doy_per_threshold: bool,
-            freq: str,  # noqa: ARG001
-            bootstrap: bool,  # noqa: ARG001
-        ) -> DataArray:
-            if self.threshold_min_value is not None:
-                # there is only a threshold_min_value when we are computing > or >=
-                thresh = self.threshold_min_value
-                from xclim.core.units import convert_units_to  # noqa: PLC0415
-
-                thresh = convert_units_to(thresh, per, context="hydro")
-                per = per.where(per > thresh, thresh)
-            if is_doy_per_threshold:
-                from xclim.core.calendar import resample_doy  # noqa: PLC0415
-
-                threshold_value = resample_doy(per, da)
-            else:
-                threshold_value = per
-            return op(da, threshold_value)
-
-        return __per_compute(
-            comparison_data,
-            per,
-            op,
-            is_doy_per_threshold,
-            freq,
-            bootstrap,
+        if bootstrap and is_doy_per_threshold:
+            return self._bootstrap_per_compute(
+                comparison_data=comparison_data,
+                per=per,
+                op=op,
+                freq=freq,
+            )
+        return self._apply_percentile_op(
+            da=comparison_data,
+            per=per,
+            op=op,
+            is_doy_per_threshold=is_doy_per_threshold,
         )
+
+    def _apply_percentile_op(
+        self,
+        da: xr.DataArray,
+        per: xr.DataArray,
+        op: Callable[[DataArray, DataArray], DataArray],
+        is_doy_per_threshold: bool,
+    ) -> DataArray:
+        if self.threshold_min_value is not None:
+            # there is only a threshold_min_value when we are computing > or >=
+            thresh = self.threshold_min_value
+            from xclim.core.units import convert_units_to  # noqa: PLC0415
+
+            thresh = convert_units_to(thresh, per, context="hydro")
+            per = per.where(per > thresh, thresh)
+        if is_doy_per_threshold:
+            from xclim.core.calendar import resample_doy  # noqa: PLC0415
+
+            threshold_value = resample_doy(per, da)
+        else:
+            threshold_value = per
+        return op(da, threshold_value)
+
+    def _bootstrap_per_compute(
+        self,
+        comparison_data: xr.DataArray,
+        per: PercentileDataArray,
+        op: Callable[[DataArray, DataArray], DataArray],
+        freq: str,
+    ) -> DataArray:
+        from xclim.core.calendar import percentile_doy  # noqa: PLC0415
+
+        clim = per.attrs["climatology_bounds"]
+        overlap_da = comparison_data.sel(time=slice(*clim))
+        if len(overlap_da.time) == 0 or len(overlap_da.time) == len(comparison_data.time):
+            return self._apply_percentile_op(
+                da=comparison_data,
+                per=per,
+                op=op,
+                is_doy_per_threshold=True,
+            )
+
+        bfreq = _get_bootstrap_freq(freq)
+        overlap_groups = overlap_da.resample(time=bfreq).groups
+        da_groups = comparison_data.resample(time=bfreq).groups
+        overlap_labels = set(overlap_groups)
+        per_values = per.percentiles.data.tolist()
+        if not isinstance(per_values, list):
+            per_values = [per_values]
+
+        acc: list[DataArray] = []
+        for year_key, year_slice in da_groups.items():
+            year_da = comparison_data.isel(time=year_slice)
+            if year_key not in overlap_labels:
+                acc.append(
+                    self._apply_percentile_op(
+                        da=year_da,
+                        per=per,
+                        op=op,
+                        is_doy_per_threshold=True,
+                    )
+                )
+                continue
+
+            donor_results: list[DataArray] = []
+            for donor_key in overlap_groups:
+                if donor_key == year_key:
+                    continue
+                boot_ref = _build_single_bootstrap_reference(
+                    overlap_da,
+                    overlap_groups,
+                    year_key,
+                    donor_key,
+                )
+                donor_per = percentile_doy(
+                    arr=boot_ref,
+                    window=per.attrs["window"],
+                    per=per_values,
+                    alpha=per.attrs["alpha"],
+                    beta=per.attrs["beta"],
+                    copy=False,
+                )
+                donor_per = PercentileDataArray.from_da(
+                    donor_per,
+                    climatology_bounds=per.attrs["climatology_bounds"],
+                )
+                if "percentiles" not in per.dims:
+                    donor_per = donor_per.squeeze("percentiles")
+                donor_results.append(
+                    self._apply_percentile_op(
+                        da=year_da,
+                        per=donor_per,
+                        op=op,
+                        is_doy_per_threshold=True,
+                    )
+                )
+            if donor_results:
+                acc.append(
+                    xr.concat(donor_results, dim="_bootstrap")
+                    .mean(dim="_bootstrap", keep_attrs=True)
+                )
+            else:
+                acc.append(
+                    self._apply_percentile_op(
+                        da=year_da,
+                        per=per,
+                        op=op,
+                        is_doy_per_threshold=True,
+                    )
+                )
+
+        result = xr.concat(acc, dim="time")
+        result.attrs.update(acc[-1].attrs)
+        return result
 
 
 def _compute_per(
@@ -514,6 +608,43 @@ def _build_doy_per(
         alpha=interpolation.alpha,
         beta=interpolation.beta,
     )
+
+
+def _get_bootstrap_freq(freq: str) -> str:
+    from xclim.core.calendar import parse_offset  # noqa: PLC0415
+
+    _, base, start_anchor, anchor = parse_offset(freq)
+    bfreq = "YS" if start_anchor else "YE"
+    if base in ["A", "Y", "Q"] and anchor is not None:
+        bfreq = f"{bfreq}-{anchor}"
+    return bfreq
+
+
+def _build_single_bootstrap_reference(
+    da: DataArray,
+    groups: dict[Any, slice],
+    target_label: Any,
+    donor_label: Any,
+    dim: str = "time",
+) -> DataArray:
+    target = da[dim][groups[target_label]]
+    source = da.isel({dim: groups[donor_label]})
+    out = da.copy(deep=True)
+    if len(source[dim]) < 360 and len(source[dim]) < len(target):
+        return out
+    if len(source[dim]) == len(target):
+        replacement = source.data
+    elif len(target) == 365:
+        replacement = source.convert_calendar("noleap").data
+    elif len(target) == 366:
+        replacement = source.convert_calendar("366_day", missing=np.nan).data
+    elif len(target) < 365:
+        replacement = source.data[: len(target)]
+    else:
+        msg = "Unsupported bootstrap year replacement shape."
+        raise NotImplementedError(msg)
+    out.loc[{dim: target}] = replacement
+    return out
 
 
 def _build_per_thresh_from_dataset(

--- a/src/icclim/_core/generic/threshold/percentile.py
+++ b/src/icclim/_core/generic/threshold/percentile.py
@@ -36,7 +36,7 @@ from icclim._core.model.threshold import Threshold, ThresholdValueType
 
 if TYPE_CHECKING:
     # Standard library
-    from collections.abc import Callable, Sequence
+    from collections.abc import Callable, Hashable, Sequence
     from datetime import datetime
 
     # Third-party
@@ -45,6 +45,11 @@ if TYPE_CHECKING:
 
     # Local
     from icclim._core.model.operator import Operator
+
+
+MIN_BOOTSTRAP_DONOR_DAYS = 360
+NOLEAP_YEAR_DAYS = 365
+LEAP_YEAR_DAYS = 366
 
 
 class PercentileThreshold(Threshold):
@@ -627,9 +632,9 @@ def _get_bootstrap_freq(freq: str) -> str:
 
 def _build_single_bootstrap_reference(
     da: DataArray,
-    groups: dict[Any, slice],
-    target_label: Any,
-    donor_label: Any,
+    groups: dict[Hashable, slice],
+    target_label: Hashable,
+    donor_label: Hashable,
     dim: str = "time",
 ) -> DataArray:
     target_slice = groups[target_label]
@@ -638,15 +643,15 @@ def _build_single_bootstrap_reference(
     target_stop = target_slice.stop or da.sizes[dim]
     target = da[dim][target_slice]
     source = da.isel({dim: donor_slice})
-    if len(source[dim]) < 360 and len(source[dim]) < len(target):
+    if len(source[dim]) < MIN_BOOTSTRAP_DONOR_DAYS and len(source[dim]) < len(target):
         return da
     if len(source[dim]) == len(target):
         replacement = source
-    elif len(target) == 365:
+    elif len(target) == NOLEAP_YEAR_DAYS:
         replacement = source.convert_calendar("noleap")
-    elif len(target) == 366:
+    elif len(target) == LEAP_YEAR_DAYS:
         replacement = source.convert_calendar("366_day", missing=np.nan)
-    elif len(target) < 365:
+    elif len(target) < NOLEAP_YEAR_DAYS:
         replacement = source.isel({dim: slice(0, len(target))})
     else:
         msg = "Unsupported bootstrap year replacement shape."

--- a/src/icclim/_core/generic/threshold/percentile.py
+++ b/src/icclim/_core/generic/threshold/percentile.py
@@ -447,7 +447,9 @@ class PercentileThreshold(Threshold):
 
         clim = per.attrs["climatology_bounds"]
         overlap_da = comparison_data.sel(time=slice(*clim))
-        if len(overlap_da.time) == 0 or len(overlap_da.time) == len(comparison_data.time):
+        if len(overlap_da.time) == 0 or len(overlap_da.time) == len(
+            comparison_data.time
+        ):
             return self._apply_percentile_op(
                 da=comparison_data,
                 per=per,
@@ -510,9 +512,7 @@ class PercentileThreshold(Threshold):
                 )
                 donor_result = donor_result.astype("float32")
                 donor_total = (
-                    donor_result
-                    if donor_total is None
-                    else donor_total + donor_result
+                    donor_result if donor_total is None else donor_total + donor_result
                 )
                 donor_count += 1
             if donor_total is not None and donor_count > 0:

--- a/src/icclim/_core/generic/threshold/percentile.py
+++ b/src/icclim/_core/generic/threshold/percentile.py
@@ -477,7 +477,8 @@ class PercentileThreshold(Threshold):
                 )
                 continue
 
-            donor_results: list[DataArray] = []
+            donor_total: DataArray | None = None
+            donor_count = 0
             for donor_key in overlap_groups:
                 if donor_key == year_key:
                     continue
@@ -501,19 +502,22 @@ class PercentileThreshold(Threshold):
                 )
                 if "percentiles" not in per.dims:
                     donor_per = donor_per.squeeze("percentiles")
-                donor_results.append(
-                    self._apply_percentile_op(
-                        da=year_da,
-                        per=donor_per,
-                        op=op,
-                        is_doy_per_threshold=True,
-                    )
+                donor_result = self._apply_percentile_op(
+                    da=year_da,
+                    per=donor_per,
+                    op=op,
+                    is_doy_per_threshold=True,
                 )
-            if donor_results:
-                acc.append(
-                    xr.concat(donor_results, dim="_bootstrap")
-                    .mean(dim="_bootstrap", keep_attrs=True)
+                donor_total = (
+                    donor_result
+                    if donor_total is None
+                    else donor_total + donor_result
                 )
+                donor_count += 1
+            if donor_total is not None and donor_count > 0:
+                bootstrap_mean = donor_total / donor_count
+                bootstrap_mean.attrs.update(donor_total.attrs)
+                acc.append(bootstrap_mean)
             else:
                 acc.append(
                     self._apply_percentile_op(

--- a/src/icclim/_core/generic/threshold/percentile.py
+++ b/src/icclim/_core/generic/threshold/percentile.py
@@ -508,6 +508,7 @@ class PercentileThreshold(Threshold):
                     op=op,
                     is_doy_per_threshold=True,
                 )
+                donor_result = donor_result.astype("float32")
                 donor_total = (
                     donor_result
                     if donor_total is None

--- a/src/icclim/_generated/_dcsc.py
+++ b/src/icclim/_generated/_dcsc.py
@@ -130,10 +130,12 @@ def tav(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -246,10 +248,12 @@ def txav(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -362,10 +366,12 @@ def trav(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -496,10 +502,12 @@ def tx10(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -651,10 +659,12 @@ def tx90(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -806,10 +816,12 @@ def tn10(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -961,10 +973,12 @@ def tn90(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -1098,10 +1112,12 @@ def tnfd(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -1217,10 +1233,12 @@ def txfd(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -1336,10 +1354,12 @@ def sd(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -1455,10 +1475,12 @@ def tx35(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -1574,10 +1596,12 @@ def tr(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -1695,10 +1719,12 @@ def txnd(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -1826,10 +1852,12 @@ def tnht(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -1957,10 +1985,12 @@ def tnnd(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -2088,10 +2118,12 @@ def tncwd(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -2219,10 +2251,12 @@ def txhwd(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -2348,10 +2382,12 @@ def hdd(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -2467,10 +2503,12 @@ def cdd(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -2586,10 +2624,12 @@ def pav(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -2702,10 +2742,12 @@ def pint(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -2821,10 +2863,12 @@ def rr(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -2937,10 +2981,12 @@ def rr1mm(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -3056,10 +3102,12 @@ def pn20mm(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -3175,10 +3223,12 @@ def pxcdd(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -3294,10 +3344,12 @@ def pxcwd(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -3431,10 +3483,12 @@ def r99(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -3587,10 +3641,12 @@ def pfl90(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -3743,10 +3799,12 @@ def pq90(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -3899,10 +3957,12 @@ def pq99(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -4052,10 +4112,12 @@ def ffav(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -4187,10 +4249,12 @@ def ff98(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".

--- a/src/icclim/_generated/_dcsc.py
+++ b/src/icclim/_generated/_dcsc.py
@@ -126,8 +126,14 @@ def tav(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -236,8 +242,14 @@ def txav(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -346,8 +358,14 @@ def trav(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -474,8 +492,14 @@ def tx10(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -623,8 +647,14 @@ def tx90(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -772,8 +802,14 @@ def tn10(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -921,8 +957,14 @@ def tn90(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -1052,8 +1094,14 @@ def tnfd(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -1165,8 +1213,14 @@ def txfd(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -1278,8 +1332,14 @@ def sd(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -1391,8 +1451,14 @@ def tx35(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -1504,8 +1570,14 @@ def tr(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -1619,8 +1691,14 @@ def txnd(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -1744,8 +1822,14 @@ def tnht(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -1869,8 +1953,14 @@ def tnnd(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -1994,8 +2084,14 @@ def tncwd(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -2119,8 +2215,14 @@ def txhwd(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -2242,8 +2344,14 @@ def hdd(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -2355,8 +2463,14 @@ def cdd(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -2468,8 +2582,14 @@ def pav(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -2578,8 +2698,14 @@ def pint(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -2691,8 +2817,14 @@ def rr(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -2801,8 +2933,14 @@ def rr1mm(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -2914,8 +3052,14 @@ def pn20mm(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -3027,8 +3171,14 @@ def pxcdd(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -3140,8 +3290,14 @@ def pxcwd(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -3271,8 +3427,14 @@ def r99(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -3421,8 +3583,14 @@ def pfl90(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -3571,8 +3739,14 @@ def pq90(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -3721,8 +3895,14 @@ def pq99(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -3868,8 +4048,14 @@ def ffav(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -3997,8 +4183,14 @@ def ff98(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".

--- a/src/icclim/_generated/_dcsc.py
+++ b/src/icclim/_generated/_dcsc.py
@@ -21,7 +21,11 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from icclim.logger import Verbosity
-    from icclim._core.model.icclim_types import FrequencyLike, InFileLike, SamplingMethodLike
+    from icclim._core.model.icclim_types import (
+        FrequencyLike,
+        InFileLike,
+        SamplingMethodLike,
+    )
     from icclim.frequency import Frequency
     from icclim._core.model.netcdf_version import NetcdfVersion
     from icclim._core.model.quantile_interpolation import QuantileInterpolation
@@ -82,7 +86,7 @@ def tav(
     TAV: Moyenne de la température moyenne.
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -147,13 +151,14 @@ def tav(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=DcscIndexRegistry.TAV,
         in_files=in_files,
@@ -191,7 +196,7 @@ def txav(
     TXAV: Moyenne de la température maximale.
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -256,13 +261,14 @@ def txav(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=DcscIndexRegistry.TXAV,
         in_files=in_files,
@@ -300,7 +306,7 @@ def trav(
     TRAV: Moyenne de l'amplitude thermique.
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -365,13 +371,14 @@ def trav(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=DcscIndexRegistry.TRAV,
         in_files=in_files,
@@ -413,7 +420,7 @@ def tx10(
     TX10: Extrême froid de la température maximale journalière (10e centile de la température maximale).
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -502,13 +509,14 @@ def tx10(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=DcscIndexRegistry.TX10,
         in_files=in_files,
@@ -561,7 +569,7 @@ def tx90(
     TX90: Extrême chaud de la température maximale journalière (90e centile de la température maximale).
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -650,13 +658,14 @@ def tx90(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=DcscIndexRegistry.TX90,
         in_files=in_files,
@@ -709,7 +718,7 @@ def tn10(
     TN10: Extrême froid de la température minimale  journalière (10e centile de la température minimale).
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -798,13 +807,14 @@ def tn10(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=DcscIndexRegistry.TN10,
         in_files=in_files,
@@ -857,7 +867,7 @@ def tn90(
     TN90: Extrême chaud de la température minimale journalière (90e centile de la température minimale).
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -946,13 +956,14 @@ def tn90(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=DcscIndexRegistry.TN90,
         in_files=in_files,
@@ -1001,7 +1012,7 @@ def tnfd(
     TNFD: Nombre de jours de gel (température minimale <= 0°C).
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -1066,13 +1077,14 @@ def tnfd(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=DcscIndexRegistry.TNFD,
         in_files=in_files,
@@ -1113,7 +1125,7 @@ def txfd(
     TXFD: Nombre de jours sans dégel (température maximale <= 0°C).
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -1178,13 +1190,14 @@ def txfd(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=DcscIndexRegistry.TXFD,
         in_files=in_files,
@@ -1225,7 +1238,7 @@ def sd(
     SD: Nombre de journées d'été (température maximale > 25°C).
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -1290,13 +1303,14 @@ def sd(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=DcscIndexRegistry.SD,
         in_files=in_files,
@@ -1337,7 +1351,7 @@ def tx35(
     TX35: Nombre de jours de forte chaleur (température maximale > 35°C).
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -1402,13 +1416,14 @@ def tx35(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=DcscIndexRegistry.TX35,
         in_files=in_files,
@@ -1449,7 +1464,7 @@ def tr(
     TR: Nombre de nuits tropicales (température minimale > 20°C).
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -1514,13 +1529,14 @@ def tr(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=DcscIndexRegistry.TR,
         in_files=in_files,
@@ -1563,7 +1579,7 @@ def txnd(
     TXND: Nombre de jours anormalement chauds (température maximale supérieure de plus de 5°C à la normale).
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -1635,13 +1651,14 @@ def txnd(
     normal_var_name : str | None, optional
         The name of the normal variable.
         If missing, icclim will try to guess which variable must be used in the `normal` dataset.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
+
     standard_index = DcscIndexRegistry.TXND
     normal_da = get_dataarray_from_dataset(
         normal_var_name, normal, standard_index.input_variables[0]
@@ -1687,7 +1704,7 @@ def tnht(
     TNHT: Nombre de nuits anormalement chaudes (température minimale supérieure de plus de 5°C à la normale).
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -1759,13 +1776,14 @@ def tnht(
     normal_var_name : str | None, optional
         The name of the normal variable.
         If missing, icclim will try to guess which variable must be used in the `normal` dataset.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
+
     standard_index = DcscIndexRegistry.TNHT
     normal_da = get_dataarray_from_dataset(
         normal_var_name, normal, standard_index.input_variables[0]
@@ -1811,7 +1829,7 @@ def tnnd(
     TNND: Nombre de jours anormalement froids (température minimale inférieure de plus de 5°C à la normale).
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -1883,13 +1901,14 @@ def tnnd(
     normal_var_name : str | None, optional
         The name of the normal variable.
         If missing, icclim will try to guess which variable must be used in the `normal` dataset.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
+
     standard_index = DcscIndexRegistry.TNND
     normal_da = get_dataarray_from_dataset(
         normal_var_name, normal, standard_index.input_variables[0]
@@ -1935,7 +1954,7 @@ def tncwd(
     TNCWD: Nombre de jours d'une vague de froid (température min < de plus de 5°C à la normale pdt au moins 5j consécutifs).
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -2007,13 +2026,14 @@ def tncwd(
     normal_var_name : str | None, optional
         The name of the normal variable.
         If missing, icclim will try to guess which variable must be used in the `normal` dataset.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
+
     standard_index = DcscIndexRegistry.TNCWD
     normal_da = get_dataarray_from_dataset(
         normal_var_name, normal, standard_index.input_variables[0]
@@ -2059,7 +2079,7 @@ def txhwd(
     TXHWD: Nombre de jours d'une vague de chaleur (température max > de plus de 5°C à la normale pdt au moins 5j consécutifs).
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -2131,13 +2151,14 @@ def txhwd(
     normal_var_name : str | None, optional
         The name of the normal variable.
         If missing, icclim will try to guess which variable must be used in the `normal` dataset.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
+
     standard_index = DcscIndexRegistry.TXHWD
     normal_da = get_dataarray_from_dataset(
         normal_var_name, normal, standard_index.input_variables[0]
@@ -2181,7 +2202,7 @@ def hdd(
     HDD: Degrés-jours de chauffage (Cumul sur la période des écarts négatifs au seuil de < 17°C par la température qt moyenne).
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -2246,13 +2267,14 @@ def hdd(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=DcscIndexRegistry.HDD,
         in_files=in_files,
@@ -2293,7 +2315,7 @@ def cdd(
     CDD: Degrés-jours de climatisation(Cumul sur la période des dépassements du seuil de > 18°C par la température qt moyenne).
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -2358,13 +2380,14 @@ def cdd(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=DcscIndexRegistry.CDD,
         in_files=in_files,
@@ -2405,7 +2428,7 @@ def pav(
     PAV: Précipitations quotidiennes moyennes.
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -2470,13 +2493,14 @@ def pav(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=DcscIndexRegistry.PAV,
         in_files=in_files,
@@ -2514,7 +2538,7 @@ def pint(
     PINT: Précipitation moyenne des jours pluvieux (RR > 1 mm).
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -2579,13 +2603,14 @@ def pint(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=DcscIndexRegistry.PINT,
         in_files=in_files,
@@ -2626,7 +2651,7 @@ def rr(
     RR: Cumul de précipitation.
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -2691,13 +2716,14 @@ def rr(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=DcscIndexRegistry.RR,
         in_files=in_files,
@@ -2735,7 +2761,7 @@ def rr1mm(
     RR1MM: Nombre de jours de pluie (précipitations >= 1 mm).
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -2800,13 +2826,14 @@ def rr1mm(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=DcscIndexRegistry.RR1MM,
         in_files=in_files,
@@ -2847,7 +2874,7 @@ def pn20mm(
     PN20MM: Nombre de jours de fortes précipitations (précipitations >= 20 mm).
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -2912,13 +2939,14 @@ def pn20mm(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=DcscIndexRegistry.PN20MM,
         in_files=in_files,
@@ -2959,7 +2987,7 @@ def pxcdd(
     PXCDD: Période de sécheresse (Max [Nbj consécutifs RR < 1 mm]).
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -3024,13 +3052,14 @@ def pxcdd(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=DcscIndexRegistry.PXCDD,
         in_files=in_files,
@@ -3071,7 +3100,7 @@ def pxcwd(
     PXCWD: Nombre maximum de jours pluvieux consécutifs (Max [Nbj consécutifs RR > 1 mm]).
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -3136,13 +3165,14 @@ def pxcwd(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=DcscIndexRegistry.PXCWD,
         in_files=in_files,
@@ -3187,7 +3217,7 @@ def r99(
     R99: Nombre de jours de précipitations extrêmes.
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -3276,13 +3306,14 @@ def r99(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=DcscIndexRegistry.R99,
         in_files=in_files,
@@ -3336,7 +3367,7 @@ def pfl90(
     PFL90: Fraction des précipitations journalières intenses.
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -3425,13 +3456,14 @@ def pfl90(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=DcscIndexRegistry.PFL90,
         in_files=in_files,
@@ -3485,7 +3517,7 @@ def pq90(
     PQ90: Précipitation quotidienne intense (90e centile des précipitations).
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -3574,13 +3606,14 @@ def pq90(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=DcscIndexRegistry.PQ90,
         in_files=in_files,
@@ -3634,7 +3667,7 @@ def pq99(
     PQ99: Précipitation quotidienne extrême (99e centile des précipitations).
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -3723,13 +3756,14 @@ def pq99(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=DcscIndexRegistry.PQ99,
         in_files=in_files,
@@ -3780,7 +3814,7 @@ def ffav(
     FFAV: Écart de la vitesse du vent moyenne journalière (par rapport à une periode de référence).
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -3859,13 +3893,14 @@ def ffav(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=DcscIndexRegistry.FFAV,
         in_files=in_files,
@@ -3908,7 +3943,7 @@ def ff98(
     FF98: Nombre de jours de vent fort (vent ≥ 98e centile de la période de référence).
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -3997,13 +4032,14 @@ def ff98(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=DcscIndexRegistry.FF98,
         in_files=in_files,

--- a/src/icclim/_generated/_dcsc.py
+++ b/src/icclim/_generated/_dcsc.py
@@ -21,11 +21,7 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from icclim.logger import Verbosity
-    from icclim._core.model.icclim_types import (
-        FrequencyLike,
-        InFileLike,
-        SamplingMethodLike,
-    )
+    from icclim._core.model.icclim_types import FrequencyLike, InFileLike, SamplingMethodLike
     from icclim.frequency import Frequency
     from icclim._core.model.netcdf_version import NetcdfVersion
     from icclim._core.model.quantile_interpolation import QuantileInterpolation
@@ -73,7 +69,7 @@ def tav(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -86,7 +82,7 @@ def tav(
     TAV: Moyenne de la température moyenne.
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -97,7 +93,7 @@ def tav(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -110,24 +106,25 @@ def tav(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -142,7 +139,7 @@ def tav(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -150,14 +147,13 @@ def tav(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=DcscIndexRegistry.TAV,
         in_files=in_files,
@@ -182,7 +178,7 @@ def txav(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -195,7 +191,7 @@ def txav(
     TXAV: Moyenne de la température maximale.
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -206,7 +202,7 @@ def txav(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -219,24 +215,25 @@ def txav(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -251,7 +248,7 @@ def txav(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -259,14 +256,13 @@ def txav(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=DcscIndexRegistry.TXAV,
         in_files=in_files,
@@ -291,7 +287,7 @@ def trav(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -304,7 +300,7 @@ def trav(
     TRAV: Moyenne de l'amplitude thermique.
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -315,7 +311,7 @@ def trav(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -328,24 +324,25 @@ def trav(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -360,7 +357,7 @@ def trav(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -368,14 +365,13 @@ def trav(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=DcscIndexRegistry.TRAV,
         in_files=in_files,
@@ -401,7 +397,7 @@ def tx10(
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
     base_period_time_range: Sequence[dt.datetime] | Sequence[str] | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     only_leap_years: bool = False,
     ignore_Feb29th: bool = False,
     interpolation: str | QuantileInterpolation = "median_unbiased",
@@ -417,7 +413,7 @@ def tx10(
     TX10: Extrême froid de la température maximale journalière (10e centile de la température maximale).
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -428,7 +424,7 @@ def tx10(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -441,13 +437,13 @@ def tx10(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
@@ -467,12 +463,13 @@ def tx10(
         bootstrapped.
         #. to compute a reference period for indices such as difference_of_mean
         (a.k.a anomaly) if a single variable is given in input.
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -480,7 +477,7 @@ def tx10(
         ``optional`` Option for February 29th (default: False).
     ignore_Feb29th : bool
         ``optional`` Ignoring or not February 29th (default: False).
-    interpolation : str | QuantileInterpolation | None, default="median_unbiased"
+    interpolation : str | QuantileInterpolation | None
         ``optional`` Interpolation method to compute percentile values:
         ``{"linear", "median_unbiased"}``
         Default is "median_unbiased", a.k.a type 8 or method 8.
@@ -497,7 +494,7 @@ def tx10(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -505,14 +502,13 @@ def tx10(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=DcscIndexRegistry.TX10,
         in_files=in_files,
@@ -549,7 +545,7 @@ def tx90(
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
     base_period_time_range: Sequence[dt.datetime] | Sequence[str] | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     only_leap_years: bool = False,
     ignore_Feb29th: bool = False,
     interpolation: str | QuantileInterpolation = "median_unbiased",
@@ -565,7 +561,7 @@ def tx90(
     TX90: Extrême chaud de la température maximale journalière (90e centile de la température maximale).
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -576,7 +572,7 @@ def tx90(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -589,13 +585,13 @@ def tx90(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
@@ -615,12 +611,13 @@ def tx90(
         bootstrapped.
         #. to compute a reference period for indices such as difference_of_mean
         (a.k.a anomaly) if a single variable is given in input.
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -628,7 +625,7 @@ def tx90(
         ``optional`` Option for February 29th (default: False).
     ignore_Feb29th : bool
         ``optional`` Ignoring or not February 29th (default: False).
-    interpolation : str | QuantileInterpolation | None, default="median_unbiased"
+    interpolation : str | QuantileInterpolation | None
         ``optional`` Interpolation method to compute percentile values:
         ``{"linear", "median_unbiased"}``
         Default is "median_unbiased", a.k.a type 8 or method 8.
@@ -645,7 +642,7 @@ def tx90(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -653,14 +650,13 @@ def tx90(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=DcscIndexRegistry.TX90,
         in_files=in_files,
@@ -697,7 +693,7 @@ def tn10(
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
     base_period_time_range: Sequence[dt.datetime] | Sequence[str] | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     only_leap_years: bool = False,
     ignore_Feb29th: bool = False,
     interpolation: str | QuantileInterpolation = "median_unbiased",
@@ -713,7 +709,7 @@ def tn10(
     TN10: Extrême froid de la température minimale  journalière (10e centile de la température minimale).
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -724,7 +720,7 @@ def tn10(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -737,13 +733,13 @@ def tn10(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
@@ -763,12 +759,13 @@ def tn10(
         bootstrapped.
         #. to compute a reference period for indices such as difference_of_mean
         (a.k.a anomaly) if a single variable is given in input.
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -776,7 +773,7 @@ def tn10(
         ``optional`` Option for February 29th (default: False).
     ignore_Feb29th : bool
         ``optional`` Ignoring or not February 29th (default: False).
-    interpolation : str | QuantileInterpolation | None, default="median_unbiased"
+    interpolation : str | QuantileInterpolation | None
         ``optional`` Interpolation method to compute percentile values:
         ``{"linear", "median_unbiased"}``
         Default is "median_unbiased", a.k.a type 8 or method 8.
@@ -793,7 +790,7 @@ def tn10(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -801,14 +798,13 @@ def tn10(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=DcscIndexRegistry.TN10,
         in_files=in_files,
@@ -845,7 +841,7 @@ def tn90(
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
     base_period_time_range: Sequence[dt.datetime] | Sequence[str] | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     only_leap_years: bool = False,
     ignore_Feb29th: bool = False,
     interpolation: str | QuantileInterpolation = "median_unbiased",
@@ -861,7 +857,7 @@ def tn90(
     TN90: Extrême chaud de la température minimale journalière (90e centile de la température minimale).
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -872,7 +868,7 @@ def tn90(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -885,13 +881,13 @@ def tn90(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
@@ -911,12 +907,13 @@ def tn90(
         bootstrapped.
         #. to compute a reference period for indices such as difference_of_mean
         (a.k.a anomaly) if a single variable is given in input.
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -924,7 +921,7 @@ def tn90(
         ``optional`` Option for February 29th (default: False).
     ignore_Feb29th : bool
         ``optional`` Ignoring or not February 29th (default: False).
-    interpolation : str | QuantileInterpolation | None, default="median_unbiased"
+    interpolation : str | QuantileInterpolation | None
         ``optional`` Interpolation method to compute percentile values:
         ``{"linear", "median_unbiased"}``
         Default is "median_unbiased", a.k.a type 8 or method 8.
@@ -941,7 +938,7 @@ def tn90(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -949,14 +946,13 @@ def tn90(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=DcscIndexRegistry.TN90,
         in_files=in_files,
@@ -992,7 +988,7 @@ def tnfd(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -1005,7 +1001,7 @@ def tnfd(
     TNFD: Nombre de jours de gel (température minimale <= 0°C).
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -1016,7 +1012,7 @@ def tnfd(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -1029,24 +1025,25 @@ def tnfd(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -1061,7 +1058,7 @@ def tnfd(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -1069,14 +1066,13 @@ def tnfd(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=DcscIndexRegistry.TNFD,
         in_files=in_files,
@@ -1104,7 +1100,7 @@ def txfd(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -1117,7 +1113,7 @@ def txfd(
     TXFD: Nombre de jours sans dégel (température maximale <= 0°C).
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -1128,7 +1124,7 @@ def txfd(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -1141,24 +1137,25 @@ def txfd(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -1173,7 +1170,7 @@ def txfd(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -1181,14 +1178,13 @@ def txfd(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=DcscIndexRegistry.TXFD,
         in_files=in_files,
@@ -1216,7 +1212,7 @@ def sd(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -1229,7 +1225,7 @@ def sd(
     SD: Nombre de journées d'été (température maximale > 25°C).
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -1240,7 +1236,7 @@ def sd(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -1253,24 +1249,25 @@ def sd(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -1285,7 +1282,7 @@ def sd(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -1293,14 +1290,13 @@ def sd(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=DcscIndexRegistry.SD,
         in_files=in_files,
@@ -1328,7 +1324,7 @@ def tx35(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -1341,7 +1337,7 @@ def tx35(
     TX35: Nombre de jours de forte chaleur (température maximale > 35°C).
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -1352,7 +1348,7 @@ def tx35(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -1365,24 +1361,25 @@ def tx35(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -1397,7 +1394,7 @@ def tx35(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -1405,14 +1402,13 @@ def tx35(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=DcscIndexRegistry.TX35,
         in_files=in_files,
@@ -1440,7 +1436,7 @@ def tr(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -1453,7 +1449,7 @@ def tr(
     TR: Nombre de nuits tropicales (température minimale > 20°C).
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -1464,7 +1460,7 @@ def tr(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -1477,24 +1473,25 @@ def tr(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -1509,7 +1506,7 @@ def tr(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -1517,14 +1514,13 @@ def tr(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=DcscIndexRegistry.TR,
         in_files=in_files,
@@ -1553,7 +1549,7 @@ def txnd(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -1567,7 +1563,7 @@ def txnd(
     TXND: Nombre de jours anormalement chauds (température maximale supérieure de plus de 5°C à la normale).
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -1578,7 +1574,7 @@ def txnd(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -1591,24 +1587,25 @@ def txnd(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -1623,7 +1620,7 @@ def txnd(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -1638,14 +1635,13 @@ def txnd(
     normal_var_name : str | None, optional
         The name of the normal variable.
         If missing, icclim will try to guess which variable must be used in the `normal` dataset.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
-
     standard_index = DcscIndexRegistry.TXND
     normal_da = get_dataarray_from_dataset(
         normal_var_name, normal, standard_index.input_variables[0]
@@ -1677,7 +1673,7 @@ def tnht(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -1691,7 +1687,7 @@ def tnht(
     TNHT: Nombre de nuits anormalement chaudes (température minimale supérieure de plus de 5°C à la normale).
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -1702,7 +1698,7 @@ def tnht(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -1715,24 +1711,25 @@ def tnht(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -1747,7 +1744,7 @@ def tnht(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -1762,14 +1759,13 @@ def tnht(
     normal_var_name : str | None, optional
         The name of the normal variable.
         If missing, icclim will try to guess which variable must be used in the `normal` dataset.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
-
     standard_index = DcscIndexRegistry.TNHT
     normal_da = get_dataarray_from_dataset(
         normal_var_name, normal, standard_index.input_variables[0]
@@ -1801,7 +1797,7 @@ def tnnd(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -1815,7 +1811,7 @@ def tnnd(
     TNND: Nombre de jours anormalement froids (température minimale inférieure de plus de 5°C à la normale).
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -1826,7 +1822,7 @@ def tnnd(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -1839,24 +1835,25 @@ def tnnd(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -1871,7 +1868,7 @@ def tnnd(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -1886,14 +1883,13 @@ def tnnd(
     normal_var_name : str | None, optional
         The name of the normal variable.
         If missing, icclim will try to guess which variable must be used in the `normal` dataset.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
-
     standard_index = DcscIndexRegistry.TNND
     normal_da = get_dataarray_from_dataset(
         normal_var_name, normal, standard_index.input_variables[0]
@@ -1925,7 +1921,7 @@ def tncwd(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -1939,7 +1935,7 @@ def tncwd(
     TNCWD: Nombre de jours d'une vague de froid (température min < de plus de 5°C à la normale pdt au moins 5j consécutifs).
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -1950,7 +1946,7 @@ def tncwd(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -1963,24 +1959,25 @@ def tncwd(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -1995,7 +1992,7 @@ def tncwd(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -2010,14 +2007,13 @@ def tncwd(
     normal_var_name : str | None, optional
         The name of the normal variable.
         If missing, icclim will try to guess which variable must be used in the `normal` dataset.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
-
     standard_index = DcscIndexRegistry.TNCWD
     normal_da = get_dataarray_from_dataset(
         normal_var_name, normal, standard_index.input_variables[0]
@@ -2049,7 +2045,7 @@ def txhwd(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -2063,7 +2059,7 @@ def txhwd(
     TXHWD: Nombre de jours d'une vague de chaleur (température max > de plus de 5°C à la normale pdt au moins 5j consécutifs).
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -2074,7 +2070,7 @@ def txhwd(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -2087,24 +2083,25 @@ def txhwd(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -2119,7 +2116,7 @@ def txhwd(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -2134,14 +2131,13 @@ def txhwd(
     normal_var_name : str | None, optional
         The name of the normal variable.
         If missing, icclim will try to guess which variable must be used in the `normal` dataset.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
-
     standard_index = DcscIndexRegistry.TXHWD
     normal_da = get_dataarray_from_dataset(
         normal_var_name, normal, standard_index.input_variables[0]
@@ -2172,7 +2168,7 @@ def hdd(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -2185,7 +2181,7 @@ def hdd(
     HDD: Degrés-jours de chauffage (Cumul sur la période des écarts négatifs au seuil de < 17°C par la température qt moyenne).
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -2196,7 +2192,7 @@ def hdd(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -2209,24 +2205,25 @@ def hdd(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -2241,7 +2238,7 @@ def hdd(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -2249,14 +2246,13 @@ def hdd(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=DcscIndexRegistry.HDD,
         in_files=in_files,
@@ -2284,7 +2280,7 @@ def cdd(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -2297,7 +2293,7 @@ def cdd(
     CDD: Degrés-jours de climatisation(Cumul sur la période des dépassements du seuil de > 18°C par la température qt moyenne).
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -2308,7 +2304,7 @@ def cdd(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -2321,24 +2317,25 @@ def cdd(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -2353,7 +2350,7 @@ def cdd(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -2361,14 +2358,13 @@ def cdd(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=DcscIndexRegistry.CDD,
         in_files=in_files,
@@ -2396,7 +2392,7 @@ def pav(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -2409,7 +2405,7 @@ def pav(
     PAV: Précipitations quotidiennes moyennes.
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -2420,7 +2416,7 @@ def pav(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -2433,24 +2429,25 @@ def pav(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -2465,7 +2462,7 @@ def pav(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -2473,14 +2470,13 @@ def pav(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=DcscIndexRegistry.PAV,
         in_files=in_files,
@@ -2505,7 +2501,7 @@ def pint(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -2518,7 +2514,7 @@ def pint(
     PINT: Précipitation moyenne des jours pluvieux (RR > 1 mm).
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -2529,7 +2525,7 @@ def pint(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -2542,24 +2538,25 @@ def pint(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -2574,7 +2571,7 @@ def pint(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -2582,14 +2579,13 @@ def pint(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=DcscIndexRegistry.PINT,
         in_files=in_files,
@@ -2617,7 +2613,7 @@ def rr(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -2630,7 +2626,7 @@ def rr(
     RR: Cumul de précipitation.
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -2641,7 +2637,7 @@ def rr(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -2654,24 +2650,25 @@ def rr(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -2686,7 +2683,7 @@ def rr(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -2694,14 +2691,13 @@ def rr(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=DcscIndexRegistry.RR,
         in_files=in_files,
@@ -2726,7 +2722,7 @@ def rr1mm(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -2739,7 +2735,7 @@ def rr1mm(
     RR1MM: Nombre de jours de pluie (précipitations >= 1 mm).
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -2750,7 +2746,7 @@ def rr1mm(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -2763,24 +2759,25 @@ def rr1mm(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -2795,7 +2792,7 @@ def rr1mm(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -2803,14 +2800,13 @@ def rr1mm(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=DcscIndexRegistry.RR1MM,
         in_files=in_files,
@@ -2838,7 +2834,7 @@ def pn20mm(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -2851,7 +2847,7 @@ def pn20mm(
     PN20MM: Nombre de jours de fortes précipitations (précipitations >= 20 mm).
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -2862,7 +2858,7 @@ def pn20mm(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -2875,24 +2871,25 @@ def pn20mm(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -2907,7 +2904,7 @@ def pn20mm(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -2915,14 +2912,13 @@ def pn20mm(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=DcscIndexRegistry.PN20MM,
         in_files=in_files,
@@ -2950,7 +2946,7 @@ def pxcdd(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -2963,7 +2959,7 @@ def pxcdd(
     PXCDD: Période de sécheresse (Max [Nbj consécutifs RR < 1 mm]).
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -2974,7 +2970,7 @@ def pxcdd(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -2987,24 +2983,25 @@ def pxcdd(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -3019,7 +3016,7 @@ def pxcdd(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -3027,14 +3024,13 @@ def pxcdd(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=DcscIndexRegistry.PXCDD,
         in_files=in_files,
@@ -3062,7 +3058,7 @@ def pxcwd(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -3075,7 +3071,7 @@ def pxcwd(
     PXCWD: Nombre maximum de jours pluvieux consécutifs (Max [Nbj consécutifs RR > 1 mm]).
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -3086,7 +3082,7 @@ def pxcwd(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -3099,24 +3095,25 @@ def pxcwd(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -3131,7 +3128,7 @@ def pxcwd(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -3139,14 +3136,13 @@ def pxcwd(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=DcscIndexRegistry.PXCWD,
         in_files=in_files,
@@ -3175,7 +3171,7 @@ def r99(
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
     base_period_time_range: Sequence[dt.datetime] | Sequence[str] | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     only_leap_years: bool = False,
     ignore_Feb29th: bool = False,
     interpolation: str | QuantileInterpolation = "median_unbiased",
@@ -3191,7 +3187,7 @@ def r99(
     R99: Nombre de jours de précipitations extrêmes.
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -3202,7 +3198,7 @@ def r99(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -3215,13 +3211,13 @@ def r99(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
@@ -3241,12 +3237,13 @@ def r99(
         bootstrapped.
         #. to compute a reference period for indices such as difference_of_mean
         (a.k.a anomaly) if a single variable is given in input.
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -3254,7 +3251,7 @@ def r99(
         ``optional`` Option for February 29th (default: False).
     ignore_Feb29th : bool
         ``optional`` Ignoring or not February 29th (default: False).
-    interpolation : str | QuantileInterpolation | None, default="median_unbiased"
+    interpolation : str | QuantileInterpolation | None
         ``optional`` Interpolation method to compute percentile values:
         ``{"linear", "median_unbiased"}``
         Default is "median_unbiased", a.k.a type 8 or method 8.
@@ -3271,7 +3268,7 @@ def r99(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -3279,14 +3276,13 @@ def r99(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=DcscIndexRegistry.R99,
         in_files=in_files,
@@ -3324,7 +3320,7 @@ def pfl90(
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
     base_period_time_range: Sequence[dt.datetime] | Sequence[str] | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     only_leap_years: bool = False,
     ignore_Feb29th: bool = False,
     interpolation: str | QuantileInterpolation = "median_unbiased",
@@ -3340,7 +3336,7 @@ def pfl90(
     PFL90: Fraction des précipitations journalières intenses.
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -3351,7 +3347,7 @@ def pfl90(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -3364,13 +3360,13 @@ def pfl90(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
@@ -3390,12 +3386,13 @@ def pfl90(
         bootstrapped.
         #. to compute a reference period for indices such as difference_of_mean
         (a.k.a anomaly) if a single variable is given in input.
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -3403,7 +3400,7 @@ def pfl90(
         ``optional`` Option for February 29th (default: False).
     ignore_Feb29th : bool
         ``optional`` Ignoring or not February 29th (default: False).
-    interpolation : str | QuantileInterpolation | None, default="median_unbiased"
+    interpolation : str | QuantileInterpolation | None
         ``optional`` Interpolation method to compute percentile values:
         ``{"linear", "median_unbiased"}``
         Default is "median_unbiased", a.k.a type 8 or method 8.
@@ -3420,7 +3417,7 @@ def pfl90(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -3428,14 +3425,13 @@ def pfl90(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=DcscIndexRegistry.PFL90,
         in_files=in_files,
@@ -3473,7 +3469,7 @@ def pq90(
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
     base_period_time_range: Sequence[dt.datetime] | Sequence[str] | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     only_leap_years: bool = False,
     ignore_Feb29th: bool = False,
     interpolation: str | QuantileInterpolation = "median_unbiased",
@@ -3489,7 +3485,7 @@ def pq90(
     PQ90: Précipitation quotidienne intense (90e centile des précipitations).
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -3500,7 +3496,7 @@ def pq90(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -3513,13 +3509,13 @@ def pq90(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
@@ -3539,12 +3535,13 @@ def pq90(
         bootstrapped.
         #. to compute a reference period for indices such as difference_of_mean
         (a.k.a anomaly) if a single variable is given in input.
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -3552,7 +3549,7 @@ def pq90(
         ``optional`` Option for February 29th (default: False).
     ignore_Feb29th : bool
         ``optional`` Ignoring or not February 29th (default: False).
-    interpolation : str | QuantileInterpolation | None, default="median_unbiased"
+    interpolation : str | QuantileInterpolation | None
         ``optional`` Interpolation method to compute percentile values:
         ``{"linear", "median_unbiased"}``
         Default is "median_unbiased", a.k.a type 8 or method 8.
@@ -3569,7 +3566,7 @@ def pq90(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -3577,14 +3574,13 @@ def pq90(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=DcscIndexRegistry.PQ90,
         in_files=in_files,
@@ -3622,7 +3618,7 @@ def pq99(
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
     base_period_time_range: Sequence[dt.datetime] | Sequence[str] | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     only_leap_years: bool = False,
     ignore_Feb29th: bool = False,
     interpolation: str | QuantileInterpolation = "median_unbiased",
@@ -3638,7 +3634,7 @@ def pq99(
     PQ99: Précipitation quotidienne extrême (99e centile des précipitations).
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -3649,7 +3645,7 @@ def pq99(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -3662,13 +3658,13 @@ def pq99(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
@@ -3688,12 +3684,13 @@ def pq99(
         bootstrapped.
         #. to compute a reference period for indices such as difference_of_mean
         (a.k.a anomaly) if a single variable is given in input.
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -3701,7 +3698,7 @@ def pq99(
         ``optional`` Option for February 29th (default: False).
     ignore_Feb29th : bool
         ``optional`` Ignoring or not February 29th (default: False).
-    interpolation : str | QuantileInterpolation | None, default="median_unbiased"
+    interpolation : str | QuantileInterpolation | None
         ``optional`` Interpolation method to compute percentile values:
         ``{"linear", "median_unbiased"}``
         Default is "median_unbiased", a.k.a type 8 or method 8.
@@ -3718,7 +3715,7 @@ def pq99(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -3726,14 +3723,13 @@ def pq99(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=DcscIndexRegistry.PQ99,
         in_files=in_files,
@@ -3771,7 +3767,7 @@ def ffav(
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
     base_period_time_range: Sequence[dt.datetime] | Sequence[str] | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -3784,7 +3780,7 @@ def ffav(
     FFAV: Écart de la vitesse du vent moyenne journalière (par rapport à une periode de référence).
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -3795,7 +3791,7 @@ def ffav(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -3808,13 +3804,13 @@ def ffav(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
@@ -3834,12 +3830,13 @@ def ffav(
         bootstrapped.
         #. to compute a reference period for indices such as difference_of_mean
         (a.k.a anomaly) if a single variable is given in input.
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -3854,7 +3851,7 @@ def ffav(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -3862,14 +3859,13 @@ def ffav(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=DcscIndexRegistry.FFAV,
         in_files=in_files,
@@ -3896,7 +3892,7 @@ def ff98(
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
     base_period_time_range: Sequence[dt.datetime] | Sequence[str] | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     only_leap_years: bool = False,
     ignore_Feb29th: bool = False,
     interpolation: str | QuantileInterpolation = "median_unbiased",
@@ -3912,7 +3908,7 @@ def ff98(
     FF98: Nombre de jours de vent fort (vent ≥ 98e centile de la période de référence).
     Source: Portail DRIAS, DCSC, MeteoFrance.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -3923,7 +3919,7 @@ def ff98(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -3936,13 +3932,13 @@ def ff98(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
@@ -3962,12 +3958,13 @@ def ff98(
         bootstrapped.
         #. to compute a reference period for indices such as difference_of_mean
         (a.k.a anomaly) if a single variable is given in input.
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -3975,7 +3972,7 @@ def ff98(
         ``optional`` Option for February 29th (default: False).
     ignore_Feb29th : bool
         ``optional`` Ignoring or not February 29th (default: False).
-    interpolation : str | QuantileInterpolation | None, default="median_unbiased"
+    interpolation : str | QuantileInterpolation | None
         ``optional`` Interpolation method to compute percentile values:
         ``{"linear", "median_unbiased"}``
         Default is "median_unbiased", a.k.a type 8 or method 8.
@@ -3992,7 +3989,7 @@ def ff98(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -4000,14 +3997,13 @@ def ff98(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.dcsc.registry import DcscIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=DcscIndexRegistry.FF98,
         in_files=in_files,

--- a/src/icclim/_generated/_ecad.py
+++ b/src/icclim/_generated/_ecad.py
@@ -158,8 +158,14 @@ def tg(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -268,8 +274,14 @@ def tn(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -378,8 +390,14 @@ def tx(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -488,8 +506,14 @@ def dtr(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -598,8 +622,14 @@ def etr(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -708,8 +738,14 @@ def vdtr(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -818,8 +854,14 @@ def su(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -931,8 +973,14 @@ def tr(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -1062,8 +1110,14 @@ def wsdi(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -1211,8 +1265,14 @@ def tg90p(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -1360,8 +1420,14 @@ def tn90p(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -1509,8 +1575,14 @@ def tx90p(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -1640,8 +1712,14 @@ def txx(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -1750,8 +1828,14 @@ def tnx(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -1860,8 +1944,14 @@ def csu(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -1973,8 +2063,14 @@ def gd4(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -2086,8 +2182,14 @@ def fd(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -2199,8 +2301,14 @@ def cfd(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -2312,8 +2420,14 @@ def hd17(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -2425,8 +2539,14 @@ def id(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -2556,8 +2676,14 @@ def tg10p(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -2705,8 +2831,14 @@ def tn10p(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -2854,8 +2986,14 @@ def tx10p(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -2985,8 +3123,14 @@ def txn(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -3095,8 +3239,14 @@ def tnn(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -3223,8 +3373,14 @@ def csdi(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -3354,8 +3510,14 @@ def cdd(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -3467,8 +3629,14 @@ def prcptot(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -3580,8 +3748,14 @@ def rr1(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -3693,8 +3867,14 @@ def sdii(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -3806,8 +3986,14 @@ def cwd(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -3919,8 +4105,14 @@ def rr(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -4029,8 +4221,14 @@ def r10mm(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -4142,8 +4340,14 @@ def r20mm(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -4255,8 +4459,14 @@ def rx1day(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -4365,8 +4575,14 @@ def rx5day(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -4493,8 +4709,14 @@ def r75p(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -4635,8 +4857,14 @@ def r75ptot(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -4777,8 +5005,14 @@ def r95p(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -4919,8 +5153,14 @@ def r95ptot(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -5061,8 +5301,14 @@ def r99p(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -5203,8 +5449,14 @@ def r99ptot(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -5327,8 +5579,14 @@ def sd(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -5437,8 +5695,14 @@ def sd1(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -5550,8 +5814,14 @@ def sd5cm(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -5663,8 +5933,14 @@ def sd50cm(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -5794,8 +6070,14 @@ def cd(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -5949,8 +6231,14 @@ def cw(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -6104,8 +6392,14 @@ def wd(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -6259,8 +6553,14 @@ def ww(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -6396,8 +6696,14 @@ def fxx(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -6506,8 +6812,14 @@ def fg6bft(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -6619,8 +6931,14 @@ def fgcalm(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -6732,8 +7050,14 @@ def fg(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -6842,8 +7166,14 @@ def ddnorth(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -6955,8 +7285,14 @@ def ddeast(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -7068,8 +7404,14 @@ def ddsouth(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -7181,8 +7523,14 @@ def ddwest(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -7294,8 +7642,14 @@ def gsl(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -7419,8 +7773,14 @@ def spi6(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -7545,8 +7905,14 @@ def spi3(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -7656,8 +8022,14 @@ def pp(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -7766,8 +8138,14 @@ def ss(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -7876,8 +8254,14 @@ def rh(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".

--- a/src/icclim/_generated/_ecad.py
+++ b/src/icclim/_generated/_ecad.py
@@ -21,11 +21,7 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from icclim.logger import Verbosity
-    from icclim._core.model.icclim_types import (
-        FrequencyLike,
-        InFileLike,
-        SamplingMethodLike,
-    )
+    from icclim._core.model.icclim_types import FrequencyLike, InFileLike, SamplingMethodLike
     from icclim.frequency import Frequency
     from icclim._core.model.netcdf_version import NetcdfVersion
     from icclim._core.model.quantile_interpolation import QuantileInterpolation
@@ -105,7 +101,7 @@ def tg(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -118,7 +114,7 @@ def tg(
     TG: Mean of daily mean temperature.
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -129,7 +125,7 @@ def tg(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -142,24 +138,25 @@ def tg(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -174,7 +171,7 @@ def tg(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -182,14 +179,13 @@ def tg(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.TG,
         in_files=in_files,
@@ -214,7 +210,7 @@ def tn(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -227,7 +223,7 @@ def tn(
     TN: Mean of daily minimum temperature.
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -238,7 +234,7 @@ def tn(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -251,24 +247,25 @@ def tn(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -283,7 +280,7 @@ def tn(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -291,14 +288,13 @@ def tn(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.TN,
         in_files=in_files,
@@ -323,7 +319,7 @@ def tx(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -336,7 +332,7 @@ def tx(
     TX: Mean of daily maximum temperature.
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -347,7 +343,7 @@ def tx(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -360,24 +356,25 @@ def tx(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -392,7 +389,7 @@ def tx(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -400,14 +397,13 @@ def tx(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.TX,
         in_files=in_files,
@@ -432,7 +428,7 @@ def dtr(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -445,7 +441,7 @@ def dtr(
     DTR: Mean Diurnal Temperature Range.
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -456,7 +452,7 @@ def dtr(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -469,24 +465,25 @@ def dtr(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -501,7 +498,7 @@ def dtr(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -509,14 +506,13 @@ def dtr(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.DTR,
         in_files=in_files,
@@ -541,7 +537,7 @@ def etr(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -554,7 +550,7 @@ def etr(
     ETR: Intra-period extreme temperature range.
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -565,7 +561,7 @@ def etr(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -578,24 +574,25 @@ def etr(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -610,7 +607,7 @@ def etr(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -618,14 +615,13 @@ def etr(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.ETR,
         in_files=in_files,
@@ -650,7 +646,7 @@ def vdtr(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -663,7 +659,7 @@ def vdtr(
     vDTR: Mean day-to-day variation in Diurnal Temperature Range.
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -674,7 +670,7 @@ def vdtr(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -687,24 +683,25 @@ def vdtr(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -719,7 +716,7 @@ def vdtr(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -727,14 +724,13 @@ def vdtr(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.VDTR,
         in_files=in_files,
@@ -759,7 +755,7 @@ def su(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -772,7 +768,7 @@ def su(
     SU: Number of Summer Days (Tmax > 25C).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -783,7 +779,7 @@ def su(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -796,24 +792,25 @@ def su(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -828,7 +825,7 @@ def su(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -836,14 +833,13 @@ def su(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.SU,
         in_files=in_files,
@@ -871,7 +867,7 @@ def tr(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -884,7 +880,7 @@ def tr(
     TR: Number of Tropical Nights (Tmin > 20C).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -895,7 +891,7 @@ def tr(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -908,24 +904,25 @@ def tr(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -940,7 +937,7 @@ def tr(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -948,14 +945,13 @@ def tr(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.TR,
         in_files=in_files,
@@ -984,7 +980,7 @@ def wsdi(
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
     base_period_time_range: Sequence[dt.datetime] | Sequence[str] | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     only_leap_years: bool = False,
     ignore_Feb29th: bool = False,
     interpolation: str | QuantileInterpolation = "median_unbiased",
@@ -1000,7 +996,7 @@ def wsdi(
     WSDI: Warm-spell duration index (days).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -1011,7 +1007,7 @@ def wsdi(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -1024,13 +1020,13 @@ def wsdi(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
@@ -1050,12 +1046,13 @@ def wsdi(
         bootstrapped.
         #. to compute a reference period for indices such as difference_of_mean
         (a.k.a anomaly) if a single variable is given in input.
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -1063,7 +1060,7 @@ def wsdi(
         ``optional`` Option for February 29th (default: False).
     ignore_Feb29th : bool
         ``optional`` Ignoring or not February 29th (default: False).
-    interpolation : str | QuantileInterpolation | None, default="median_unbiased"
+    interpolation : str | QuantileInterpolation | None
         ``optional`` Interpolation method to compute percentile values:
         ``{"linear", "median_unbiased"}``
         Default is "median_unbiased", a.k.a type 8 or method 8.
@@ -1080,7 +1077,7 @@ def wsdi(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -1088,14 +1085,13 @@ def wsdi(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.WSDI,
         in_files=in_files,
@@ -1132,7 +1128,7 @@ def tg90p(
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
     base_period_time_range: Sequence[dt.datetime] | Sequence[str] | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     only_leap_years: bool = False,
     ignore_Feb29th: bool = False,
     interpolation: str | QuantileInterpolation = "median_unbiased",
@@ -1148,7 +1144,7 @@ def tg90p(
     TG90p: Days when Tmean > 90th percentile.
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -1159,7 +1155,7 @@ def tg90p(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -1172,13 +1168,13 @@ def tg90p(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
@@ -1198,12 +1194,13 @@ def tg90p(
         bootstrapped.
         #. to compute a reference period for indices such as difference_of_mean
         (a.k.a anomaly) if a single variable is given in input.
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -1211,7 +1208,7 @@ def tg90p(
         ``optional`` Option for February 29th (default: False).
     ignore_Feb29th : bool
         ``optional`` Ignoring or not February 29th (default: False).
-    interpolation : str | QuantileInterpolation | None, default="median_unbiased"
+    interpolation : str | QuantileInterpolation | None
         ``optional`` Interpolation method to compute percentile values:
         ``{"linear", "median_unbiased"}``
         Default is "median_unbiased", a.k.a type 8 or method 8.
@@ -1228,7 +1225,7 @@ def tg90p(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -1236,14 +1233,13 @@ def tg90p(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.TG90P,
         in_files=in_files,
@@ -1280,7 +1276,7 @@ def tn90p(
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
     base_period_time_range: Sequence[dt.datetime] | Sequence[str] | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     only_leap_years: bool = False,
     ignore_Feb29th: bool = False,
     interpolation: str | QuantileInterpolation = "median_unbiased",
@@ -1296,7 +1292,7 @@ def tn90p(
     TN90p: Days when Tmin > 90th percentile.
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -1307,7 +1303,7 @@ def tn90p(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -1320,13 +1316,13 @@ def tn90p(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
@@ -1346,12 +1342,13 @@ def tn90p(
         bootstrapped.
         #. to compute a reference period for indices such as difference_of_mean
         (a.k.a anomaly) if a single variable is given in input.
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -1359,7 +1356,7 @@ def tn90p(
         ``optional`` Option for February 29th (default: False).
     ignore_Feb29th : bool
         ``optional`` Ignoring or not February 29th (default: False).
-    interpolation : str | QuantileInterpolation | None, default="median_unbiased"
+    interpolation : str | QuantileInterpolation | None
         ``optional`` Interpolation method to compute percentile values:
         ``{"linear", "median_unbiased"}``
         Default is "median_unbiased", a.k.a type 8 or method 8.
@@ -1376,7 +1373,7 @@ def tn90p(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -1384,14 +1381,13 @@ def tn90p(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.TN90P,
         in_files=in_files,
@@ -1428,7 +1424,7 @@ def tx90p(
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
     base_period_time_range: Sequence[dt.datetime] | Sequence[str] | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     only_leap_years: bool = False,
     ignore_Feb29th: bool = False,
     interpolation: str | QuantileInterpolation = "median_unbiased",
@@ -1444,7 +1440,7 @@ def tx90p(
     TX90p: Days when Tmax > 90th daily percentile.
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -1455,7 +1451,7 @@ def tx90p(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -1468,13 +1464,13 @@ def tx90p(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
@@ -1494,12 +1490,13 @@ def tx90p(
         bootstrapped.
         #. to compute a reference period for indices such as difference_of_mean
         (a.k.a anomaly) if a single variable is given in input.
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -1507,7 +1504,7 @@ def tx90p(
         ``optional`` Option for February 29th (default: False).
     ignore_Feb29th : bool
         ``optional`` Ignoring or not February 29th (default: False).
-    interpolation : str | QuantileInterpolation | None, default="median_unbiased"
+    interpolation : str | QuantileInterpolation | None
         ``optional`` Interpolation method to compute percentile values:
         ``{"linear", "median_unbiased"}``
         Default is "median_unbiased", a.k.a type 8 or method 8.
@@ -1524,7 +1521,7 @@ def tx90p(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -1532,14 +1529,13 @@ def tx90p(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.TX90P,
         in_files=in_files,
@@ -1575,7 +1571,7 @@ def txx(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -1588,7 +1584,7 @@ def txx(
     TXx: Maximum daily maximum temperature.
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -1599,7 +1595,7 @@ def txx(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -1612,24 +1608,25 @@ def txx(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -1644,7 +1641,7 @@ def txx(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -1652,14 +1649,13 @@ def txx(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.TXX,
         in_files=in_files,
@@ -1684,7 +1680,7 @@ def tnx(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -1697,7 +1693,7 @@ def tnx(
     TNx: Maximum daily minimum temperature.
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -1708,7 +1704,7 @@ def tnx(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -1721,24 +1717,25 @@ def tnx(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -1753,7 +1750,7 @@ def tnx(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -1761,14 +1758,13 @@ def tnx(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.TNX,
         in_files=in_files,
@@ -1793,7 +1789,7 @@ def csu(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -1806,7 +1802,7 @@ def csu(
     CSU: Maximum number of consecutive summer days (Tmax >25 C).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -1817,7 +1813,7 @@ def csu(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -1830,24 +1826,25 @@ def csu(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -1862,7 +1859,7 @@ def csu(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -1870,14 +1867,13 @@ def csu(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.CSU,
         in_files=in_files,
@@ -1905,7 +1901,7 @@ def gd4(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -1918,7 +1914,7 @@ def gd4(
     GD4: Growing degree days (sum of Tmean > 4 C).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -1929,7 +1925,7 @@ def gd4(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -1942,24 +1938,25 @@ def gd4(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -1974,7 +1971,7 @@ def gd4(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -1982,14 +1979,13 @@ def gd4(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.GD4,
         in_files=in_files,
@@ -2017,7 +2013,7 @@ def fd(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -2030,7 +2026,7 @@ def fd(
     FD: Number of Frost Days (Tmin < 0C).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -2041,7 +2037,7 @@ def fd(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -2054,24 +2050,25 @@ def fd(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -2086,7 +2083,7 @@ def fd(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -2094,14 +2091,13 @@ def fd(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.FD,
         in_files=in_files,
@@ -2129,7 +2125,7 @@ def cfd(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -2142,7 +2138,7 @@ def cfd(
     CFD: Maximum number of consecutive frost days (Tmin < 0 C).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -2153,7 +2149,7 @@ def cfd(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -2166,24 +2162,25 @@ def cfd(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -2198,7 +2195,7 @@ def cfd(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -2206,14 +2203,13 @@ def cfd(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.CFD,
         in_files=in_files,
@@ -2241,7 +2237,7 @@ def hd17(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -2254,7 +2250,7 @@ def hd17(
     HD17: Heating degree days (sum of Tmean < 17 C).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -2265,7 +2261,7 @@ def hd17(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -2278,24 +2274,25 @@ def hd17(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -2310,7 +2307,7 @@ def hd17(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -2318,14 +2315,13 @@ def hd17(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.HD17,
         in_files=in_files,
@@ -2353,7 +2349,7 @@ def id(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -2366,7 +2362,7 @@ def id(
     ID: Number of sharp Ice Days (Tmax < 0C).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -2377,7 +2373,7 @@ def id(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -2390,24 +2386,25 @@ def id(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -2422,7 +2419,7 @@ def id(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -2430,14 +2427,13 @@ def id(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.ID,
         in_files=in_files,
@@ -2466,7 +2462,7 @@ def tg10p(
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
     base_period_time_range: Sequence[dt.datetime] | Sequence[str] | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     only_leap_years: bool = False,
     ignore_Feb29th: bool = False,
     interpolation: str | QuantileInterpolation = "median_unbiased",
@@ -2482,7 +2478,7 @@ def tg10p(
     TG10p: Days when Tmean < 10th percentile.
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -2493,7 +2489,7 @@ def tg10p(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -2506,13 +2502,13 @@ def tg10p(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
@@ -2532,12 +2528,13 @@ def tg10p(
         bootstrapped.
         #. to compute a reference period for indices such as difference_of_mean
         (a.k.a anomaly) if a single variable is given in input.
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -2545,7 +2542,7 @@ def tg10p(
         ``optional`` Option for February 29th (default: False).
     ignore_Feb29th : bool
         ``optional`` Ignoring or not February 29th (default: False).
-    interpolation : str | QuantileInterpolation | None, default="median_unbiased"
+    interpolation : str | QuantileInterpolation | None
         ``optional`` Interpolation method to compute percentile values:
         ``{"linear", "median_unbiased"}``
         Default is "median_unbiased", a.k.a type 8 or method 8.
@@ -2562,7 +2559,7 @@ def tg10p(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -2570,14 +2567,13 @@ def tg10p(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.TG10P,
         in_files=in_files,
@@ -2614,7 +2610,7 @@ def tn10p(
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
     base_period_time_range: Sequence[dt.datetime] | Sequence[str] | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     only_leap_years: bool = False,
     ignore_Feb29th: bool = False,
     interpolation: str | QuantileInterpolation = "median_unbiased",
@@ -2630,7 +2626,7 @@ def tn10p(
     TN10p: Days when Tmin < 10th percentile.
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -2641,7 +2637,7 @@ def tn10p(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -2654,13 +2650,13 @@ def tn10p(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
@@ -2680,12 +2676,13 @@ def tn10p(
         bootstrapped.
         #. to compute a reference period for indices such as difference_of_mean
         (a.k.a anomaly) if a single variable is given in input.
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -2693,7 +2690,7 @@ def tn10p(
         ``optional`` Option for February 29th (default: False).
     ignore_Feb29th : bool
         ``optional`` Ignoring or not February 29th (default: False).
-    interpolation : str | QuantileInterpolation | None, default="median_unbiased"
+    interpolation : str | QuantileInterpolation | None
         ``optional`` Interpolation method to compute percentile values:
         ``{"linear", "median_unbiased"}``
         Default is "median_unbiased", a.k.a type 8 or method 8.
@@ -2710,7 +2707,7 @@ def tn10p(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -2718,14 +2715,13 @@ def tn10p(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.TN10P,
         in_files=in_files,
@@ -2762,7 +2758,7 @@ def tx10p(
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
     base_period_time_range: Sequence[dt.datetime] | Sequence[str] | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     only_leap_years: bool = False,
     ignore_Feb29th: bool = False,
     interpolation: str | QuantileInterpolation = "median_unbiased",
@@ -2778,7 +2774,7 @@ def tx10p(
     TX10p: Days when Tmax < 10th percentile.
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -2789,7 +2785,7 @@ def tx10p(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -2802,13 +2798,13 @@ def tx10p(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
@@ -2828,12 +2824,13 @@ def tx10p(
         bootstrapped.
         #. to compute a reference period for indices such as difference_of_mean
         (a.k.a anomaly) if a single variable is given in input.
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -2841,7 +2838,7 @@ def tx10p(
         ``optional`` Option for February 29th (default: False).
     ignore_Feb29th : bool
         ``optional`` Ignoring or not February 29th (default: False).
-    interpolation : str | QuantileInterpolation | None, default="median_unbiased"
+    interpolation : str | QuantileInterpolation | None
         ``optional`` Interpolation method to compute percentile values:
         ``{"linear", "median_unbiased"}``
         Default is "median_unbiased", a.k.a type 8 or method 8.
@@ -2858,7 +2855,7 @@ def tx10p(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -2866,14 +2863,13 @@ def tx10p(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.TX10P,
         in_files=in_files,
@@ -2909,7 +2905,7 @@ def txn(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -2922,7 +2918,7 @@ def txn(
     TXn: Minimum daily maximum temperature.
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -2933,7 +2929,7 @@ def txn(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -2946,24 +2942,25 @@ def txn(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -2978,7 +2975,7 @@ def txn(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -2986,14 +2983,13 @@ def txn(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.TXN,
         in_files=in_files,
@@ -3018,7 +3014,7 @@ def tnn(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -3031,7 +3027,7 @@ def tnn(
     TNn: Minimum daily minimum temperature.
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -3042,7 +3038,7 @@ def tnn(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -3055,24 +3051,25 @@ def tnn(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -3087,7 +3084,7 @@ def tnn(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -3095,14 +3092,13 @@ def tnn(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.TNN,
         in_files=in_files,
@@ -3128,7 +3124,7 @@ def csdi(
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
     base_period_time_range: Sequence[dt.datetime] | Sequence[str] | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     only_leap_years: bool = False,
     ignore_Feb29th: bool = False,
     interpolation: str | QuantileInterpolation = "median_unbiased",
@@ -3144,7 +3140,7 @@ def csdi(
     CSDI: Cold-spell duration index (days).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -3155,7 +3151,7 @@ def csdi(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -3168,13 +3164,13 @@ def csdi(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
@@ -3194,12 +3190,13 @@ def csdi(
         bootstrapped.
         #. to compute a reference period for indices such as difference_of_mean
         (a.k.a anomaly) if a single variable is given in input.
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -3207,7 +3204,7 @@ def csdi(
         ``optional`` Option for February 29th (default: False).
     ignore_Feb29th : bool
         ``optional`` Ignoring or not February 29th (default: False).
-    interpolation : str | QuantileInterpolation | None, default="median_unbiased"
+    interpolation : str | QuantileInterpolation | None
         ``optional`` Interpolation method to compute percentile values:
         ``{"linear", "median_unbiased"}``
         Default is "median_unbiased", a.k.a type 8 or method 8.
@@ -3224,7 +3221,7 @@ def csdi(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -3232,14 +3229,13 @@ def csdi(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.CSDI,
         in_files=in_files,
@@ -3275,7 +3271,7 @@ def cdd(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -3288,7 +3284,7 @@ def cdd(
     CDD: Maximum consecutive dry days (Precip < 1mm).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -3299,7 +3295,7 @@ def cdd(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -3312,24 +3308,25 @@ def cdd(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -3344,7 +3341,7 @@ def cdd(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -3352,14 +3349,13 @@ def cdd(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.CDD,
         in_files=in_files,
@@ -3387,7 +3383,7 @@ def prcptot(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -3400,7 +3396,7 @@ def prcptot(
     PRCPTOT: Total precipitation during Wet Days.
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -3411,7 +3407,7 @@ def prcptot(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -3424,24 +3420,25 @@ def prcptot(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -3456,7 +3453,7 @@ def prcptot(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -3464,14 +3461,13 @@ def prcptot(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.PRCPTOT,
         in_files=in_files,
@@ -3499,7 +3495,7 @@ def rr1(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -3512,7 +3508,7 @@ def rr1(
     RR1: Number of Wet Days (precip >= 1 mm).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -3523,7 +3519,7 @@ def rr1(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -3536,24 +3532,25 @@ def rr1(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -3568,7 +3565,7 @@ def rr1(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -3576,14 +3573,13 @@ def rr1(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.RR1,
         in_files=in_files,
@@ -3611,7 +3607,7 @@ def sdii(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -3624,7 +3620,7 @@ def sdii(
     SDII: Average precipitation during Wet Days (SDII).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -3635,7 +3631,7 @@ def sdii(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -3648,24 +3644,25 @@ def sdii(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -3680,7 +3677,7 @@ def sdii(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -3688,14 +3685,13 @@ def sdii(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.SDII,
         in_files=in_files,
@@ -3723,7 +3719,7 @@ def cwd(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -3736,7 +3732,7 @@ def cwd(
     CWD: Maximum consecutive wet days (Precip >= 1mm).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -3747,7 +3743,7 @@ def cwd(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -3760,24 +3756,25 @@ def cwd(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -3792,7 +3789,7 @@ def cwd(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -3800,14 +3797,13 @@ def cwd(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.CWD,
         in_files=in_files,
@@ -3835,7 +3831,7 @@ def rr(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -3848,7 +3844,7 @@ def rr(
     RR: Precipitation sum (mm).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -3859,7 +3855,7 @@ def rr(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -3872,24 +3868,25 @@ def rr(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -3904,7 +3901,7 @@ def rr(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -3912,14 +3909,13 @@ def rr(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.RR,
         in_files=in_files,
@@ -3944,7 +3940,7 @@ def r10mm(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -3957,7 +3953,7 @@ def r10mm(
     R10mm: Number of heavy precipitation days (Precip >=10mm).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -3968,7 +3964,7 @@ def r10mm(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -3981,24 +3977,25 @@ def r10mm(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -4013,7 +4010,7 @@ def r10mm(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -4021,14 +4018,13 @@ def r10mm(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.R10MM,
         in_files=in_files,
@@ -4056,7 +4052,7 @@ def r20mm(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -4069,7 +4065,7 @@ def r20mm(
     R20mm: Number of very heavy precipitation days (Precip >= 20mm).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -4080,7 +4076,7 @@ def r20mm(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -4093,24 +4089,25 @@ def r20mm(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -4125,7 +4122,7 @@ def r20mm(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -4133,14 +4130,13 @@ def r20mm(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.R20MM,
         in_files=in_files,
@@ -4168,7 +4164,7 @@ def rx1day(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -4181,7 +4177,7 @@ def rx1day(
     RX1day: Maximum 1-day total precipitation.
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -4192,7 +4188,7 @@ def rx1day(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -4205,24 +4201,25 @@ def rx1day(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -4237,7 +4234,7 @@ def rx1day(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -4245,14 +4242,13 @@ def rx1day(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.RX1DAY,
         in_files=in_files,
@@ -4277,7 +4273,7 @@ def rx5day(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -4290,7 +4286,7 @@ def rx5day(
     RX5day: Maximum 5-day total precipitation.
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -4301,7 +4297,7 @@ def rx5day(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -4314,24 +4310,25 @@ def rx5day(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -4346,7 +4343,7 @@ def rx5day(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -4354,14 +4351,13 @@ def rx5day(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.RX5DAY,
         in_files=in_files,
@@ -4387,7 +4383,7 @@ def r75p(
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
     base_period_time_range: Sequence[dt.datetime] | Sequence[str] | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     only_leap_years: bool = False,
     ignore_Feb29th: bool = False,
     interpolation: str | QuantileInterpolation = "median_unbiased",
@@ -4403,7 +4399,7 @@ def r75p(
     R75p: Days with RR > 75th percentile of daily amounts (moderate wet days) (d).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -4414,7 +4410,7 @@ def r75p(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -4427,13 +4423,13 @@ def r75p(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
@@ -4453,12 +4449,13 @@ def r75p(
         bootstrapped.
         #. to compute a reference period for indices such as difference_of_mean
         (a.k.a anomaly) if a single variable is given in input.
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -4466,7 +4463,7 @@ def r75p(
         ``optional`` Option for February 29th (default: False).
     ignore_Feb29th : bool
         ``optional`` Ignoring or not February 29th (default: False).
-    interpolation : str | QuantileInterpolation | None, default="median_unbiased"
+    interpolation : str | QuantileInterpolation | None
         ``optional`` Interpolation method to compute percentile values:
         ``{"linear", "median_unbiased"}``
         Default is "median_unbiased", a.k.a type 8 or method 8.
@@ -4483,7 +4480,7 @@ def r75p(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -4491,14 +4488,13 @@ def r75p(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.R75P,
         in_files=in_files,
@@ -4528,7 +4524,7 @@ def r75ptot(
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
     base_period_time_range: Sequence[dt.datetime] | Sequence[str] | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     only_leap_years: bool = False,
     ignore_Feb29th: bool = False,
     interpolation: str | QuantileInterpolation = "median_unbiased",
@@ -4544,7 +4540,7 @@ def r75ptot(
     R75pTOT: Precipitation fraction due to moderate wet days (> 75th percentile).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -4555,7 +4551,7 @@ def r75ptot(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -4568,13 +4564,13 @@ def r75ptot(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
@@ -4594,12 +4590,13 @@ def r75ptot(
         bootstrapped.
         #. to compute a reference period for indices such as difference_of_mean
         (a.k.a anomaly) if a single variable is given in input.
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -4607,7 +4604,7 @@ def r75ptot(
         ``optional`` Option for February 29th (default: False).
     ignore_Feb29th : bool
         ``optional`` Ignoring or not February 29th (default: False).
-    interpolation : str | QuantileInterpolation | None, default="median_unbiased"
+    interpolation : str | QuantileInterpolation | None
         ``optional`` Interpolation method to compute percentile values:
         ``{"linear", "median_unbiased"}``
         Default is "median_unbiased", a.k.a type 8 or method 8.
@@ -4624,7 +4621,7 @@ def r75ptot(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -4632,14 +4629,13 @@ def r75ptot(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.R75PTOT,
         in_files=in_files,
@@ -4669,7 +4665,7 @@ def r95p(
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
     base_period_time_range: Sequence[dt.datetime] | Sequence[str] | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     only_leap_years: bool = False,
     ignore_Feb29th: bool = False,
     interpolation: str | QuantileInterpolation = "median_unbiased",
@@ -4685,7 +4681,7 @@ def r95p(
     R95p: Days with RR > 95th percentile of daily amounts (very wet days) (days).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -4696,7 +4692,7 @@ def r95p(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -4709,13 +4705,13 @@ def r95p(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
@@ -4735,12 +4731,13 @@ def r95p(
         bootstrapped.
         #. to compute a reference period for indices such as difference_of_mean
         (a.k.a anomaly) if a single variable is given in input.
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -4748,7 +4745,7 @@ def r95p(
         ``optional`` Option for February 29th (default: False).
     ignore_Feb29th : bool
         ``optional`` Ignoring or not February 29th (default: False).
-    interpolation : str | QuantileInterpolation | None, default="median_unbiased"
+    interpolation : str | QuantileInterpolation | None
         ``optional`` Interpolation method to compute percentile values:
         ``{"linear", "median_unbiased"}``
         Default is "median_unbiased", a.k.a type 8 or method 8.
@@ -4765,7 +4762,7 @@ def r95p(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -4773,14 +4770,13 @@ def r95p(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.R95P,
         in_files=in_files,
@@ -4810,7 +4806,7 @@ def r95ptot(
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
     base_period_time_range: Sequence[dt.datetime] | Sequence[str] | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     only_leap_years: bool = False,
     ignore_Feb29th: bool = False,
     interpolation: str | QuantileInterpolation = "median_unbiased",
@@ -4826,7 +4822,7 @@ def r95ptot(
     R95pTOT: Precipitation fraction due to very wet days (> 95th percentile).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -4837,7 +4833,7 @@ def r95ptot(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -4850,13 +4846,13 @@ def r95ptot(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
@@ -4876,12 +4872,13 @@ def r95ptot(
         bootstrapped.
         #. to compute a reference period for indices such as difference_of_mean
         (a.k.a anomaly) if a single variable is given in input.
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -4889,7 +4886,7 @@ def r95ptot(
         ``optional`` Option for February 29th (default: False).
     ignore_Feb29th : bool
         ``optional`` Ignoring or not February 29th (default: False).
-    interpolation : str | QuantileInterpolation | None, default="median_unbiased"
+    interpolation : str | QuantileInterpolation | None
         ``optional`` Interpolation method to compute percentile values:
         ``{"linear", "median_unbiased"}``
         Default is "median_unbiased", a.k.a type 8 or method 8.
@@ -4906,7 +4903,7 @@ def r95ptot(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -4914,14 +4911,13 @@ def r95ptot(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.R95PTOT,
         in_files=in_files,
@@ -4951,7 +4947,7 @@ def r99p(
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
     base_period_time_range: Sequence[dt.datetime] | Sequence[str] | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     only_leap_years: bool = False,
     ignore_Feb29th: bool = False,
     interpolation: str | QuantileInterpolation = "median_unbiased",
@@ -4967,7 +4963,7 @@ def r99p(
     R99p: Days with RR > 99th percentile of daily amounts (extremely wet days).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -4978,7 +4974,7 @@ def r99p(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -4991,13 +4987,13 @@ def r99p(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
@@ -5017,12 +5013,13 @@ def r99p(
         bootstrapped.
         #. to compute a reference period for indices such as difference_of_mean
         (a.k.a anomaly) if a single variable is given in input.
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -5030,7 +5027,7 @@ def r99p(
         ``optional`` Option for February 29th (default: False).
     ignore_Feb29th : bool
         ``optional`` Ignoring or not February 29th (default: False).
-    interpolation : str | QuantileInterpolation | None, default="median_unbiased"
+    interpolation : str | QuantileInterpolation | None
         ``optional`` Interpolation method to compute percentile values:
         ``{"linear", "median_unbiased"}``
         Default is "median_unbiased", a.k.a type 8 or method 8.
@@ -5047,7 +5044,7 @@ def r99p(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -5055,14 +5052,13 @@ def r99p(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.R99P,
         in_files=in_files,
@@ -5092,7 +5088,7 @@ def r99ptot(
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
     base_period_time_range: Sequence[dt.datetime] | Sequence[str] | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     only_leap_years: bool = False,
     ignore_Feb29th: bool = False,
     interpolation: str | QuantileInterpolation = "median_unbiased",
@@ -5108,7 +5104,7 @@ def r99ptot(
     R99pTOT: Precipitation fraction due to extremely wet days (> 99th percentile).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -5119,7 +5115,7 @@ def r99ptot(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -5132,13 +5128,13 @@ def r99ptot(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
@@ -5158,12 +5154,13 @@ def r99ptot(
         bootstrapped.
         #. to compute a reference period for indices such as difference_of_mean
         (a.k.a anomaly) if a single variable is given in input.
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -5171,7 +5168,7 @@ def r99ptot(
         ``optional`` Option for February 29th (default: False).
     ignore_Feb29th : bool
         ``optional`` Ignoring or not February 29th (default: False).
-    interpolation : str | QuantileInterpolation | None, default="median_unbiased"
+    interpolation : str | QuantileInterpolation | None
         ``optional`` Interpolation method to compute percentile values:
         ``{"linear", "median_unbiased"}``
         Default is "median_unbiased", a.k.a type 8 or method 8.
@@ -5188,7 +5185,7 @@ def r99ptot(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -5196,14 +5193,13 @@ def r99ptot(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.R99PTOT,
         in_files=in_files,
@@ -5232,7 +5228,7 @@ def sd(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -5245,7 +5241,7 @@ def sd(
     SD: Mean of daily snow depth.
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -5256,7 +5252,7 @@ def sd(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -5269,24 +5265,25 @@ def sd(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -5301,7 +5298,7 @@ def sd(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -5309,14 +5306,13 @@ def sd(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.SD,
         in_files=in_files,
@@ -5341,7 +5337,7 @@ def sd1(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -5354,7 +5350,7 @@ def sd1(
     SD1: Snow days (SD >= 1 cm).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -5365,7 +5361,7 @@ def sd1(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -5378,24 +5374,25 @@ def sd1(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -5410,7 +5407,7 @@ def sd1(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -5418,14 +5415,13 @@ def sd1(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.SD1,
         in_files=in_files,
@@ -5453,7 +5449,7 @@ def sd5cm(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -5466,7 +5462,7 @@ def sd5cm(
     SD5cm: Number of days with snow depth >= 5 cm.
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -5477,7 +5473,7 @@ def sd5cm(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -5490,24 +5486,25 @@ def sd5cm(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -5522,7 +5519,7 @@ def sd5cm(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -5530,14 +5527,13 @@ def sd5cm(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.SD5CM,
         in_files=in_files,
@@ -5565,7 +5561,7 @@ def sd50cm(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -5578,7 +5574,7 @@ def sd50cm(
     SD50cm: Number of days with snow depth >= 50 cm.
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -5589,7 +5585,7 @@ def sd50cm(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -5602,24 +5598,25 @@ def sd50cm(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -5634,7 +5631,7 @@ def sd50cm(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -5642,14 +5639,13 @@ def sd50cm(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.SD50CM,
         in_files=in_files,
@@ -5678,7 +5674,7 @@ def cd(
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
     base_period_time_range: Sequence[dt.datetime] | Sequence[str] | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     only_leap_years: bool = False,
     ignore_Feb29th: bool = False,
     interpolation: str | QuantileInterpolation = "median_unbiased",
@@ -5694,7 +5690,7 @@ def cd(
     CD: Days with TG < 25th percentile of daily mean temperature and RR <25th percentile of daily precipitation sum (cold/dry days).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -5705,7 +5701,7 @@ def cd(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -5718,13 +5714,13 @@ def cd(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
@@ -5744,12 +5740,13 @@ def cd(
         bootstrapped.
         #. to compute a reference period for indices such as difference_of_mean
         (a.k.a anomaly) if a single variable is given in input.
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -5757,7 +5754,7 @@ def cd(
         ``optional`` Option for February 29th (default: False).
     ignore_Feb29th : bool
         ``optional`` Ignoring or not February 29th (default: False).
-    interpolation : str | QuantileInterpolation | None, default="median_unbiased"
+    interpolation : str | QuantileInterpolation | None
         ``optional`` Interpolation method to compute percentile values:
         ``{"linear", "median_unbiased"}``
         Default is "median_unbiased", a.k.a type 8 or method 8.
@@ -5774,7 +5771,7 @@ def cd(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -5782,14 +5779,13 @@ def cd(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.CD,
         in_files=in_files,
@@ -5809,18 +5805,18 @@ def cd(
         run_index=run_index,
         allow_partial_seasons=allow_partial_seasons,
         threshold=[
-            build_threshold(
-                query="< 25 doy_per",
-                doy_window_width=5,
-                only_leap_years=only_leap_years,
-                interpolation=interpolation,
-                reference_period=base_period_time_range,
-            ),
-            build_threshold(
-                query="< 25 period_per",
-                threshold_min_value="1 mm/day",
-            ),
-        ],
+        build_threshold(
+            query="< 25 doy_per",
+            doy_window_width=5,
+            only_leap_years=only_leap_years,
+            interpolation=interpolation,
+            reference_period=base_period_time_range,
+        ),
+        build_threshold(
+            query="< 25 period_per",
+            threshold_min_value="1 mm/day",
+        )
+    ],
         out_unit="day",
     )
 
@@ -5832,7 +5828,7 @@ def cw(
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
     base_period_time_range: Sequence[dt.datetime] | Sequence[str] | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     only_leap_years: bool = False,
     ignore_Feb29th: bool = False,
     interpolation: str | QuantileInterpolation = "median_unbiased",
@@ -5848,7 +5844,7 @@ def cw(
     CW: Days with TG < 25th percentile of daily mean temperature and RR >75th percentile of daily precipitation sum (cold/wet days).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -5859,7 +5855,7 @@ def cw(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -5872,13 +5868,13 @@ def cw(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
@@ -5898,12 +5894,13 @@ def cw(
         bootstrapped.
         #. to compute a reference period for indices such as difference_of_mean
         (a.k.a anomaly) if a single variable is given in input.
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -5911,7 +5908,7 @@ def cw(
         ``optional`` Option for February 29th (default: False).
     ignore_Feb29th : bool
         ``optional`` Ignoring or not February 29th (default: False).
-    interpolation : str | QuantileInterpolation | None, default="median_unbiased"
+    interpolation : str | QuantileInterpolation | None
         ``optional`` Interpolation method to compute percentile values:
         ``{"linear", "median_unbiased"}``
         Default is "median_unbiased", a.k.a type 8 or method 8.
@@ -5928,7 +5925,7 @@ def cw(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -5936,14 +5933,13 @@ def cw(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.CW,
         in_files=in_files,
@@ -5963,18 +5959,18 @@ def cw(
         run_index=run_index,
         allow_partial_seasons=allow_partial_seasons,
         threshold=[
-            build_threshold(
-                query="< 25 doy_per",
-                doy_window_width=5,
-                only_leap_years=only_leap_years,
-                interpolation=interpolation,
-                reference_period=base_period_time_range,
-            ),
-            build_threshold(
-                query="> 75 period_per",
-                threshold_min_value="1 mm/day",
-            ),
-        ],
+        build_threshold(
+            query="< 25 doy_per",
+            doy_window_width=5,
+            only_leap_years=only_leap_years,
+            interpolation=interpolation,
+            reference_period=base_period_time_range,
+        ),
+        build_threshold(
+            query="> 75 period_per",
+            threshold_min_value="1 mm/day",
+        )
+    ],
         out_unit="day",
     )
 
@@ -5986,7 +5982,7 @@ def wd(
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
     base_period_time_range: Sequence[dt.datetime] | Sequence[str] | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     only_leap_years: bool = False,
     ignore_Feb29th: bool = False,
     interpolation: str | QuantileInterpolation = "median_unbiased",
@@ -6002,7 +5998,7 @@ def wd(
     WD: Days with TG > 75th percentile of daily mean temperature and RR <25th percentile of daily precipitation sum (warm/dry days).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -6013,7 +6009,7 @@ def wd(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -6026,13 +6022,13 @@ def wd(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
@@ -6052,12 +6048,13 @@ def wd(
         bootstrapped.
         #. to compute a reference period for indices such as difference_of_mean
         (a.k.a anomaly) if a single variable is given in input.
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -6065,7 +6062,7 @@ def wd(
         ``optional`` Option for February 29th (default: False).
     ignore_Feb29th : bool
         ``optional`` Ignoring or not February 29th (default: False).
-    interpolation : str | QuantileInterpolation | None, default="median_unbiased"
+    interpolation : str | QuantileInterpolation | None
         ``optional`` Interpolation method to compute percentile values:
         ``{"linear", "median_unbiased"}``
         Default is "median_unbiased", a.k.a type 8 or method 8.
@@ -6082,7 +6079,7 @@ def wd(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -6090,14 +6087,13 @@ def wd(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.WD,
         in_files=in_files,
@@ -6117,18 +6113,18 @@ def wd(
         run_index=run_index,
         allow_partial_seasons=allow_partial_seasons,
         threshold=[
-            build_threshold(
-                query="> 75 doy_per",
-                doy_window_width=5,
-                only_leap_years=only_leap_years,
-                interpolation=interpolation,
-                reference_period=base_period_time_range,
-            ),
-            build_threshold(
-                query="< 25 period_per",
-                threshold_min_value="1 mm/day",
-            ),
-        ],
+        build_threshold(
+            query="> 75 doy_per",
+            doy_window_width=5,
+            only_leap_years=only_leap_years,
+            interpolation=interpolation,
+            reference_period=base_period_time_range,
+        ),
+        build_threshold(
+            query="< 25 period_per",
+            threshold_min_value="1 mm/day",
+        )
+    ],
         out_unit="day",
     )
 
@@ -6140,7 +6136,7 @@ def ww(
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
     base_period_time_range: Sequence[dt.datetime] | Sequence[str] | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     only_leap_years: bool = False,
     ignore_Feb29th: bool = False,
     interpolation: str | QuantileInterpolation = "median_unbiased",
@@ -6156,7 +6152,7 @@ def ww(
     WW: Days with TG > 75th percentile of daily mean temperature and RR >75th percentile of daily precipitation sum (warm/wet days).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -6167,7 +6163,7 @@ def ww(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -6180,13 +6176,13 @@ def ww(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
@@ -6206,12 +6202,13 @@ def ww(
         bootstrapped.
         #. to compute a reference period for indices such as difference_of_mean
         (a.k.a anomaly) if a single variable is given in input.
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -6219,7 +6216,7 @@ def ww(
         ``optional`` Option for February 29th (default: False).
     ignore_Feb29th : bool
         ``optional`` Ignoring or not February 29th (default: False).
-    interpolation : str | QuantileInterpolation | None, default="median_unbiased"
+    interpolation : str | QuantileInterpolation | None
         ``optional`` Interpolation method to compute percentile values:
         ``{"linear", "median_unbiased"}``
         Default is "median_unbiased", a.k.a type 8 or method 8.
@@ -6236,7 +6233,7 @@ def ww(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -6244,14 +6241,13 @@ def ww(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.WW,
         in_files=in_files,
@@ -6271,18 +6267,18 @@ def ww(
         run_index=run_index,
         allow_partial_seasons=allow_partial_seasons,
         threshold=[
-            build_threshold(
-                query="> 75 doy_per",
-                doy_window_width=5,
-                only_leap_years=only_leap_years,
-                interpolation=interpolation,
-                reference_period=base_period_time_range,
-            ),
-            build_threshold(
-                query="> 75 period_per",
-                threshold_min_value="1 mm/day",
-            ),
-        ],
+        build_threshold(
+            query="> 75 doy_per",
+            doy_window_width=5,
+            only_leap_years=only_leap_years,
+            interpolation=interpolation,
+            reference_period=base_period_time_range,
+        ),
+        build_threshold(
+            query="> 75 period_per",
+            threshold_min_value="1 mm/day",
+        )
+    ],
         out_unit="day",
     )
 
@@ -6293,7 +6289,7 @@ def fxx(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -6306,7 +6302,7 @@ def fxx(
     FXx: Maximum value of daily maximum wind gust.
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -6317,7 +6313,7 @@ def fxx(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -6330,24 +6326,25 @@ def fxx(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -6362,7 +6359,7 @@ def fxx(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -6370,14 +6367,13 @@ def fxx(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.FXX,
         in_files=in_files,
@@ -6402,7 +6398,7 @@ def fg6bft(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -6415,7 +6411,7 @@ def fg6bft(
     FG6Bft: Days with daily averaged wind ≥ 6 Bft (10.8 m s-1).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -6426,7 +6422,7 @@ def fg6bft(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -6439,24 +6435,25 @@ def fg6bft(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -6471,7 +6468,7 @@ def fg6bft(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -6479,14 +6476,13 @@ def fg6bft(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.FG6BFT,
         in_files=in_files,
@@ -6514,7 +6510,7 @@ def fgcalm(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -6527,7 +6523,7 @@ def fgcalm(
     FGcalm: Calm days, days with daily averaged wind <= 2 m s-1.
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -6538,7 +6534,7 @@ def fgcalm(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -6551,24 +6547,25 @@ def fgcalm(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -6583,7 +6580,7 @@ def fgcalm(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -6591,14 +6588,13 @@ def fgcalm(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.FGCALM,
         in_files=in_files,
@@ -6626,7 +6622,7 @@ def fg(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -6639,7 +6635,7 @@ def fg(
     FG: Mean of daily mean wind strength.
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -6650,7 +6646,7 @@ def fg(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -6663,24 +6659,25 @@ def fg(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -6695,7 +6692,7 @@ def fg(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -6703,14 +6700,13 @@ def fg(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.FG,
         in_files=in_files,
@@ -6735,7 +6731,7 @@ def ddnorth(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -6748,7 +6744,7 @@ def ddnorth(
     DDnorth: Days with northerly winds (DD > 315° or DD ≤ 45°).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -6759,7 +6755,7 @@ def ddnorth(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -6772,24 +6768,25 @@ def ddnorth(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -6804,7 +6801,7 @@ def ddnorth(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -6812,14 +6809,13 @@ def ddnorth(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.DDNORTH,
         in_files=in_files,
@@ -6847,7 +6843,7 @@ def ddeast(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -6860,7 +6856,7 @@ def ddeast(
     DDeast: Days with easterly winds (45° < DD <= 135°).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -6871,7 +6867,7 @@ def ddeast(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -6884,24 +6880,25 @@ def ddeast(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -6916,7 +6913,7 @@ def ddeast(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -6924,14 +6921,13 @@ def ddeast(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.DDEAST,
         in_files=in_files,
@@ -6959,7 +6955,7 @@ def ddsouth(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -6972,7 +6968,7 @@ def ddsouth(
     DDsouth: Days with southerly winds (135° < DD <= 225°).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -6983,7 +6979,7 @@ def ddsouth(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -6996,24 +6992,25 @@ def ddsouth(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -7028,7 +7025,7 @@ def ddsouth(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -7036,14 +7033,13 @@ def ddsouth(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.DDSOUTH,
         in_files=in_files,
@@ -7071,7 +7067,7 @@ def ddwest(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -7084,7 +7080,7 @@ def ddwest(
     DDwest: Days with westerly winds (225° < DD <= 315°).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -7095,7 +7091,7 @@ def ddwest(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -7108,24 +7104,25 @@ def ddwest(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -7140,7 +7137,7 @@ def ddwest(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -7148,14 +7145,13 @@ def ddwest(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.DDWEST,
         in_files=in_files,
@@ -7183,7 +7179,7 @@ def gsl(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -7196,7 +7192,7 @@ def gsl(
     GSL: Growing season length.
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -7207,7 +7203,7 @@ def gsl(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -7220,24 +7216,25 @@ def gsl(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -7252,7 +7249,7 @@ def gsl(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -7260,14 +7257,13 @@ def gsl(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.GSL,
         in_files=in_files,
@@ -7293,7 +7289,7 @@ def spi6(
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
     base_period_time_range: Sequence[dt.datetime] | Sequence[str] | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -7306,7 +7302,7 @@ def spi6(
     SPI6: 6-Month Standardized Precipitation Index.
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -7317,7 +7313,7 @@ def spi6(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -7330,13 +7326,13 @@ def spi6(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
@@ -7356,12 +7352,13 @@ def spi6(
         bootstrapped.
         #. to compute a reference period for indices such as difference_of_mean
         (a.k.a anomaly) if a single variable is given in input.
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -7376,7 +7373,7 @@ def spi6(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -7384,14 +7381,13 @@ def spi6(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.SPI6,
         in_files=in_files,
@@ -7418,7 +7414,7 @@ def spi3(
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
     base_period_time_range: Sequence[dt.datetime] | Sequence[str] | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -7431,7 +7427,7 @@ def spi3(
     SPI3: 3-Month Standardized Precipitation Index.
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -7442,7 +7438,7 @@ def spi3(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -7455,13 +7451,13 @@ def spi3(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
@@ -7481,12 +7477,13 @@ def spi3(
         bootstrapped.
         #. to compute a reference period for indices such as difference_of_mean
         (a.k.a anomaly) if a single variable is given in input.
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -7501,7 +7498,7 @@ def spi3(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -7509,14 +7506,13 @@ def spi3(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.SPI3,
         in_files=in_files,
@@ -7542,7 +7538,7 @@ def pp(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -7555,7 +7551,7 @@ def pp(
     PP: Mean of daily sea level pressure (hPa).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -7566,7 +7562,7 @@ def pp(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -7579,24 +7575,25 @@ def pp(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -7611,7 +7608,7 @@ def pp(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -7619,14 +7616,13 @@ def pp(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.PP,
         in_files=in_files,
@@ -7651,7 +7647,7 @@ def ss(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -7664,7 +7660,7 @@ def ss(
     SS: Sunshine duration (hours).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -7675,7 +7671,7 @@ def ss(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -7688,24 +7684,25 @@ def ss(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -7720,7 +7717,7 @@ def ss(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -7728,14 +7725,13 @@ def ss(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.SS,
         in_files=in_files,
@@ -7760,7 +7756,7 @@ def rh(
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
     logs_verbosity: Verbosity | str = "LOW",
@@ -7773,7 +7769,7 @@ def rh(
     RH: Mean of daily relative humidity (%).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -7784,7 +7780,7 @@ def rh(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -7797,24 +7793,25 @@ def rh(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -7829,7 +7826,7 @@ def rh(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -7837,14 +7834,13 @@ def rh(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
-
     return icclim.index(
         index_name=EcadIndexRegistry.RH,
         in_files=in_files,

--- a/src/icclim/_generated/_ecad.py
+++ b/src/icclim/_generated/_ecad.py
@@ -21,7 +21,11 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from icclim.logger import Verbosity
-    from icclim._core.model.icclim_types import FrequencyLike, InFileLike, SamplingMethodLike
+    from icclim._core.model.icclim_types import (
+        FrequencyLike,
+        InFileLike,
+        SamplingMethodLike,
+    )
     from icclim.frequency import Frequency
     from icclim._core.model.netcdf_version import NetcdfVersion
     from icclim._core.model.quantile_interpolation import QuantileInterpolation
@@ -114,7 +118,7 @@ def tg(
     TG: Mean of daily mean temperature.
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -179,13 +183,14 @@ def tg(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.TG,
         in_files=in_files,
@@ -223,7 +228,7 @@ def tn(
     TN: Mean of daily minimum temperature.
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -288,13 +293,14 @@ def tn(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.TN,
         in_files=in_files,
@@ -332,7 +338,7 @@ def tx(
     TX: Mean of daily maximum temperature.
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -397,13 +403,14 @@ def tx(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.TX,
         in_files=in_files,
@@ -441,7 +448,7 @@ def dtr(
     DTR: Mean Diurnal Temperature Range.
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -506,13 +513,14 @@ def dtr(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.DTR,
         in_files=in_files,
@@ -550,7 +558,7 @@ def etr(
     ETR: Intra-period extreme temperature range.
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -615,13 +623,14 @@ def etr(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.ETR,
         in_files=in_files,
@@ -659,7 +668,7 @@ def vdtr(
     vDTR: Mean day-to-day variation in Diurnal Temperature Range.
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -724,13 +733,14 @@ def vdtr(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.VDTR,
         in_files=in_files,
@@ -768,7 +778,7 @@ def su(
     SU: Number of Summer Days (Tmax > 25C).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -833,13 +843,14 @@ def su(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.SU,
         in_files=in_files,
@@ -880,7 +891,7 @@ def tr(
     TR: Number of Tropical Nights (Tmin > 20C).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -945,13 +956,14 @@ def tr(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.TR,
         in_files=in_files,
@@ -996,7 +1008,7 @@ def wsdi(
     WSDI: Warm-spell duration index (days).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -1085,13 +1097,14 @@ def wsdi(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.WSDI,
         in_files=in_files,
@@ -1144,7 +1157,7 @@ def tg90p(
     TG90p: Days when Tmean > 90th percentile.
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -1233,13 +1246,14 @@ def tg90p(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.TG90P,
         in_files=in_files,
@@ -1292,7 +1306,7 @@ def tn90p(
     TN90p: Days when Tmin > 90th percentile.
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -1381,13 +1395,14 @@ def tn90p(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.TN90P,
         in_files=in_files,
@@ -1440,7 +1455,7 @@ def tx90p(
     TX90p: Days when Tmax > 90th daily percentile.
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -1529,13 +1544,14 @@ def tx90p(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.TX90P,
         in_files=in_files,
@@ -1584,7 +1600,7 @@ def txx(
     TXx: Maximum daily maximum temperature.
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -1649,13 +1665,14 @@ def txx(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.TXX,
         in_files=in_files,
@@ -1693,7 +1710,7 @@ def tnx(
     TNx: Maximum daily minimum temperature.
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -1758,13 +1775,14 @@ def tnx(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.TNX,
         in_files=in_files,
@@ -1802,7 +1820,7 @@ def csu(
     CSU: Maximum number of consecutive summer days (Tmax >25 C).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -1867,13 +1885,14 @@ def csu(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.CSU,
         in_files=in_files,
@@ -1914,7 +1933,7 @@ def gd4(
     GD4: Growing degree days (sum of Tmean > 4 C).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -1979,13 +1998,14 @@ def gd4(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.GD4,
         in_files=in_files,
@@ -2026,7 +2046,7 @@ def fd(
     FD: Number of Frost Days (Tmin < 0C).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -2091,13 +2111,14 @@ def fd(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.FD,
         in_files=in_files,
@@ -2138,7 +2159,7 @@ def cfd(
     CFD: Maximum number of consecutive frost days (Tmin < 0 C).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -2203,13 +2224,14 @@ def cfd(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.CFD,
         in_files=in_files,
@@ -2250,7 +2272,7 @@ def hd17(
     HD17: Heating degree days (sum of Tmean < 17 C).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -2315,13 +2337,14 @@ def hd17(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.HD17,
         in_files=in_files,
@@ -2362,7 +2385,7 @@ def id(
     ID: Number of sharp Ice Days (Tmax < 0C).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -2427,13 +2450,14 @@ def id(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.ID,
         in_files=in_files,
@@ -2478,7 +2502,7 @@ def tg10p(
     TG10p: Days when Tmean < 10th percentile.
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -2567,13 +2591,14 @@ def tg10p(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.TG10P,
         in_files=in_files,
@@ -2626,7 +2651,7 @@ def tn10p(
     TN10p: Days when Tmin < 10th percentile.
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -2715,13 +2740,14 @@ def tn10p(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.TN10P,
         in_files=in_files,
@@ -2774,7 +2800,7 @@ def tx10p(
     TX10p: Days when Tmax < 10th percentile.
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -2863,13 +2889,14 @@ def tx10p(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.TX10P,
         in_files=in_files,
@@ -2918,7 +2945,7 @@ def txn(
     TXn: Minimum daily maximum temperature.
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -2983,13 +3010,14 @@ def txn(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.TXN,
         in_files=in_files,
@@ -3027,7 +3055,7 @@ def tnn(
     TNn: Minimum daily minimum temperature.
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -3092,13 +3120,14 @@ def tnn(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.TNN,
         in_files=in_files,
@@ -3140,7 +3169,7 @@ def csdi(
     CSDI: Cold-spell duration index (days).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -3229,13 +3258,14 @@ def csdi(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.CSDI,
         in_files=in_files,
@@ -3284,7 +3314,7 @@ def cdd(
     CDD: Maximum consecutive dry days (Precip < 1mm).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -3349,13 +3379,14 @@ def cdd(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.CDD,
         in_files=in_files,
@@ -3396,7 +3427,7 @@ def prcptot(
     PRCPTOT: Total precipitation during Wet Days.
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -3461,13 +3492,14 @@ def prcptot(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.PRCPTOT,
         in_files=in_files,
@@ -3508,7 +3540,7 @@ def rr1(
     RR1: Number of Wet Days (precip >= 1 mm).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -3573,13 +3605,14 @@ def rr1(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.RR1,
         in_files=in_files,
@@ -3620,7 +3653,7 @@ def sdii(
     SDII: Average precipitation during Wet Days (SDII).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -3685,13 +3718,14 @@ def sdii(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.SDII,
         in_files=in_files,
@@ -3732,7 +3766,7 @@ def cwd(
     CWD: Maximum consecutive wet days (Precip >= 1mm).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -3797,13 +3831,14 @@ def cwd(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.CWD,
         in_files=in_files,
@@ -3844,7 +3879,7 @@ def rr(
     RR: Precipitation sum (mm).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -3909,13 +3944,14 @@ def rr(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.RR,
         in_files=in_files,
@@ -3953,7 +3989,7 @@ def r10mm(
     R10mm: Number of heavy precipitation days (Precip >=10mm).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -4018,13 +4054,14 @@ def r10mm(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.R10MM,
         in_files=in_files,
@@ -4065,7 +4102,7 @@ def r20mm(
     R20mm: Number of very heavy precipitation days (Precip >= 20mm).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -4130,13 +4167,14 @@ def r20mm(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.R20MM,
         in_files=in_files,
@@ -4177,7 +4215,7 @@ def rx1day(
     RX1day: Maximum 1-day total precipitation.
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -4242,13 +4280,14 @@ def rx1day(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.RX1DAY,
         in_files=in_files,
@@ -4286,7 +4325,7 @@ def rx5day(
     RX5day: Maximum 5-day total precipitation.
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -4351,13 +4390,14 @@ def rx5day(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.RX5DAY,
         in_files=in_files,
@@ -4399,7 +4439,7 @@ def r75p(
     R75p: Days with RR > 75th percentile of daily amounts (moderate wet days) (d).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -4488,13 +4528,14 @@ def r75p(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.R75P,
         in_files=in_files,
@@ -4540,7 +4581,7 @@ def r75ptot(
     R75pTOT: Precipitation fraction due to moderate wet days (> 75th percentile).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -4629,13 +4670,14 @@ def r75ptot(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.R75PTOT,
         in_files=in_files,
@@ -4681,7 +4723,7 @@ def r95p(
     R95p: Days with RR > 95th percentile of daily amounts (very wet days) (days).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -4770,13 +4812,14 @@ def r95p(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.R95P,
         in_files=in_files,
@@ -4822,7 +4865,7 @@ def r95ptot(
     R95pTOT: Precipitation fraction due to very wet days (> 95th percentile).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -4911,13 +4954,14 @@ def r95ptot(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.R95PTOT,
         in_files=in_files,
@@ -4963,7 +5007,7 @@ def r99p(
     R99p: Days with RR > 99th percentile of daily amounts (extremely wet days).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -5052,13 +5096,14 @@ def r99p(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.R99P,
         in_files=in_files,
@@ -5104,7 +5149,7 @@ def r99ptot(
     R99pTOT: Precipitation fraction due to extremely wet days (> 99th percentile).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -5193,13 +5238,14 @@ def r99ptot(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.R99PTOT,
         in_files=in_files,
@@ -5241,7 +5287,7 @@ def sd(
     SD: Mean of daily snow depth.
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -5306,13 +5352,14 @@ def sd(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.SD,
         in_files=in_files,
@@ -5350,7 +5397,7 @@ def sd1(
     SD1: Snow days (SD >= 1 cm).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -5415,13 +5462,14 @@ def sd1(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.SD1,
         in_files=in_files,
@@ -5462,7 +5510,7 @@ def sd5cm(
     SD5cm: Number of days with snow depth >= 5 cm.
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -5527,13 +5575,14 @@ def sd5cm(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.SD5CM,
         in_files=in_files,
@@ -5574,7 +5623,7 @@ def sd50cm(
     SD50cm: Number of days with snow depth >= 50 cm.
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -5639,13 +5688,14 @@ def sd50cm(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.SD50CM,
         in_files=in_files,
@@ -5690,7 +5740,7 @@ def cd(
     CD: Days with TG < 25th percentile of daily mean temperature and RR <25th percentile of daily precipitation sum (cold/dry days).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -5779,13 +5829,14 @@ def cd(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.CD,
         in_files=in_files,
@@ -5805,18 +5856,18 @@ def cd(
         run_index=run_index,
         allow_partial_seasons=allow_partial_seasons,
         threshold=[
-        build_threshold(
-            query="< 25 doy_per",
-            doy_window_width=5,
-            only_leap_years=only_leap_years,
-            interpolation=interpolation,
-            reference_period=base_period_time_range,
-        ),
-        build_threshold(
-            query="< 25 period_per",
-            threshold_min_value="1 mm/day",
-        )
-    ],
+            build_threshold(
+                query="< 25 doy_per",
+                doy_window_width=5,
+                only_leap_years=only_leap_years,
+                interpolation=interpolation,
+                reference_period=base_period_time_range,
+            ),
+            build_threshold(
+                query="< 25 period_per",
+                threshold_min_value="1 mm/day",
+            ),
+        ],
         out_unit="day",
     )
 
@@ -5844,7 +5895,7 @@ def cw(
     CW: Days with TG < 25th percentile of daily mean temperature and RR >75th percentile of daily precipitation sum (cold/wet days).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -5933,13 +5984,14 @@ def cw(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.CW,
         in_files=in_files,
@@ -5959,18 +6011,18 @@ def cw(
         run_index=run_index,
         allow_partial_seasons=allow_partial_seasons,
         threshold=[
-        build_threshold(
-            query="< 25 doy_per",
-            doy_window_width=5,
-            only_leap_years=only_leap_years,
-            interpolation=interpolation,
-            reference_period=base_period_time_range,
-        ),
-        build_threshold(
-            query="> 75 period_per",
-            threshold_min_value="1 mm/day",
-        )
-    ],
+            build_threshold(
+                query="< 25 doy_per",
+                doy_window_width=5,
+                only_leap_years=only_leap_years,
+                interpolation=interpolation,
+                reference_period=base_period_time_range,
+            ),
+            build_threshold(
+                query="> 75 period_per",
+                threshold_min_value="1 mm/day",
+            ),
+        ],
         out_unit="day",
     )
 
@@ -5998,7 +6050,7 @@ def wd(
     WD: Days with TG > 75th percentile of daily mean temperature and RR <25th percentile of daily precipitation sum (warm/dry days).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -6087,13 +6139,14 @@ def wd(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.WD,
         in_files=in_files,
@@ -6113,18 +6166,18 @@ def wd(
         run_index=run_index,
         allow_partial_seasons=allow_partial_seasons,
         threshold=[
-        build_threshold(
-            query="> 75 doy_per",
-            doy_window_width=5,
-            only_leap_years=only_leap_years,
-            interpolation=interpolation,
-            reference_period=base_period_time_range,
-        ),
-        build_threshold(
-            query="< 25 period_per",
-            threshold_min_value="1 mm/day",
-        )
-    ],
+            build_threshold(
+                query="> 75 doy_per",
+                doy_window_width=5,
+                only_leap_years=only_leap_years,
+                interpolation=interpolation,
+                reference_period=base_period_time_range,
+            ),
+            build_threshold(
+                query="< 25 period_per",
+                threshold_min_value="1 mm/day",
+            ),
+        ],
         out_unit="day",
     )
 
@@ -6152,7 +6205,7 @@ def ww(
     WW: Days with TG > 75th percentile of daily mean temperature and RR >75th percentile of daily precipitation sum (warm/wet days).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -6241,13 +6294,14 @@ def ww(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.WW,
         in_files=in_files,
@@ -6267,18 +6321,18 @@ def ww(
         run_index=run_index,
         allow_partial_seasons=allow_partial_seasons,
         threshold=[
-        build_threshold(
-            query="> 75 doy_per",
-            doy_window_width=5,
-            only_leap_years=only_leap_years,
-            interpolation=interpolation,
-            reference_period=base_period_time_range,
-        ),
-        build_threshold(
-            query="> 75 period_per",
-            threshold_min_value="1 mm/day",
-        )
-    ],
+            build_threshold(
+                query="> 75 doy_per",
+                doy_window_width=5,
+                only_leap_years=only_leap_years,
+                interpolation=interpolation,
+                reference_period=base_period_time_range,
+            ),
+            build_threshold(
+                query="> 75 period_per",
+                threshold_min_value="1 mm/day",
+            ),
+        ],
         out_unit="day",
     )
 
@@ -6302,7 +6356,7 @@ def fxx(
     FXx: Maximum value of daily maximum wind gust.
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -6367,13 +6421,14 @@ def fxx(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.FXX,
         in_files=in_files,
@@ -6411,7 +6466,7 @@ def fg6bft(
     FG6Bft: Days with daily averaged wind ≥ 6 Bft (10.8 m s-1).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -6476,13 +6531,14 @@ def fg6bft(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.FG6BFT,
         in_files=in_files,
@@ -6523,7 +6579,7 @@ def fgcalm(
     FGcalm: Calm days, days with daily averaged wind <= 2 m s-1.
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -6588,13 +6644,14 @@ def fgcalm(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.FGCALM,
         in_files=in_files,
@@ -6635,7 +6692,7 @@ def fg(
     FG: Mean of daily mean wind strength.
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -6700,13 +6757,14 @@ def fg(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.FG,
         in_files=in_files,
@@ -6744,7 +6802,7 @@ def ddnorth(
     DDnorth: Days with northerly winds (DD > 315° or DD ≤ 45°).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -6809,13 +6867,14 @@ def ddnorth(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.DDNORTH,
         in_files=in_files,
@@ -6856,7 +6915,7 @@ def ddeast(
     DDeast: Days with easterly winds (45° < DD <= 135°).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -6921,13 +6980,14 @@ def ddeast(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.DDEAST,
         in_files=in_files,
@@ -6968,7 +7028,7 @@ def ddsouth(
     DDsouth: Days with southerly winds (135° < DD <= 225°).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -7033,13 +7093,14 @@ def ddsouth(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.DDSOUTH,
         in_files=in_files,
@@ -7080,7 +7141,7 @@ def ddwest(
     DDwest: Days with westerly winds (225° < DD <= 315°).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -7145,13 +7206,14 @@ def ddwest(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.DDWEST,
         in_files=in_files,
@@ -7192,7 +7254,7 @@ def gsl(
     GSL: Growing season length.
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -7257,13 +7319,14 @@ def gsl(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.GSL,
         in_files=in_files,
@@ -7302,7 +7365,7 @@ def spi6(
     SPI6: 6-Month Standardized Precipitation Index.
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -7381,13 +7444,14 @@ def spi6(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.SPI6,
         in_files=in_files,
@@ -7427,7 +7491,7 @@ def spi3(
     SPI3: 3-Month Standardized Precipitation Index.
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -7506,13 +7570,14 @@ def spi3(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.SPI3,
         in_files=in_files,
@@ -7551,7 +7616,7 @@ def pp(
     PP: Mean of daily sea level pressure (hPa).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -7616,13 +7681,14 @@ def pp(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.PP,
         in_files=in_files,
@@ -7660,7 +7726,7 @@ def ss(
     SS: Sunshine duration (hours).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -7725,13 +7791,14 @@ def ss(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.SS,
         in_files=in_files,
@@ -7769,7 +7836,7 @@ def rh(
     RH: Mean of daily relative humidity (%).
     Source: ECA&D, Algorithm Theoretical Basis Document (ATBD) v11.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -7834,13 +7901,14 @@ def rh(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
 
     """  # noqa: D401
     from icclim.ecad.registry import EcadIndexRegistry  # noqa: PLC0415
+
     return icclim.index(
         index_name=EcadIndexRegistry.RH,
         in_files=in_files,

--- a/src/icclim/_generated/_ecad.py
+++ b/src/icclim/_generated/_ecad.py
@@ -162,10 +162,12 @@ def tg(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -278,10 +280,12 @@ def tn(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -394,10 +398,12 @@ def tx(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -510,10 +516,12 @@ def dtr(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -626,10 +634,12 @@ def etr(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -742,10 +752,12 @@ def vdtr(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -858,10 +870,12 @@ def su(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -977,10 +991,12 @@ def tr(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -1114,10 +1130,12 @@ def wsdi(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -1269,10 +1287,12 @@ def tg90p(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -1424,10 +1444,12 @@ def tn90p(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -1579,10 +1601,12 @@ def tx90p(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -1716,10 +1740,12 @@ def txx(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -1832,10 +1858,12 @@ def tnx(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -1948,10 +1976,12 @@ def csu(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -2067,10 +2097,12 @@ def gd4(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -2186,10 +2218,12 @@ def fd(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -2305,10 +2339,12 @@ def cfd(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -2424,10 +2460,12 @@ def hd17(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -2543,10 +2581,12 @@ def id(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -2680,10 +2720,12 @@ def tg10p(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -2835,10 +2877,12 @@ def tn10p(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -2990,10 +3034,12 @@ def tx10p(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -3127,10 +3173,12 @@ def txn(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -3243,10 +3291,12 @@ def tnn(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -3377,10 +3427,12 @@ def csdi(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -3514,10 +3566,12 @@ def cdd(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -3633,10 +3687,12 @@ def prcptot(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -3752,10 +3808,12 @@ def rr1(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -3871,10 +3929,12 @@ def sdii(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -3990,10 +4050,12 @@ def cwd(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -4109,10 +4171,12 @@ def rr(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -4225,10 +4289,12 @@ def r10mm(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -4344,10 +4410,12 @@ def r20mm(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -4463,10 +4531,12 @@ def rx1day(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -4579,10 +4649,12 @@ def rx5day(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -4713,10 +4785,12 @@ def r75p(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -4861,10 +4935,12 @@ def r75ptot(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -5009,10 +5085,12 @@ def r95p(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -5157,10 +5235,12 @@ def r95ptot(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -5305,10 +5385,12 @@ def r99p(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -5453,10 +5535,12 @@ def r99ptot(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -5583,10 +5667,12 @@ def sd(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -5699,10 +5785,12 @@ def sd1(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -5818,10 +5906,12 @@ def sd5cm(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -5937,10 +6027,12 @@ def sd50cm(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -6074,10 +6166,12 @@ def cd(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -6235,10 +6329,12 @@ def cw(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -6396,10 +6492,12 @@ def wd(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -6557,10 +6655,12 @@ def ww(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -6700,10 +6800,12 @@ def fxx(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -6816,10 +6918,12 @@ def fg6bft(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -6935,10 +7039,12 @@ def fgcalm(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -7054,10 +7160,12 @@ def fg(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -7170,10 +7278,12 @@ def ddnorth(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -7289,10 +7399,12 @@ def ddeast(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -7408,10 +7520,12 @@ def ddsouth(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -7527,10 +7641,12 @@ def ddwest(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -7646,10 +7762,12 @@ def gsl(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -7777,10 +7895,12 @@ def spi6(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -7909,10 +8029,12 @@ def spi3(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -8026,10 +8148,12 @@ def pp(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -8142,10 +8266,12 @@ def ss(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -8258,10 +8384,12 @@ def rh(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".

--- a/src/icclim/_generated/_generic.py
+++ b/src/icclim/_generated/_generic.py
@@ -21,7 +21,11 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from icclim.logger import Verbosity
-    from icclim._core.model.icclim_types import FrequencyLike, InFileLike, SamplingMethodLike
+    from icclim._core.model.icclim_types import (
+        FrequencyLike,
+        InFileLike,
+        SamplingMethodLike,
+    )
     from icclim.frequency import Frequency
     from icclim._core.model.netcdf_version import NetcdfVersion
     from icclim._core.model.quantile_interpolation import QuantileInterpolation
@@ -68,12 +72,12 @@ def count_occurrences(
     date_event: bool = False,
     run_index: str | None = "first",
     allow_partial_seasons: bool | Literal["start", "end"] = False,
-    ) -> Dataset:
+) -> Dataset:
     """Count occurrences when threshold(s) are met (e.g. SU, Tx90p, RR1).
 
     count_occurrences: Count occurrences when threshold(s) are met (e.g. SU, Tx90p, RR1).
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -149,7 +153,7 @@ def count_occurrences(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
@@ -193,12 +197,12 @@ def max_consecutive_occurrence(
     date_event: bool = False,
     run_index: str | None = "first",
     allow_partial_seasons: bool | Literal["start", "end"] = False,
-    ) -> Dataset:
+) -> Dataset:
     """Count the maximum number of consecutive occurrences when threshold(s) are met (e.g. CDD, CSU, CWD).
 
     max_consecutive_occurrence: Count the maximum number of consecutive occurrences when threshold(s) are met (e.g. CDD, CSU, CWD).
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -274,7 +278,7 @@ def max_consecutive_occurrence(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
@@ -319,12 +323,12 @@ def sum_of_spell_lengths(
     min_spell_length: int | None = 6,
     run_index: str | None = "first",
     allow_partial_seasons: bool | Literal["start", "end"] = False,
-    ) -> Dataset:
+) -> Dataset:
     """Sum the lengths of each consecutive occurrence spell when threshold(s) are met. The minimum spell length is controlled by `min_spell_length` (e.g. WSDI, CSDI).
 
     sum_of_spell_lengths: Sum the lengths of each consecutive occurrence spell when threshold(s) are met. The minimum spell length is controlled by `min_spell_length` (e.g. WSDI, CSDI).
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -403,7 +407,7 @@ def sum_of_spell_lengths(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
@@ -448,12 +452,12 @@ def excess(
     date_event: bool = False,
     run_index: str | None = "first",
     allow_partial_seasons: bool | Literal["start", "end"] = False,
-    ) -> Dataset:
+) -> Dataset:
     """Compute the excess over the given threshold. The excess is `sum(x[x>t] - t)` where x is the studied variable and t the threshold (e.g. GD4).
 
     excess: Compute the excess over the given threshold. The excess is `sum(x[x>t] - t)` where x is the studied variable and t the threshold (e.g. GD4).
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -529,7 +533,7 @@ def excess(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
@@ -573,12 +577,12 @@ def deficit(
     date_event: bool = False,
     run_index: str | None = "first",
     allow_partial_seasons: bool | Literal["start", "end"] = False,
-    ) -> Dataset:
+) -> Dataset:
     """Compute the deficit below the given threshold. The deficit is `sum(t - x[x<t])` where x is the studied variable and t the threshold (e.g. HD17).
 
     deficit: Compute the deficit below the given threshold. The deficit is `sum(t - x[x<t])` where x is the studied variable and t the threshold (e.g. HD17).
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -654,7 +658,7 @@ def deficit(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
@@ -698,12 +702,12 @@ def fraction_of_total(
     date_event: bool = False,
     run_index: str | None = "first",
     allow_partial_seasons: bool | Literal["start", "end"] = False,
-    ) -> Dataset:
+) -> Dataset:
     """Compute the fraction of values meeting threshold(s) over the sum of every values (e.g. R75pTOT, R95pTOT).
 
     fraction_of_total: Compute the fraction of values meeting threshold(s) over the sum of every values (e.g. R75pTOT, R95pTOT).
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -779,7 +783,7 @@ def fraction_of_total(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
@@ -823,12 +827,12 @@ def maximum(
     date_event: bool = False,
     run_index: str | None = "first",
     allow_partial_seasons: bool | Literal["start", "end"] = False,
-    ) -> Dataset:
+) -> Dataset:
     """Maximum of values that met threshold(s), if threshold(s) are given (e.g. Txx, Tnx).
 
     maximum: Maximum of values that met threshold(s), if threshold(s) are given (e.g. Txx, Tnx).
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -904,7 +908,7 @@ def maximum(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
@@ -948,12 +952,12 @@ def minimum(
     date_event: bool = False,
     run_index: str | None = "first",
     allow_partial_seasons: bool | Literal["start", "end"] = False,
-    ) -> Dataset:
+) -> Dataset:
     """Minimum of values that met threshold(s), if threshold(s) are given (e.g. Txn, Tnn).
 
     minimum: Minimum of values that met threshold(s), if threshold(s) are given (e.g. Txn, Tnn).
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -1029,7 +1033,7 @@ def minimum(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
@@ -1073,12 +1077,12 @@ def average(
     date_event: bool = False,
     run_index: str | None = "first",
     allow_partial_seasons: bool | Literal["start", "end"] = False,
-    ) -> Dataset:
+) -> Dataset:
     """Average of values that met threshold(s), if threshold(s) are given (e.g. Tx, Tn).
 
     average: Average of values that met threshold(s), if threshold(s) are given (e.g. Tx, Tn).
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -1154,7 +1158,7 @@ def average(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
@@ -1198,12 +1202,12 @@ def sum(
     date_event: bool = False,
     run_index: str | None = "first",
     allow_partial_seasons: bool | Literal["start", "end"] = False,
-    ) -> Dataset:
+) -> Dataset:
     """Sum of values that met threshold(s), if threshold(s) are given (e.g. PRCPTOT, RR).
 
     sum: Sum of values that met threshold(s), if threshold(s) are given (e.g. PRCPTOT, RR).
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -1279,7 +1283,7 @@ def sum(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
@@ -1323,12 +1327,12 @@ def standard_deviation(
     date_event: bool = False,
     run_index: str | None = "first",
     allow_partial_seasons: bool | Literal["start", "end"] = False,
-    ) -> Dataset:
+) -> Dataset:
     """Standard deviation of values that met threshold(s), if threshold(s) are given.
 
     standard_deviation: Standard deviation of values that met threshold(s), if threshold(s) are given.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -1404,7 +1408,7 @@ def standard_deviation(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
@@ -1449,12 +1453,12 @@ def max_of_rolling_sum(
     rolling_window_width: int | None = 5,
     run_index: str | None = "first",
     allow_partial_seasons: bool | Literal["start", "end"] = False,
-    ) -> Dataset:
+) -> Dataset:
     """Maximum of rolling sum over time dimension (e.g. RX5DAY: maximum 5 days window of precipitation accumulation).
 
     max_of_rolling_sum: Maximum of rolling sum over time dimension (e.g. RX5DAY: maximum 5 days window of precipitation accumulation).
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -1533,7 +1537,7 @@ def max_of_rolling_sum(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
@@ -1579,12 +1583,12 @@ def min_of_rolling_sum(
     rolling_window_width: int | None = 5,
     run_index: str | None = "first",
     allow_partial_seasons: bool | Literal["start", "end"] = False,
-    ) -> Dataset:
+) -> Dataset:
     """Minimum of rolling sum over time dimension.
 
     min_of_rolling_sum: Minimum of rolling sum over time dimension.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -1663,7 +1667,7 @@ def min_of_rolling_sum(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
@@ -1709,12 +1713,12 @@ def max_of_rolling_average(
     rolling_window_width: int | None = 5,
     run_index: str | None = "first",
     allow_partial_seasons: bool | Literal["start", "end"] = False,
-    ) -> Dataset:
+) -> Dataset:
     """Maximum of rolling average over time dimension.
 
     max_of_rolling_average: Maximum of rolling average over time dimension.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -1793,7 +1797,7 @@ def max_of_rolling_average(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
@@ -1839,12 +1843,12 @@ def min_of_rolling_average(
     rolling_window_width: int | None = 5,
     run_index: str | None = "first",
     allow_partial_seasons: bool | Literal["start", "end"] = False,
-    ) -> Dataset:
+) -> Dataset:
     """Minimum of rolling average over time dimension.
 
     min_of_rolling_average: Minimum of rolling average over time dimension.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -1923,7 +1927,7 @@ def min_of_rolling_average(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
@@ -1968,12 +1972,12 @@ def mean_of_difference(
     date_event: bool = False,
     run_index: str | None = "first",
     allow_partial_seasons: bool | Literal["start", "end"] = False,
-    ) -> Dataset:
+) -> Dataset:
     """Average of the difference between two variables, or one variable and it's reference period values (e.g. DTR: `mean(tasmax - tasmin)`).
 
     mean_of_difference: Average of the difference between two variables, or one variable and it's reference period values (e.g. DTR: `mean(tasmax - tasmin)`).
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -2049,7 +2053,7 @@ def mean_of_difference(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
@@ -2093,12 +2097,12 @@ def difference_of_extremes(
     date_event: bool = False,
     run_index: str | None = "first",
     allow_partial_seasons: bool | Literal["start", "end"] = False,
-    ) -> Dataset:
+) -> Dataset:
     """Difference of extremes between two variables, or one variable and it's reference period values. The extremes are always `maximum` for the first variable and `minimum` for the second variable (e.g. ETR: `max(tasmax) - min(tasmin)`).
 
     difference_of_extremes: Difference of extremes between two variables, or one variable and it's reference period values. The extremes are always `maximum` for the first variable and `minimum` for the second variable (e.g. ETR: `max(tasmax) - min(tasmin)`).
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -2174,7 +2178,7 @@ def difference_of_extremes(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
@@ -2218,12 +2222,12 @@ def mean_of_absolute_one_time_step_difference(
     date_event: bool = False,
     run_index: str | None = "first",
     allow_partial_seasons: bool | Literal["start", "end"] = False,
-    ) -> Dataset:
+) -> Dataset:
     """Average of the absolute one time step by one time step difference between two variables, or one variable and it's reference period values (e.g. vDTR: `mean((tasmax[i] - tasmin[i]) - (tasmax[i-1] - tasmin[i-1])` ; where i is the day of measure).
 
     mean_of_absolute_one_time_step_difference: Average of the absolute one time step by one time step difference between two variables, or one variable and it's reference period values (e.g. vDTR: `mean((tasmax[i] - tasmin[i]) - (tasmax[i-1] - tasmin[i-1])` ; where i is the day of measure).
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -2299,7 +2303,7 @@ def mean_of_absolute_one_time_step_difference(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
@@ -2344,12 +2348,12 @@ def difference_of_means(
     sampling_method: SamplingMethodLike = "resample",
     run_index: str | None = "first",
     allow_partial_seasons: bool | Literal["start", "end"] = False,
-    ) -> Dataset:
+) -> Dataset:
     """Difference of the average between two variables, or one variable and it's reference period values (e.g. anomaly: `mean(tasmax) - mean(tasmax_ref]))`.
 
     difference_of_means: Difference of the average between two variables, or one variable and it's reference period values (e.g. anomaly: `mean(tasmax) - mean(tasmax_ref]))`.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -2433,7 +2437,7 @@ def difference_of_means(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
@@ -2478,12 +2482,12 @@ def percentile(
     date_event: bool = False,
     run_index: str | None = "first",
     allow_partial_seasons: bool | Literal["start", "end"] = False,
-    ) -> Dataset:
+) -> Dataset:
     """Percentile of a variable.
 
     percentile: Percentile of a variable.
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -2559,7 +2563,7 @@ def percentile(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
@@ -2588,8 +2592,8 @@ def percentile(
 
 
 def custom_index(
-        user_index: UserIndexDict,
-        in_files: InFileLike,
+    user_index: UserIndexDict,
+    in_files: InFileLike,
     var_name: str | Sequence[str] | None = None,
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
@@ -2616,7 +2620,7 @@ def custom_index(
     Use the `user_index` parameter to describe how the index should be computed.
     You can find some examples in icclim documentation at :ref:`custom indices`
 
-    
+
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -2726,7 +2730,7 @@ def custom_index(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-    
+
     Notes
     -----
     This function has been auto-generated.
@@ -2754,6 +2758,5 @@ def custom_index(
         rolling_window_width=rolling_window_width,
         sampling_method=sampling_method,
         run_index=run_index,
-        allow_partial_seasons=allow_partial_seasons
+        allow_partial_seasons=allow_partial_seasons,
     )
-    

--- a/src/icclim/_generated/_generic.py
+++ b/src/icclim/_generated/_generic.py
@@ -122,8 +122,14 @@ def count_occurrences(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -247,8 +253,14 @@ def max_consecutive_occurrence(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -373,8 +385,14 @@ def sum_of_spell_lengths(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     min_spell_length : int
         ``optional`` Minimum spell duration to be taken into account when computing
         the sum_of_spell_lengths.
@@ -502,8 +520,14 @@ def excess(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -627,8 +651,14 @@ def deficit(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -752,8 +782,14 @@ def fraction_of_total(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -877,8 +913,14 @@ def maximum(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -1002,8 +1044,14 @@ def minimum(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -1127,8 +1175,14 @@ def average(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -1252,8 +1306,14 @@ def sum(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -1377,8 +1437,14 @@ def standard_deviation(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -1503,8 +1569,14 @@ def max_of_rolling_sum(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     rolling_window_width : int
         ``optional`` Window width of the rolling window for indicators such as
         `{max_of_rolling_sum, max_of_rolling_average, min_of_rolling_sum, min_of_rolling_average}`
@@ -1633,8 +1705,14 @@ def min_of_rolling_sum(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     rolling_window_width : int
         ``optional`` Window width of the rolling window for indicators such as
         `{max_of_rolling_sum, max_of_rolling_average, min_of_rolling_sum, min_of_rolling_average}`
@@ -1763,8 +1841,14 @@ def max_of_rolling_average(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     rolling_window_width : int
         ``optional`` Window width of the rolling window for indicators such as
         `{max_of_rolling_sum, max_of_rolling_average, min_of_rolling_sum, min_of_rolling_average}`
@@ -1893,8 +1977,14 @@ def min_of_rolling_average(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     rolling_window_width : int
         ``optional`` Window width of the rolling window for indicators such as
         `{max_of_rolling_sum, max_of_rolling_average, min_of_rolling_sum, min_of_rolling_average}`
@@ -2022,8 +2112,14 @@ def mean_of_difference(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -2147,8 +2243,14 @@ def difference_of_extremes(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -2272,8 +2374,14 @@ def mean_of_absolute_one_time_step_difference(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -2398,8 +2506,14 @@ def difference_of_means(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -2532,8 +2646,14 @@ def percentile(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -2674,8 +2794,14 @@ def custom_index(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     doy_window_width : int
         ``optional`` Window width used to aggreagte day of year values when computing
         day of year percentiles (doy_per)

--- a/src/icclim/_generated/_generic.py
+++ b/src/icclim/_generated/_generic.py
@@ -126,10 +126,12 @@ def count_occurrences(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -257,10 +259,12 @@ def max_consecutive_occurrence(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -389,10 +393,12 @@ def sum_of_spell_lengths(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     min_spell_length : int
         ``optional`` Minimum spell duration to be taken into account when computing
         the sum_of_spell_lengths.
@@ -524,10 +530,12 @@ def excess(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -655,10 +663,12 @@ def deficit(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -786,10 +796,12 @@ def fraction_of_total(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -917,10 +929,12 @@ def maximum(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -1048,10 +1062,12 @@ def minimum(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -1179,10 +1195,12 @@ def average(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -1310,10 +1328,12 @@ def sum(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -1441,10 +1461,12 @@ def standard_deviation(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -1573,10 +1595,12 @@ def max_of_rolling_sum(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     rolling_window_width : int
         ``optional`` Window width of the rolling window for indicators such as
         `{max_of_rolling_sum, max_of_rolling_average, min_of_rolling_sum, min_of_rolling_average}`
@@ -1709,10 +1733,12 @@ def min_of_rolling_sum(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     rolling_window_width : int
         ``optional`` Window width of the rolling window for indicators such as
         `{max_of_rolling_sum, max_of_rolling_average, min_of_rolling_sum, min_of_rolling_average}`
@@ -1845,10 +1871,12 @@ def max_of_rolling_average(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     rolling_window_width : int
         ``optional`` Window width of the rolling window for indicators such as
         `{max_of_rolling_sum, max_of_rolling_average, min_of_rolling_sum, min_of_rolling_average}`
@@ -1981,10 +2009,12 @@ def min_of_rolling_average(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     rolling_window_width : int
         ``optional`` Window width of the rolling window for indicators such as
         `{max_of_rolling_sum, max_of_rolling_average, min_of_rolling_sum, min_of_rolling_average}`
@@ -2116,10 +2146,12 @@ def mean_of_difference(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -2247,10 +2279,12 @@ def difference_of_extremes(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -2378,10 +2412,12 @@ def mean_of_absolute_one_time_step_difference(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -2510,10 +2546,12 @@ def difference_of_means(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -2650,10 +2688,12 @@ def percentile(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
@@ -2798,10 +2838,12 @@ def custom_index(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     doy_window_width : int
         ``optional`` Window width used to aggreagte day of year values when computing
         day of year percentiles (doy_per)

--- a/src/icclim/_generated/_generic.py
+++ b/src/icclim/_generated/_generic.py
@@ -21,11 +21,7 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from icclim.logger import Verbosity
-    from icclim._core.model.icclim_types import (
-        FrequencyLike,
-        InFileLike,
-        SamplingMethodLike,
-    )
+    from icclim._core.model.icclim_types import FrequencyLike, InFileLike, SamplingMethodLike
     from icclim.frequency import Frequency
     from icclim._core.model.netcdf_version import NetcdfVersion
     from icclim._core.model.quantile_interpolation import QuantileInterpolation
@@ -63,7 +59,7 @@ def count_occurrences(
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
     threshold: str | Threshold | Sequence[str | Threshold] | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     out_unit: str | None = None,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
@@ -72,12 +68,12 @@ def count_occurrences(
     date_event: bool = False,
     run_index: str | None = "first",
     allow_partial_seasons: bool | Literal["start", "end"] = False,
-) -> Dataset:
+    ) -> Dataset:
     """Count occurrences when threshold(s) are met (e.g. SU, Tx90p, RR1).
 
     count_occurrences: Count occurrences when threshold(s) are met (e.g. SU, Tx90p, RR1).
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -88,7 +84,7 @@ def count_occurrences(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -101,29 +97,30 @@ def count_occurrences(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    threshold : float | list[float] | None, default=depend
+    threshold : float | list[float] | None
         ``optional`` User defined threshold for certain indices.
         Default depend on the index, see their individual definition.
         When a list of threshold is provided, the index will be computed for each
         thresholds.
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -144,7 +141,7 @@ def count_occurrences(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -152,7 +149,7 @@ def count_occurrences(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
@@ -187,7 +184,7 @@ def max_consecutive_occurrence(
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
     threshold: str | Threshold | Sequence[str | Threshold] | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     out_unit: str | None = None,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
@@ -196,12 +193,12 @@ def max_consecutive_occurrence(
     date_event: bool = False,
     run_index: str | None = "first",
     allow_partial_seasons: bool | Literal["start", "end"] = False,
-) -> Dataset:
+    ) -> Dataset:
     """Count the maximum number of consecutive occurrences when threshold(s) are met (e.g. CDD, CSU, CWD).
 
     max_consecutive_occurrence: Count the maximum number of consecutive occurrences when threshold(s) are met (e.g. CDD, CSU, CWD).
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -212,7 +209,7 @@ def max_consecutive_occurrence(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -225,29 +222,30 @@ def max_consecutive_occurrence(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    threshold : float | list[float] | None, default=depend
+    threshold : float | list[float] | None
         ``optional`` User defined threshold for certain indices.
         Default depend on the index, see their individual definition.
         When a list of threshold is provided, the index will be computed for each
         thresholds.
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -268,7 +266,7 @@ def max_consecutive_occurrence(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -276,7 +274,7 @@ def max_consecutive_occurrence(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
@@ -311,7 +309,7 @@ def sum_of_spell_lengths(
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
     threshold: str | Threshold | Sequence[str | Threshold] | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     out_unit: str | None = None,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
@@ -321,12 +319,12 @@ def sum_of_spell_lengths(
     min_spell_length: int | None = 6,
     run_index: str | None = "first",
     allow_partial_seasons: bool | Literal["start", "end"] = False,
-) -> Dataset:
+    ) -> Dataset:
     """Sum the lengths of each consecutive occurrence spell when threshold(s) are met. The minimum spell length is controlled by `min_spell_length` (e.g. WSDI, CSDI).
 
     sum_of_spell_lengths: Sum the lengths of each consecutive occurrence spell when threshold(s) are met. The minimum spell length is controlled by `min_spell_length` (e.g. WSDI, CSDI).
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -337,7 +335,7 @@ def sum_of_spell_lengths(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -350,32 +348,33 @@ def sum_of_spell_lengths(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    threshold : float | list[float] | None, default=depend
+    threshold : float | list[float] | None
         ``optional`` User defined threshold for certain indices.
         Default depend on the index, see their individual definition.
         When a list of threshold is provided, the index will be computed for each
         thresholds.
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
     min_spell_length : int
         ``optional`` Minimum spell duration to be taken into account when computing
         the sum_of_spell_lengths.
-    run_index : str | None, default="first"
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -396,7 +395,7 @@ def sum_of_spell_lengths(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -404,7 +403,7 @@ def sum_of_spell_lengths(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
@@ -440,7 +439,7 @@ def excess(
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
     threshold: str | Threshold | Sequence[str | Threshold] | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     out_unit: str | None = None,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
@@ -449,12 +448,12 @@ def excess(
     date_event: bool = False,
     run_index: str | None = "first",
     allow_partial_seasons: bool | Literal["start", "end"] = False,
-) -> Dataset:
+    ) -> Dataset:
     """Compute the excess over the given threshold. The excess is `sum(x[x>t] - t)` where x is the studied variable and t the threshold (e.g. GD4).
 
     excess: Compute the excess over the given threshold. The excess is `sum(x[x>t] - t)` where x is the studied variable and t the threshold (e.g. GD4).
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -465,7 +464,7 @@ def excess(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -478,29 +477,30 @@ def excess(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    threshold : float | list[float] | None, default=depend
+    threshold : float | list[float] | None
         ``optional`` User defined threshold for certain indices.
         Default depend on the index, see their individual definition.
         When a list of threshold is provided, the index will be computed for each
         thresholds.
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -521,7 +521,7 @@ def excess(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -529,7 +529,7 @@ def excess(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
@@ -564,7 +564,7 @@ def deficit(
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
     threshold: str | Threshold | Sequence[str | Threshold] | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     out_unit: str | None = None,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
@@ -573,12 +573,12 @@ def deficit(
     date_event: bool = False,
     run_index: str | None = "first",
     allow_partial_seasons: bool | Literal["start", "end"] = False,
-) -> Dataset:
+    ) -> Dataset:
     """Compute the deficit below the given threshold. The deficit is `sum(t - x[x<t])` where x is the studied variable and t the threshold (e.g. HD17).
 
     deficit: Compute the deficit below the given threshold. The deficit is `sum(t - x[x<t])` where x is the studied variable and t the threshold (e.g. HD17).
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -589,7 +589,7 @@ def deficit(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -602,29 +602,30 @@ def deficit(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    threshold : float | list[float] | None, default=depend
+    threshold : float | list[float] | None
         ``optional`` User defined threshold for certain indices.
         Default depend on the index, see their individual definition.
         When a list of threshold is provided, the index will be computed for each
         thresholds.
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -645,7 +646,7 @@ def deficit(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -653,7 +654,7 @@ def deficit(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
@@ -688,7 +689,7 @@ def fraction_of_total(
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
     threshold: str | Threshold | Sequence[str | Threshold] | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     out_unit: str | None = None,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
@@ -697,12 +698,12 @@ def fraction_of_total(
     date_event: bool = False,
     run_index: str | None = "first",
     allow_partial_seasons: bool | Literal["start", "end"] = False,
-) -> Dataset:
+    ) -> Dataset:
     """Compute the fraction of values meeting threshold(s) over the sum of every values (e.g. R75pTOT, R95pTOT).
 
     fraction_of_total: Compute the fraction of values meeting threshold(s) over the sum of every values (e.g. R75pTOT, R95pTOT).
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -713,7 +714,7 @@ def fraction_of_total(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -726,29 +727,30 @@ def fraction_of_total(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    threshold : float | list[float] | None, default=depend
+    threshold : float | list[float] | None
         ``optional`` User defined threshold for certain indices.
         Default depend on the index, see their individual definition.
         When a list of threshold is provided, the index will be computed for each
         thresholds.
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -769,7 +771,7 @@ def fraction_of_total(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -777,7 +779,7 @@ def fraction_of_total(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
@@ -812,7 +814,7 @@ def maximum(
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
     threshold: str | Threshold | Sequence[str | Threshold] | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     out_unit: str | None = None,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
@@ -821,12 +823,12 @@ def maximum(
     date_event: bool = False,
     run_index: str | None = "first",
     allow_partial_seasons: bool | Literal["start", "end"] = False,
-) -> Dataset:
+    ) -> Dataset:
     """Maximum of values that met threshold(s), if threshold(s) are given (e.g. Txx, Tnx).
 
     maximum: Maximum of values that met threshold(s), if threshold(s) are given (e.g. Txx, Tnx).
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -837,7 +839,7 @@ def maximum(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -850,29 +852,30 @@ def maximum(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    threshold : float | list[float] | None, default=depend
+    threshold : float | list[float] | None
         ``optional`` User defined threshold for certain indices.
         Default depend on the index, see their individual definition.
         When a list of threshold is provided, the index will be computed for each
         thresholds.
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -893,7 +896,7 @@ def maximum(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -901,7 +904,7 @@ def maximum(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
@@ -936,7 +939,7 @@ def minimum(
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
     threshold: str | Threshold | Sequence[str | Threshold] | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     out_unit: str | None = None,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
@@ -945,12 +948,12 @@ def minimum(
     date_event: bool = False,
     run_index: str | None = "first",
     allow_partial_seasons: bool | Literal["start", "end"] = False,
-) -> Dataset:
+    ) -> Dataset:
     """Minimum of values that met threshold(s), if threshold(s) are given (e.g. Txn, Tnn).
 
     minimum: Minimum of values that met threshold(s), if threshold(s) are given (e.g. Txn, Tnn).
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -961,7 +964,7 @@ def minimum(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -974,29 +977,30 @@ def minimum(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    threshold : float | list[float] | None, default=depend
+    threshold : float | list[float] | None
         ``optional`` User defined threshold for certain indices.
         Default depend on the index, see their individual definition.
         When a list of threshold is provided, the index will be computed for each
         thresholds.
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -1017,7 +1021,7 @@ def minimum(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -1025,7 +1029,7 @@ def minimum(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
@@ -1060,7 +1064,7 @@ def average(
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
     threshold: str | Threshold | Sequence[str | Threshold] | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     out_unit: str | None = None,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
@@ -1069,12 +1073,12 @@ def average(
     date_event: bool = False,
     run_index: str | None = "first",
     allow_partial_seasons: bool | Literal["start", "end"] = False,
-) -> Dataset:
+    ) -> Dataset:
     """Average of values that met threshold(s), if threshold(s) are given (e.g. Tx, Tn).
 
     average: Average of values that met threshold(s), if threshold(s) are given (e.g. Tx, Tn).
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -1085,7 +1089,7 @@ def average(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -1098,29 +1102,30 @@ def average(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    threshold : float | list[float] | None, default=depend
+    threshold : float | list[float] | None
         ``optional`` User defined threshold for certain indices.
         Default depend on the index, see their individual definition.
         When a list of threshold is provided, the index will be computed for each
         thresholds.
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -1141,7 +1146,7 @@ def average(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -1149,7 +1154,7 @@ def average(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
@@ -1184,7 +1189,7 @@ def sum(
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
     threshold: str | Threshold | Sequence[str | Threshold] | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     out_unit: str | None = None,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
@@ -1193,12 +1198,12 @@ def sum(
     date_event: bool = False,
     run_index: str | None = "first",
     allow_partial_seasons: bool | Literal["start", "end"] = False,
-) -> Dataset:
+    ) -> Dataset:
     """Sum of values that met threshold(s), if threshold(s) are given (e.g. PRCPTOT, RR).
 
     sum: Sum of values that met threshold(s), if threshold(s) are given (e.g. PRCPTOT, RR).
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -1209,7 +1214,7 @@ def sum(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -1222,29 +1227,30 @@ def sum(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    threshold : float | list[float] | None, default=depend
+    threshold : float | list[float] | None
         ``optional`` User defined threshold for certain indices.
         Default depend on the index, see their individual definition.
         When a list of threshold is provided, the index will be computed for each
         thresholds.
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -1265,7 +1271,7 @@ def sum(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -1273,7 +1279,7 @@ def sum(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
@@ -1308,7 +1314,7 @@ def standard_deviation(
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
     threshold: str | Threshold | Sequence[str | Threshold] | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     out_unit: str | None = None,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
@@ -1317,12 +1323,12 @@ def standard_deviation(
     date_event: bool = False,
     run_index: str | None = "first",
     allow_partial_seasons: bool | Literal["start", "end"] = False,
-) -> Dataset:
+    ) -> Dataset:
     """Standard deviation of values that met threshold(s), if threshold(s) are given.
 
     standard_deviation: Standard deviation of values that met threshold(s), if threshold(s) are given.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -1333,7 +1339,7 @@ def standard_deviation(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -1346,29 +1352,30 @@ def standard_deviation(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    threshold : float | list[float] | None, default=depend
+    threshold : float | list[float] | None
         ``optional`` User defined threshold for certain indices.
         Default depend on the index, see their individual definition.
         When a list of threshold is provided, the index will be computed for each
         thresholds.
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -1389,7 +1396,7 @@ def standard_deviation(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -1397,7 +1404,7 @@ def standard_deviation(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
@@ -1432,7 +1439,7 @@ def max_of_rolling_sum(
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
     threshold: str | Threshold | Sequence[str | Threshold] | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     out_unit: str | None = None,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
@@ -1442,12 +1449,12 @@ def max_of_rolling_sum(
     rolling_window_width: int | None = 5,
     run_index: str | None = "first",
     allow_partial_seasons: bool | Literal["start", "end"] = False,
-) -> Dataset:
+    ) -> Dataset:
     """Maximum of rolling sum over time dimension (e.g. RX5DAY: maximum 5 days window of precipitation accumulation).
 
     max_of_rolling_sum: Maximum of rolling sum over time dimension (e.g. RX5DAY: maximum 5 days window of precipitation accumulation).
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -1458,7 +1465,7 @@ def max_of_rolling_sum(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -1471,32 +1478,33 @@ def max_of_rolling_sum(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    threshold : float | list[float] | None, default=depend
+    threshold : float | list[float] | None
         ``optional`` User defined threshold for certain indices.
         Default depend on the index, see their individual definition.
         When a list of threshold is provided, the index will be computed for each
         thresholds.
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
     rolling_window_width : int
         ``optional`` Window width of the rolling window for indicators such as
         `{max_of_rolling_sum, max_of_rolling_average, min_of_rolling_sum, min_of_rolling_average}`
-    run_index : str | None, default="first"
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -1517,7 +1525,7 @@ def max_of_rolling_sum(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -1525,7 +1533,7 @@ def max_of_rolling_sum(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
@@ -1561,7 +1569,7 @@ def min_of_rolling_sum(
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
     threshold: str | Threshold | Sequence[str | Threshold] | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     out_unit: str | None = None,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
@@ -1571,12 +1579,12 @@ def min_of_rolling_sum(
     rolling_window_width: int | None = 5,
     run_index: str | None = "first",
     allow_partial_seasons: bool | Literal["start", "end"] = False,
-) -> Dataset:
+    ) -> Dataset:
     """Minimum of rolling sum over time dimension.
 
     min_of_rolling_sum: Minimum of rolling sum over time dimension.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -1587,7 +1595,7 @@ def min_of_rolling_sum(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -1600,32 +1608,33 @@ def min_of_rolling_sum(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    threshold : float | list[float] | None, default=depend
+    threshold : float | list[float] | None
         ``optional`` User defined threshold for certain indices.
         Default depend on the index, see their individual definition.
         When a list of threshold is provided, the index will be computed for each
         thresholds.
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
     rolling_window_width : int
         ``optional`` Window width of the rolling window for indicators such as
         `{max_of_rolling_sum, max_of_rolling_average, min_of_rolling_sum, min_of_rolling_average}`
-    run_index : str | None, default="first"
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -1646,7 +1655,7 @@ def min_of_rolling_sum(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -1654,7 +1663,7 @@ def min_of_rolling_sum(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
@@ -1690,7 +1699,7 @@ def max_of_rolling_average(
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
     threshold: str | Threshold | Sequence[str | Threshold] | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     out_unit: str | None = None,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
@@ -1700,12 +1709,12 @@ def max_of_rolling_average(
     rolling_window_width: int | None = 5,
     run_index: str | None = "first",
     allow_partial_seasons: bool | Literal["start", "end"] = False,
-) -> Dataset:
+    ) -> Dataset:
     """Maximum of rolling average over time dimension.
 
     max_of_rolling_average: Maximum of rolling average over time dimension.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -1716,7 +1725,7 @@ def max_of_rolling_average(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -1729,32 +1738,33 @@ def max_of_rolling_average(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    threshold : float | list[float] | None, default=depend
+    threshold : float | list[float] | None
         ``optional`` User defined threshold for certain indices.
         Default depend on the index, see their individual definition.
         When a list of threshold is provided, the index will be computed for each
         thresholds.
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
     rolling_window_width : int
         ``optional`` Window width of the rolling window for indicators such as
         `{max_of_rolling_sum, max_of_rolling_average, min_of_rolling_sum, min_of_rolling_average}`
-    run_index : str | None, default="first"
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -1775,7 +1785,7 @@ def max_of_rolling_average(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -1783,7 +1793,7 @@ def max_of_rolling_average(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
@@ -1819,7 +1829,7 @@ def min_of_rolling_average(
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
     threshold: str | Threshold | Sequence[str | Threshold] | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     out_unit: str | None = None,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
@@ -1829,12 +1839,12 @@ def min_of_rolling_average(
     rolling_window_width: int | None = 5,
     run_index: str | None = "first",
     allow_partial_seasons: bool | Literal["start", "end"] = False,
-) -> Dataset:
+    ) -> Dataset:
     """Minimum of rolling average over time dimension.
 
     min_of_rolling_average: Minimum of rolling average over time dimension.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -1845,7 +1855,7 @@ def min_of_rolling_average(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -1858,32 +1868,33 @@ def min_of_rolling_average(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    threshold : float | list[float] | None, default=depend
+    threshold : float | list[float] | None
         ``optional`` User defined threshold for certain indices.
         Default depend on the index, see their individual definition.
         When a list of threshold is provided, the index will be computed for each
         thresholds.
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
     rolling_window_width : int
         ``optional`` Window width of the rolling window for indicators such as
         `{max_of_rolling_sum, max_of_rolling_average, min_of_rolling_sum, min_of_rolling_average}`
-    run_index : str | None, default="first"
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -1904,7 +1915,7 @@ def min_of_rolling_average(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -1912,7 +1923,7 @@ def min_of_rolling_average(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
@@ -1948,7 +1959,7 @@ def mean_of_difference(
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
     threshold: str | Threshold | Sequence[str | Threshold] | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     out_unit: str | None = None,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
@@ -1957,12 +1968,12 @@ def mean_of_difference(
     date_event: bool = False,
     run_index: str | None = "first",
     allow_partial_seasons: bool | Literal["start", "end"] = False,
-) -> Dataset:
+    ) -> Dataset:
     """Average of the difference between two variables, or one variable and it's reference period values (e.g. DTR: `mean(tasmax - tasmin)`).
 
     mean_of_difference: Average of the difference between two variables, or one variable and it's reference period values (e.g. DTR: `mean(tasmax - tasmin)`).
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -1973,7 +1984,7 @@ def mean_of_difference(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -1986,29 +1997,30 @@ def mean_of_difference(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    threshold : float | list[float] | None, default=depend
+    threshold : float | list[float] | None
         ``optional`` User defined threshold for certain indices.
         Default depend on the index, see their individual definition.
         When a list of threshold is provided, the index will be computed for each
         thresholds.
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -2029,7 +2041,7 @@ def mean_of_difference(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -2037,7 +2049,7 @@ def mean_of_difference(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
@@ -2072,7 +2084,7 @@ def difference_of_extremes(
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
     threshold: str | Threshold | Sequence[str | Threshold] | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     out_unit: str | None = None,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
@@ -2081,12 +2093,12 @@ def difference_of_extremes(
     date_event: bool = False,
     run_index: str | None = "first",
     allow_partial_seasons: bool | Literal["start", "end"] = False,
-) -> Dataset:
+    ) -> Dataset:
     """Difference of extremes between two variables, or one variable and it's reference period values. The extremes are always `maximum` for the first variable and `minimum` for the second variable (e.g. ETR: `max(tasmax) - min(tasmin)`).
 
     difference_of_extremes: Difference of extremes between two variables, or one variable and it's reference period values. The extremes are always `maximum` for the first variable and `minimum` for the second variable (e.g. ETR: `max(tasmax) - min(tasmin)`).
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -2097,7 +2109,7 @@ def difference_of_extremes(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -2110,29 +2122,30 @@ def difference_of_extremes(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    threshold : float | list[float] | None, default=depend
+    threshold : float | list[float] | None
         ``optional`` User defined threshold for certain indices.
         Default depend on the index, see their individual definition.
         When a list of threshold is provided, the index will be computed for each
         thresholds.
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -2153,7 +2166,7 @@ def difference_of_extremes(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -2161,7 +2174,7 @@ def difference_of_extremes(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
@@ -2196,7 +2209,7 @@ def mean_of_absolute_one_time_step_difference(
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
     threshold: str | Threshold | Sequence[str | Threshold] | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     out_unit: str | None = None,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
@@ -2205,12 +2218,12 @@ def mean_of_absolute_one_time_step_difference(
     date_event: bool = False,
     run_index: str | None = "first",
     allow_partial_seasons: bool | Literal["start", "end"] = False,
-) -> Dataset:
+    ) -> Dataset:
     """Average of the absolute one time step by one time step difference between two variables, or one variable and it's reference period values (e.g. vDTR: `mean((tasmax[i] - tasmin[i]) - (tasmax[i-1] - tasmin[i-1])` ; where i is the day of measure).
 
     mean_of_absolute_one_time_step_difference: Average of the absolute one time step by one time step difference between two variables, or one variable and it's reference period values (e.g. vDTR: `mean((tasmax[i] - tasmin[i]) - (tasmax[i-1] - tasmin[i-1])` ; where i is the day of measure).
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -2221,7 +2234,7 @@ def mean_of_absolute_one_time_step_difference(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -2234,29 +2247,30 @@ def mean_of_absolute_one_time_step_difference(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    threshold : float | list[float] | None, default=depend
+    threshold : float | list[float] | None
         ``optional`` User defined threshold for certain indices.
         Default depend on the index, see their individual definition.
         When a list of threshold is provided, the index will be computed for each
         thresholds.
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -2277,7 +2291,7 @@ def mean_of_absolute_one_time_step_difference(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -2285,7 +2299,7 @@ def mean_of_absolute_one_time_step_difference(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
@@ -2320,7 +2334,7 @@ def difference_of_means(
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
     threshold: str | Threshold | Sequence[str | Threshold] | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     out_unit: str | None = None,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
@@ -2330,12 +2344,12 @@ def difference_of_means(
     sampling_method: SamplingMethodLike = "resample",
     run_index: str | None = "first",
     allow_partial_seasons: bool | Literal["start", "end"] = False,
-) -> Dataset:
+    ) -> Dataset:
     """Difference of the average between two variables, or one variable and it's reference period values (e.g. anomaly: `mean(tasmax) - mean(tasmax_ref]))`.
 
     difference_of_means: Difference of the average between two variables, or one variable and it's reference period values (e.g. anomaly: `mean(tasmax) - mean(tasmax_ref]))`.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -2346,7 +2360,7 @@ def difference_of_means(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -2359,29 +2373,30 @@ def difference_of_means(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    threshold : float | list[float] | None, default=depend
+    threshold : float | list[float] | None
         ``optional`` User defined threshold for certain indices.
         Default depend on the index, see their individual definition.
         When a list of threshold is provided, the index will be computed for each
         thresholds.
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -2410,7 +2425,7 @@ def difference_of_means(
         (default: "resample")
         `groupby_ref_and_resample_study` may only be used when computing the
         `difference_of_means` (a.k.a the anomaly).
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -2418,7 +2433,7 @@ def difference_of_means(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
@@ -2454,7 +2469,7 @@ def percentile(
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
     threshold: str | Threshold | Sequence[str | Threshold] | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     ignore_Feb29th: bool = False,
     out_unit: str | None = None,
     netcdf_version: str | NetcdfVersion = "NETCDF4",
@@ -2463,12 +2478,12 @@ def percentile(
     date_event: bool = False,
     run_index: str | None = "first",
     allow_partial_seasons: bool | Literal["start", "end"] = False,
-) -> Dataset:
+    ) -> Dataset:
     """Percentile of a variable.
 
     percentile: Percentile of a variable.
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -2479,7 +2494,7 @@ def percentile(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -2492,29 +2507,30 @@ def percentile(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
         Use the function returned value instead to retrieve the computed value.
         If ``out_file`` already exists, icclim will overwrite it!
-    threshold : float | list[float] | None, default=depend
+    threshold : float | list[float] | None
         ``optional`` User defined threshold for certain indices.
         Default depend on the index, see their individual definition.
         When a list of threshold is provided, the index will be computed for each
         thresholds.
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    run_index : str | None, default="first"
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -2535,7 +2551,7 @@ def percentile(
     logs_verbosity : str | Verbosity
         ``optional`` Configure how verbose icclim is.
         Possible values: ``{"LOW", "HIGH", "SILENT"}`` (default: "LOW")
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -2543,7 +2559,7 @@ def percentile(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
@@ -2572,14 +2588,14 @@ def percentile(
 
 
 def custom_index(
-    user_index: UserIndexDict,
-    in_files: InFileLike,
+        user_index: UserIndexDict,
+        in_files: InFileLike,
     var_name: str | Sequence[str] | None = None,
     slice_mode: FrequencyLike | Frequency = "year",
     time_range: Sequence[dt.datetime | str] | None = None,
     out_file: str | None = None,
     base_period_time_range: Sequence[dt.datetime] | Sequence[str] | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     doy_window_width: int = 5,
     only_leap_years: bool = False,
     ignore_Feb29th: bool = False,
@@ -2600,7 +2616,7 @@ def custom_index(
     Use the `user_index` parameter to describe how the index should be computed.
     You can find some examples in icclim documentation at :ref:`custom indices`
 
-
+    
     Parameters
     ----------
     in_files : str | list[str] | Dataset | DataArray | InputDictionary
@@ -2611,7 +2627,7 @@ def custom_index(
         If None (default) on ECA&D index, the variable is guessed based on the
         climate index wanted.
         Mandatory for a user index.
-    slice_mode : FrequencyLike | Frequency, default="year"
+    slice_mode : FrequencyLike | Frequency
         Type of temporal aggregation:
         The possibles values are ``{"year", "month", "DJF", "MAM", "JJA", "SON",
         "ONDJFM" or "AMJJAS", ("season", [1,2,3]), ("month", [1,2,3,])}``
@@ -2624,13 +2640,13 @@ def custom_index(
         ``(start_da, end_da)``.
         Default is "year".
         See :ref:`slice_mode` for details.
-    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None, default=is
+    time_range : list[datetime.datetime ] | list[str]  | tuple[str, str] | None
         ``optional`` Temporal range: upper and lower bounds for temporal subsetting.
         If ``None``, whole period of input files will be processed.
         The dates can either be given as instance of datetime.datetime or as string
         values. For strings, many format are accepted.
         Default is ``None``.
-    out_file : str | None, default="icclim_out.nc"
+    out_file : str | None
         Output NetCDF file name (default: "icclim_out.nc" in the current directory).
         Default is "icclim_out.nc".
         If the input ``in_files`` is a ``Dataset``, ``out_file`` field is ignored.
@@ -2650,12 +2666,13 @@ def custom_index(
         bootstrapped.
         #. to compute a reference period for indices such as difference_of_mean
         (a.k.a anomaly) if a single variable is given in input.
-    bootstrap : bool | None
+    bootstrap : bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
-    doy_window_width : int, default=5
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
+    doy_window_width : int
         ``optional`` Window width used to aggreagte day of year values when computing
         day of year percentiles (doy_per)
         Default: 5 (5 days).
@@ -2665,7 +2682,7 @@ def custom_index(
     rolling_window_width : int
         ``optional`` Window width of the rolling window for indicators such as
         `{max_of_rolling_sum, max_of_rolling_average, min_of_rolling_sum, min_of_rolling_average}`
-    run_index : str | None, default="first"
+    run_index : str | None
         ``optional`` The index to use for the run length encoding (e.g. "first", "last", "mid").
         Default is "first".
         Ignored for non spell indices.
@@ -2673,7 +2690,7 @@ def custom_index(
         ``optional`` Option for February 29th (default: False).
     ignore_Feb29th : bool
         ``optional`` Ignoring or not February 29th (default: False).
-    interpolation : str | QuantileInterpolation | None, default="median_unbiased"
+    interpolation : str | QuantileInterpolation | None
         ``optional`` Interpolation method to compute percentile values:
         ``{"linear", "median_unbiased"}``
         Default is "median_unbiased", a.k.a type 8 or method 8.
@@ -2701,7 +2718,7 @@ def custom_index(
         (default: "resample")
         `groupby_ref_and_resample_study` may only be used when computing the
         `difference_of_means` (a.k.a the anomaly).
-    allow_partial_seasons : bool | "start" | "end", default=False
+    allow_partial_seasons : bool | "start" | "end"
         Flag indicating whether to allow partial seasons to be included in the
         index calculation.
         - True: Unmasks both the first and last periods.
@@ -2709,7 +2726,7 @@ def custom_index(
         - "start": Unmasks only the first period.
         - "end": Unmasks only the last period.
         Default is False.
-
+    
     Notes
     -----
     This function has been auto-generated.
@@ -2737,5 +2754,6 @@ def custom_index(
         rolling_window_width=rolling_window_width,
         sampling_method=sampling_method,
         run_index=run_index,
-        allow_partial_seasons=allow_partial_seasons,
+        allow_partial_seasons=allow_partial_seasons
     )
+    

--- a/src/icclim/main.py
+++ b/src/icclim/main.py
@@ -334,8 +334,14 @@ def index(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
-        which is slower but avoids building one large Dask graph.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. Use ``"safe"`` to request this reliability mode
+        explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
+        graph path for diagnostics. ``bootstrap=False`` should only be used as an
+        explicit user shortcut for fast exploratory assessments, because disabling
+        bootstrap removes the overlap correction and can bias percentile-based
+        results.
     doy_window_width: int
         ``optional`` Window width used to aggreagte day of year values when computing
         day of year percentiles (doy_per)

--- a/src/icclim/main.py
+++ b/src/icclim/main.py
@@ -230,7 +230,7 @@ def index(
     callback_percentage_start_value: int = 0,
     callback_percentage_total: int = 100,
     base_period_time_range: Sequence[dt.datetime] | Sequence[str] | None = None,
-    bootstrap: bool | None = None,
+    bootstrap: bool | Literal["safe"] | None = None,
     doy_window_width: int = 5,
     only_leap_years: bool = False,
     ignore_Feb29th: bool = False,
@@ -330,11 +330,12 @@ def index(
         bootstrapped.
         #. to compute a reference period for indices such as difference_of_mean
         (a.k.a anomaly) if a single variable is given in input.
-    bootstrap: bool | None
+    bootstrap: bool | "safe" | None
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
+        threshold type. Use ``"safe"`` to run bootstrap through bounded spatial tiles,
+        which is slower but avoids building one large Dask graph.
     doy_window_width: int
         ``optional`` Window width used to aggreagte day of year values when computing
         day of year percentiles (doy_per)
@@ -541,7 +542,7 @@ def _build_config(
     threshold: str | Threshold | Sequence[str | Threshold] | None,
     callback: Callable[[int], None],
     base_period_time_range: Sequence[dt.datetime] | Sequence[str] | None,
-    bootstrap: bool | None,
+    bootstrap: bool | Literal["safe"] | None,
     doy_window_width: int,
     only_leap_years: bool,
     ignore_feb29th: bool,
@@ -661,7 +662,7 @@ def _build_user_index_config(
     time_range: Sequence[dt.datetime | str] | None,
     callback: Callable[[int], None],
     base_period_time_range: Sequence[dt.datetime] | Sequence[str] | None,
-    bootstrap: bool | None,
+    bootstrap: bool | Literal["safe"] | None,
     doy_window_width: int,
     only_leap_years: bool,
     ignore_feb29th: bool,
@@ -745,7 +746,7 @@ def _build_standard_index_config(
     threshold: str | Threshold | Sequence[str | Threshold] | None,
     callback: Callable[[int], None],
     base_period_time_range: Sequence[dt.datetime] | Sequence[str] | None,
-    bootstrap: bool | None,
+    bootstrap: bool | Literal["safe"] | None,
     doy_window_width: int,
     only_leap_years: bool,
     ignore_feb29th: bool,

--- a/src/icclim/main.py
+++ b/src/icclim/main.py
@@ -338,10 +338,12 @@ def index(
         uses bounded spatial tiles so users do not have to find a working dask chunking
         strategy by trial and error. Use ``"safe"`` to request this reliability mode
         explicitly, or set ``ICCLIM_BOOTSTRAP_MODE=default`` to keep the legacy dask
-        graph path for diagnostics. ``bootstrap=False`` should only be used as an
-        explicit user shortcut for fast exploratory assessments, because disabling
-        bootstrap removes the overlap correction and can bias percentile-based
-        results.
+        graph path for diagnostics. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        ``bootstrap=False`` should only be used as an explicit user shortcut for fast
+        exploratory assessments, because disabling bootstrap removes the overlap
+        correction and can bias percentile-based results.
     doy_window_width: int
         ``optional`` Window width used to aggreagte day of year values when computing
         day of year percentiles (doy_per)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -808,10 +808,16 @@ class TestIntegration:
             "slice_mode": "ms",
         }
 
-        default = icclim.index(**common_kwargs).compute()
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_MODE", "default")
+        legacy = icclim.index(**common_kwargs).compute()
+        monkeypatch.delenv("ICCLIM_BOOTSTRAP_MODE")
+
+        default = icclim.index(**common_kwargs)
         safe = icclim.index(**common_kwargs, bootstrap="safe").compute()
 
-        xr.testing.assert_allclose(safe.TX90p, default.TX90p)
+        assert not hasattr(default.TX90p.data, "__dask_graph__")
+        xr.testing.assert_allclose(default.TX90p, legacy.TX90p)
+        xr.testing.assert_allclose(safe.TX90p, legacy.TX90p)
 
     def test_index_wsdi__no_bootstrap_because_no_overlap(self) -> None:
         tas = stub_tas(tas_value=27 + K2C)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -753,6 +753,29 @@ class TestIntegration:
         assert res.TX90p.sel(time="2042-01") == 0
         assert res.TX90p.sel(time="2043-01") == 5
 
+    def test_index_tx90p__bootstrap_3_years_with_dask(self) -> None:
+        tas = stub_tas(tas_value=27 + K2C)
+        tas[5:10] = 0
+        tas[370:375] = 40 + K2C
+        tas[735:740] = 10 + K2C
+        tas = tas.chunk({"time": 365, "lat": 1, "lon": 1})
+        res = icclim.index(
+            index_name="tx90p",
+            in_files=tas,
+            doy_window_width=1,
+            time_range=("2042-01-01", "2045-12-31"),
+            base_period_time_range=("2042-01-01", "2044-12-31"),
+            out_file=self.OUTPUT_FILE,
+            slice_mode="ms",
+        ).compute()
+        assert REFERENCE_PERIOD_ID in res.TX90p.attrs
+        jan_slice = res.TX90p.sel(time=slice("2042-01-01", "2044-12-31"))
+        jan_values = jan_slice.where(jan_slice.time.dt.month == 1, drop=True).values.ravel()
+        assert jan_values.dtype.kind == "f"
+        assert len(set(jan_values.tolist())) > 1
+        assert jan_values.min() >= 0
+        assert jan_values.max() <= 31
+
     def test_index_tx90p__bootstrap_can_be_disabled(self) -> None:
         tas = stub_tas(tas_value=27 + K2C)
         tas[5:10] = 0
@@ -784,6 +807,24 @@ class TestIntegration:
         # 1 more day than in tas because of resample_doy that interpolate values
         assert res.WSDI.isel(time=0) == 11
 
+    def test_index_wsdi__bootstrap_overlap_runs(self) -> None:
+        tas = stub_tas(tas_value=27 + K2C)
+        tas[0:10] = 0
+        tas[370:382] = 35 + K2C
+        tas = tas.chunk({"time": 365, "lat": 1, "lon": 1})
+        res = icclim.index(
+            index_name="wsdi",
+            in_files=tas,
+            doy_window_width=1,
+            time_range=("2042-01-01", "2045-12-31"),
+            base_period_time_range=("2042-01-01", "2043-12-31"),
+            out_file=self.OUTPUT_FILE,
+            slice_mode="ms",
+        ).compute()
+        assert REFERENCE_PERIOD_ID in res.WSDI.attrs
+        assert res.WSDI.dtype.kind == "f"
+        assert float(res.WSDI.min()) >= 0
+
     def test_index_csdi__no_bootstrap_because_no_overlap(self) -> None:
         tas = stub_tas(tas_value=2 + K2C)
         tas[0:10] = 35 + K2C
@@ -799,6 +840,24 @@ class TestIntegration:
         assert REFERENCE_PERIOD_ID not in res.CSDI.attrs
         # 1 more day than in tas because of resample_doy that interpolate values
         assert res.CSDI.isel(time=0) == 11
+
+    def test_index_csdi__bootstrap_overlap_runs(self) -> None:
+        tas = stub_tas(tas_value=2 + K2C)
+        tas[0:10] = 35 + K2C
+        tas[370:382] = -5 + K2C
+        tas = tas.chunk({"time": 365, "lat": 1, "lon": 1})
+        res = icclim.index(
+            index_name="csdi",
+            in_files=tas,
+            doy_window_width=1,
+            time_range=("2042-01-01", "2045-12-31"),
+            base_period_time_range=("2042-01-01", "2043-12-31"),
+            out_file=self.OUTPUT_FILE,
+            slice_mode="ms",
+        ).compute()
+        assert REFERENCE_PERIOD_ID in res.CSDI.attrs
+        assert res.CSDI.dtype.kind == "f"
+        assert float(res.CSDI.min()) >= 0
 
     def test_count_occurrences__date_event(self) -> None:
         tas = stub_tas(tas_value=2 + K2C)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -14,6 +14,7 @@ import xarray as xr
 import icclim
 from icclim import __version__ as icclim_version
 from icclim._core.constants import PART_OF_A_WHOLE_UNIT, REFERENCE_PERIOD_ID, UNITS_KEY
+from icclim._core.generic import functions as generic_functions
 from icclim._core.model.index_group import IndexGroupRegistry
 from icclim.ecad.registry import EcadIndexRegistry
 from icclim.exception import InvalidIcclimArgumentError
@@ -818,6 +819,29 @@ class TestIntegration:
         assert not hasattr(default.TX90p.data, "__dask_graph__")
         xr.testing.assert_allclose(default.TX90p, legacy.TX90p)
         xr.testing.assert_allclose(safe.TX90p, legacy.TX90p)
+
+    def test_index_tx90p__safe_bootstrap_uses_memory_budget(self, monkeypatch) -> None:
+        monkeypatch.delenv("ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS", raising=False)
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY", "1B")
+        tas = stub_tas(tas_value=27 + K2C, lat_length=2, lon_length=2)
+        tas[5:10] = 0
+        tas = tas.chunk({"time": 365, "lat": 1, "lon": 1})
+
+        generic_functions.reset_bootstrap_profile()
+        res = icclim.index(
+            index_name="tx90p",
+            in_files=tas,
+            doy_window_width=1,
+            time_range=("2042-01-01", "2045-12-31"),
+            base_period_time_range=("2042-01-01", "2043-12-31"),
+            out_file=self.OUTPUT_FILE,
+            slice_mode="ms",
+        )
+        profile = generic_functions.get_bootstrap_profile()
+
+        assert not hasattr(res.TX90p.data, "__dask_graph__")
+        assert profile["bootstrap_safe_max_tile_cells"] == 1
+        assert profile["bootstrap_safe_tile_count"] == 4
 
     def test_index_wsdi__no_bootstrap_because_no_overlap(self) -> None:
         tas = stub_tas(tas_value=27 + K2C)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -736,6 +736,23 @@ class TestIntegration:
         # 2043 values are compared to 2042's 90th percentile due to bootstrap
         assert res.TX90p.sel(time="2043-01") == 5
 
+    def test_index_tx90p__bootstrap_2_years_with_dask(self) -> None:
+        tas = stub_tas(tas_value=27 + K2C)
+        tas[5:10] = 0
+        tas = tas.chunk({"time": 365, "lat": 1, "lon": 1})
+        res = icclim.index(
+            index_name="tx90p",
+            in_files=tas,
+            doy_window_width=1,
+            time_range=("2042-01-01", "2045-12-31"),
+            base_period_time_range=("2042-01-01", "2043-12-31"),
+            out_file=self.OUTPUT_FILE,
+            slice_mode="ms",
+        ).compute()
+        assert REFERENCE_PERIOD_ID in res.TX90p.attrs
+        assert res.TX90p.sel(time="2042-01") == 0
+        assert res.TX90p.sel(time="2043-01") == 5
+
     def test_index_tx90p__bootstrap_can_be_disabled(self) -> None:
         tas = stub_tas(tas_value=27 + K2C)
         tas[5:10] = 0

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -843,6 +843,50 @@ class TestIntegration:
         assert profile["bootstrap_safe_max_tile_cells"] == 1
         assert profile["bootstrap_safe_tile_count"] == 4
 
+    def test_index_tx90p__safe_bootstrap_retries_on_memory_error(
+        self,
+        monkeypatch,
+    ) -> None:
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS", "4")
+        tas = stub_tas(tas_value=27 + K2C, lat_length=2, lon_length=2)
+        tas[5:10] = 0
+        tas = tas.chunk({"time": 365, "lat": 1, "lon": 1})
+        original_bootstrap = generic_functions._compute_bootstrapped_percentile_index
+
+        def fail_until_single_cell(*args, **kwargs):
+            climate_var = args[0]
+            spatial_cells = 1
+            for dim, size in climate_var.studied_data.sizes.items():
+                if dim != "time":
+                    spatial_cells *= size
+            if spatial_cells > 1:
+                msg = "simulated bootstrap tile memory pressure"
+                raise MemoryError(msg)
+            return original_bootstrap(*args, **kwargs)
+
+        monkeypatch.setattr(
+            generic_functions,
+            "_compute_bootstrapped_percentile_index",
+            fail_until_single_cell,
+        )
+        generic_functions.reset_bootstrap_profile()
+
+        res = icclim.index(
+            index_name="tx90p",
+            in_files=tas,
+            doy_window_width=1,
+            time_range=("2042-01-01", "2045-12-31"),
+            base_period_time_range=("2042-01-01", "2043-12-31"),
+            out_file=self.OUTPUT_FILE,
+            slice_mode="ms",
+        )
+        profile = generic_functions.get_bootstrap_profile()
+
+        assert not hasattr(res.TX90p.data, "__dask_graph__")
+        assert profile["bootstrap_safe_memory_retry_count"] == 2
+        assert profile["bootstrap_safe_max_tile_cells"] == 1
+        assert profile["bootstrap_safe_tile_count"] == 4
+
     def test_index_wsdi__no_bootstrap_because_no_overlap(self) -> None:
         tas = stub_tas(tas_value=27 + K2C)
         tas[0:10] = 0

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -791,6 +791,25 @@ class TestIntegration:
         )
         assert REFERENCE_PERIOD_ID not in res.TX90p.attrs
 
+    def test_index_tx90p__bootstrap_safe_matches_default(self) -> None:
+        tas = stub_tas(tas_value=27 + K2C)
+        tas[5:10] = 0
+        tas = tas.chunk({"time": 365, "lat": 1, "lon": 1})
+        common_kwargs = dict(
+            index_name="tx90p",
+            in_files=tas,
+            doy_window_width=1,
+            time_range=("2042-01-01", "2045-12-31"),
+            base_period_time_range=("2042-01-01", "2043-12-31"),
+            out_file=self.OUTPUT_FILE,
+            slice_mode="ms",
+        )
+
+        default = icclim.index(**common_kwargs).compute()
+        safe = icclim.index(**common_kwargs, bootstrap="safe").compute()
+
+        xr.testing.assert_allclose(safe.TX90p, default.TX90p)
+
     def test_index_wsdi__no_bootstrap_because_no_overlap(self) -> None:
         tas = stub_tas(tas_value=27 + K2C)
         tas[0:10] = 0

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -770,7 +770,9 @@ class TestIntegration:
         ).compute()
         assert REFERENCE_PERIOD_ID in res.TX90p.attrs
         jan_slice = res.TX90p.sel(time=slice("2042-01-01", "2044-12-31"))
-        jan_values = jan_slice.where(jan_slice.time.dt.month == 1, drop=True).values.ravel()
+        jan_values = jan_slice.where(
+            jan_slice.time.dt.month == 1, drop=True
+        ).values.ravel()
         assert jan_values.dtype.kind == "f"
         assert len(set(jan_values.tolist())) > 1
         assert jan_values.min() >= 0

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -791,19 +791,20 @@ class TestIntegration:
         )
         assert REFERENCE_PERIOD_ID not in res.TX90p.attrs
 
-    def test_index_tx90p__bootstrap_safe_matches_default(self) -> None:
-        tas = stub_tas(tas_value=27 + K2C)
+    def test_index_tx90p__bootstrap_safe_matches_default(self, monkeypatch) -> None:
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS", "1")
+        tas = stub_tas(tas_value=27 + K2C, lat_length=2, lon_length=2)
         tas[5:10] = 0
         tas = tas.chunk({"time": 365, "lat": 1, "lon": 1})
-        common_kwargs = dict(
-            index_name="tx90p",
-            in_files=tas,
-            doy_window_width=1,
-            time_range=("2042-01-01", "2045-12-31"),
-            base_period_time_range=("2042-01-01", "2043-12-31"),
-            out_file=self.OUTPUT_FILE,
-            slice_mode="ms",
-        )
+        common_kwargs = {
+            "index_name": "tx90p",
+            "in_files": tas,
+            "doy_window_width": 1,
+            "time_range": ("2042-01-01", "2045-12-31"),
+            "base_period_time_range": ("2042-01-01", "2043-12-31"),
+            "out_file": self.OUTPUT_FILE,
+            "slice_mode": "ms",
+        }
 
         default = icclim.index(**common_kwargs).compute()
         safe = icclim.index(**common_kwargs, bootstrap="safe").compute()

--- a/tests/test_percentile_bootstrap.py
+++ b/tests/test_percentile_bootstrap.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from icclim._core.generic.threshold.percentile import (
+    _build_single_bootstrap_reference,
+)
+from tests.testing_utils import stub_tas
+
+
+def test_build_single_bootstrap_reference__common_year_target_from_leap_donor() -> None:
+    tas = stub_tas()
+    groups = tas.resample(time="YS").groups
+
+    boot_ref = _build_single_bootstrap_reference(
+        tas,
+        groups,
+        pd.Timestamp("2045-01-01"),
+        pd.Timestamp("2044-01-01"),
+    )
+
+    target_time = tas.sel(time=slice("2045-01-01", "2045-12-31")).time
+    replaced_time = boot_ref.sel(time=slice("2045-01-01", "2045-12-31")).time
+
+    assert boot_ref.sizes["time"] == tas.sizes["time"]
+    assert replaced_time.equals(target_time)
+    assert len(replaced_time) == 365
+    assert boot_ref.indexes["time"].is_unique
+
+
+def test_build_single_bootstrap_reference__leap_year_target_from_common_donor() -> None:
+    tas = stub_tas()
+    groups = tas.resample(time="YS").groups
+
+    boot_ref = _build_single_bootstrap_reference(
+        tas,
+        groups,
+        pd.Timestamp("2044-01-01"),
+        pd.Timestamp("2045-01-01"),
+    )
+
+    target_time = tas.sel(time=slice("2044-01-01", "2044-12-31")).time
+    replaced_time = boot_ref.sel(time=slice("2044-01-01", "2044-12-31")).time
+
+    assert boot_ref.sizes["time"] == tas.sizes["time"]
+    assert replaced_time.equals(target_time)
+    assert len(replaced_time) == 366
+    assert boot_ref.indexes["time"].is_unique


### PR DESCRIPTION
## Summary

- Make Dask-backed percentile count bootstrap use a bounded tiled reliability path by default when bootstrap is actually needed.
- Size safe-bootstrap spatial tiles from a memory budget: `ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY` defaults to `2GB`; `ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS` remains an expert/test override.
- If a safe tile fails with a memory-like error, automatically halve the tile size and retry, down to one spatial cell per tile before raising a clear error.
- Keep `bootstrap="safe"` as an explicit way to request the same reliability path, and add `ICCLIM_BOOTSTRAP_MODE=default` only as a diagnostic escape hatch for comparing with the legacy graph path.
- Keep `bootstrap=False` as an explicit user-selected shortcut for fast exploratory assessment only; docs warn that it disables the overlap correction and can bias percentile-based results.

## Why

This PR is about reliability, not speed. Large Dask-backed percentile bootstrap jobs can fail before users get any result: graph construction can become effectively unbounded, or execution can exhaust memory. Users should not have to trial-and-error chunking strategies to make scientifically required bootstrap run.

The intended behavior is closer to icclim v4: possibly long, but bounded and much more likely to finish. The tiled path computes and loads bounded spatial tiles instead of returning one huge deferred bootstrap graph. The memory-budget heuristic and retry loop intentionally trade speed for lower peak-memory risk.

## Scientific Note

Bootstrap remains the default when the reference period overlaps the study period and the overlap structure is bootstrappable. `bootstrap=False` is not a robustness fix; it is only for quick exploratory assessment because it removes the overlap correction and can produce biased percentile-index results.

## Validation

- `pre-commit run --all-files`
- `pytest tests/test_main.py -k 'bootstrap or tg90p or tx90p or wsdi or csdi' tests/test_percentile_bootstrap.py tests/test_generic_functions.py tests/test_generated_api.py -q`
- Added a regression test that simulates memory pressure and verifies safe bootstrap retries with smaller tiles until the computation succeeds.
- Local real-NetCDF TG90P smoke, `ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY=512MB`: `graph_tasks=0`, `bootstrap_safe_tile_count=1`, total about `12s`.
- Local real-NetCDF TG90P smoke, `ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY=10MB`: `graph_tasks=0`, `bootstrap_safe_tile_count=3`, same result mean as the 512MB run, total about `32s`.

## Benchmark Notes

- Earlier Kraken TG90P benchmark with the safe path returned an eager result with `graph_tasks=0`.
- Numerical comparison against the current default bootstrap path showed max absolute difference around `7e-6`, consistent with floating-point-level variation.
- This PR does not claim a speed improvement; large-scale HPC validation should focus on whether jobs finish reliably without Dask graph/memory failure.

## Current Scope

- Automatic safe tiled execution currently applies to percentile count indices such as TG90P/TX90P/TN90P.
- Spell/run-length percentile indices still use the existing bootstrap path and remain a follow-up target.
