### PR TITLE
Improve Dask reliability for percentile count bootstrap

### DIFF
--- a/doc/source/how_to/dask.rst
+++ b/doc/source/how_to/dask.rst
@@ -218,6 +218,10 @@ https://docs.dask.org/en/stable/scheduling.html#local-threads
    The bootstrap period is the overlapping years between the period
    where percentile are computed (a.k.a "in base") and the period where
    the climate index is computed (a.k.a "out of base").
+|  For dask-backed percentile count indices, icclim automatically uses bounded
+   spatial tiles when bootstrap is needed. This reliability path may be slower,
+   but it avoids leaving users with a very large Dask graph that may never
+   finish.
 
 .. note::
 
@@ -583,9 +587,22 @@ Disk read and write analysis - Dashboard
    -  This bootstrap is scientifically important when percentile thresholds are
       computed on a reference period that overlaps the study period, especially
       for ETCCDI-style percentile-based extreme indices such as the 10th and
-      90th percentile temperature indices. If the exact overlap treatment is
-      too expensive for your dask setup, ``bootstrap=False`` can be used as a
-      pragmatic performance workaround.
+      90th percentile temperature indices. For dask-backed percentile count
+      indices, icclim automatically uses a tiled reliability path to avoid one
+      huge bootstrap graph. If the exact overlap treatment is still
+      operationally impossible, a user may explicitly choose ``bootstrap=False``
+      only for fast exploratory assessment. This disables the overlap correction,
+      so percentile-based results can be scientifically biased and should not be
+      treated as the corrected final result.
+   -  Expert configuration: lower
+      ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``) to reduce peak
+      memory further, for example ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY=512MB``.
+      This creates more spatial tiles and can be slower, but each tile asks dask
+      to keep less bootstrap working data in memory.
+   -  Expert diagnostics: ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` overrides the
+      memory-derived tile size with an explicit maximum number of spatial cells
+      per tile. ``ICCLIM_BOOTSTRAP_MODE=default`` disables the safe tiled path
+      and keeps the legacy dask graph path for comparison only.
 
 Worker chatterbox syndrome - Dashboard
 ======================================

--- a/doc/source/references/api/icclim/index.rst
+++ b/doc/source/references/api/icclim/index.rst
@@ -106,13 +106,21 @@ Package Contents
    :param bootstrap: ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
                      Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
                      ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-                     threshold type. This overlap-based bootstrap is part of the standard
+                     threshold type. For dask-backed percentile count indices, icclim
+                     automatically computes bootstrap one bounded spatial tile at a time so
+                     users do not have to find a working dask chunking strategy by trial and
+                     error. The safe path derives its spatial tile size from
+                     ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+                     ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+                     Set ``ICCLIM_BOOTSTRAP_MODE=default`` only for diagnostics to keep the
+                     legacy dask graph path.
+                     This overlap-based bootstrap is part of the standard
                      treatment for percentile-based extreme indices when the reference period
                      overlaps the study period. In practice it matters for common ETCCDI-style
                      thresholds such as the 10th and 90th percentiles, and can be even more
-                     consequential for stronger percentile thresholds. Because it is
-                     computationally expensive, ``bootstrap=False`` can still be a useful
-                     pragmatic workaround on large dask-backed datasets.
+                     consequential for stronger percentile thresholds. ``bootstrap=False`` is
+                     only a user-selected shortcut for fast exploratory assessment: it disables
+                     the overlap correction and can bias percentile-based results.
    :type bootstrap: bool | None
    :param doy_window_width: ``optional`` Window width used to aggreagte day of year values when computing
                             day of year percentiles (doy_per)

--- a/doc/source/references/release_notes.rst
+++ b/doc/source/references/release_notes.rst
@@ -13,7 +13,7 @@ Details
 =======
 
 -  [fix] Restore compatibility with latest ``xclim`` releases by adapting ``to_agg_units`` calls to the installed API signature instead of always passing ``deffreq``.
--  [enh] Add a ``bootstrap`` override to ``icclim.index(...)`` for day-of-year percentile thresholds. Use ``bootstrap=False`` to disable overlap-based bootstrap on large dask-backed datasets when the default path is too expensive.
+-  [enh] Add bootstrap reliability controls for day-of-year percentile thresholds. For dask-backed percentile count indices, icclim now uses a memory-budgeted tiled bootstrap path by default to avoid oversized dask graphs and reduce peak memory risk. ``bootstrap=False`` remains an explicit user shortcut for fast exploratory assessment only, because it disables the overlap correction and can bias percentile-based results.
 -  [maint] Keep the existing bootstrap implementation as the release path while follow-up work continues on a native replacement. The experimental prepared-state optimization is not included in ``v7.1.3``.
 -  [maint] Bump ``peter-evans/create-pull-request`` from ``v7`` to ``v8`` in CI maintenance workflows to avoid GitHub Actions Node 20 deprecation warnings.
 

--- a/doc/source/references/thresholds.rst
+++ b/doc/source/references/thresholds.rst
@@ -133,9 +133,16 @@ Two flavours exist, selected by the unit string:
    avoid artificially inflated counts. This is relevant for standard
    percentile-based extreme indices, including the classic 10th and 90th
    percentile temperature indices, and can be even more important for stronger
-   percentile thresholds. On very large dask-backed datasets, users may still
-   choose ``bootstrap=False`` as a pragmatic workaround when the full
-   bootstrapping procedure is too expensive.
+   percentile thresholds. On dask-backed percentile count indices, icclim uses
+   bounded spatial tiles automatically when bootstrap is needed, so users do not
+   have to discover a working dask chunking strategy by trial and error. The safe
+   path derives its spatial tile size from
+   ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+   ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override. Users may
+   still choose ``bootstrap=False`` only as a fast exploratory shortcut when the
+   full bootstrapping procedure is operationally impossible. This disables the
+   overlap correction, so percentile-based results can be scientifically biased
+   and should not be treated as the corrected final result.
 
 BoundedThreshold
 ================

--- a/src/icclim/_core/climate_variable.py
+++ b/src/icclim/_core/climate_variable.py
@@ -369,8 +369,8 @@ def must_run_bootstrap(
         )
     ):
         return False
-    if bootstrap is not None:
-        return bootstrap
+    if bootstrap is False:
+        return False
     reference = threshold.value
     time_index = da.indexes.get("time")
     if time_index is None:

--- a/src/icclim/_core/generic/functions.py
+++ b/src/icclim/_core/generic/functions.py
@@ -18,9 +18,12 @@ The `DataArray` instance is the result of the computation of the generic index.
 from __future__ import annotations
 
 import operator
+import os
 import warnings
 from collections.abc import Callable
+from copy import copy
 from functools import partial
+from time import perf_counter
 from typing import TYPE_CHECKING, Any, cast
 from warnings import warn
 
@@ -63,6 +66,31 @@ if TYPE_CHECKING:
     from icclim._core.generic.threshold.percentile import PercentileThreshold
     from icclim._core.model.logical_link import LogicalLink
     from icclim._core.model.threshold import Threshold
+
+
+_BOOTSTRAP_PROFILE: dict[str, float | int] = {}
+_DEFAULT_BOOTSTRAP_SAFE_TILE_MEMORY = "2GB"
+_BOOTSTRAP_SAFE_MEMORY_FACTOR = 12
+
+
+def reset_bootstrap_profile() -> None:
+    _BOOTSTRAP_PROFILE.clear()
+
+
+def get_bootstrap_profile() -> dict[str, float | int]:
+    return dict(_BOOTSTRAP_PROFILE)
+
+
+def _profile_bootstrap_add(name: str, seconds: float) -> None:
+    _BOOTSTRAP_PROFILE[name] = float(_BOOTSTRAP_PROFILE.get(name, 0.0)) + seconds
+
+
+def _profile_bootstrap_inc(name: str, count: int = 1) -> None:
+    _BOOTSTRAP_PROFILE[name] = int(_BOOTSTRAP_PROFILE.get(name, 0)) + count
+
+
+def _profile_bootstrap_set(name: str, value: float) -> None:
+    _BOOTSTRAP_PROFILE[name] = value
 
 
 def count_occurrences(
@@ -118,6 +146,24 @@ def count_occurrences(
     >>> int(result.count_occurrences.isel(time=0).values)
     365
     """
+    if len(climate_vars) == 1 and not date_event:
+        safe_bootstrapped = _compute_safe_tiled_count_occurrences(
+            climate_vars[0],
+            resample_freq,
+        )
+        if safe_bootstrapped is not None:
+            if to_percent:
+                safe_bootstrapped = _to_percent(safe_bootstrapped, resample_freq)
+                safe_bootstrapped.attrs[UNITS_KEY] = "%"
+                return safe_bootstrapped
+            freq = check_freq(climate_vars[0].studied_data, dim="time")
+            return _safe_to_agg_units(
+                safe_bootstrapped,
+                climate_vars[0].studied_data,
+                "count",
+                deffreq=freq,
+            )
+
     if date_event:
         reducer_op = _count_occurrences_with_date
     else:
@@ -1205,6 +1251,259 @@ def _compute_exceedance(
         if climatology_bounds is not None:
             exceedances.attrs[REFERENCE_PERIOD_ID] = climatology_bounds
     return exceedances
+
+
+def _compute_safe_tiled_count_occurrences(
+    climate_var: ClimateVariable,
+    resample_freq: Frequency,
+) -> DataArray | None:
+    threshold = climate_var.threshold
+    if threshold is None:
+        return None
+    from icclim._core.generic.threshold.percentile import (  # noqa: PLC0415
+        PercentileThreshold,
+    )
+
+    if (
+        not isinstance(threshold, PercentileThreshold)
+        or not threshold.is_doy_per_threshold
+    ):
+        return None
+    if not _should_use_safe_count_bootstrap(climate_var):
+        return None
+    if not must_run_bootstrap(
+        climate_var.studied_data, threshold, climate_var.bootstrap
+    ):
+        return None
+
+    safe_start = perf_counter()
+    max_cells = _get_safe_bootstrap_max_cells(
+        climate_var.studied_data,
+        threshold,
+        resample_freq,
+    )
+    _profile_bootstrap_set("bootstrap_safe_max_tile_cells", max_cells)
+    while True:
+        try:
+            return _compute_safe_tiled_count_occurrences_with_max_cells(
+                climate_var,
+                threshold,
+                resample_freq,
+                max_cells,
+                safe_start,
+            )
+        except Exception as err:  # noqa: PERF203
+            if not _is_memory_like_bootstrap_error(err):
+                raise
+            if max_cells <= 1:
+                msg = (
+                    "Percentile bootstrap failed even with one spatial cell per tile. "
+                    "Try reducing the time range, using fewer workers/threads, or "
+                    "running with more memory."
+                )
+                raise MemoryError(msg) from err
+            max_cells = max(1, max_cells // 2)
+            _profile_bootstrap_inc("bootstrap_safe_memory_retry_count")
+            _profile_bootstrap_set("bootstrap_safe_max_tile_cells", max_cells)
+
+
+def _compute_safe_tiled_count_occurrences_with_max_cells(
+    climate_var: ClimateVariable,
+    threshold: PercentileThreshold,
+    resample_freq: Frequency,
+    max_cells: int,
+    safe_start: float,
+) -> DataArray:
+    tile_results: list[DataArray] = []
+    for tile_indexers in _iter_spatial_tiles(climate_var.studied_data, max_cells):
+        tile_start = perf_counter()
+        tile_study = climate_var.studied_data.isel(tile_indexers)
+        tile_threshold = _slice_threshold_for_tile(threshold, tile_indexers)
+        tile_exceedance = _compute_exceedance(
+            tile_study,
+            tile_threshold,
+            freq=resample_freq.pandas_freq,
+            bootstrap=True,
+        )
+        tile_result = tile_exceedance.resample(time=resample_freq.pandas_freq).sum(
+            dim="time"
+        )
+        if "percentiles" in tile_result.dims:
+            tile_result = tile_result.squeeze("percentiles")
+        tile_results.append(tile_result.load())
+        _profile_bootstrap_inc("bootstrap_safe_tile_count")
+        _profile_bootstrap_add(
+            "bootstrap_safe_tile_seconds",
+            perf_counter() - tile_start,
+        )
+
+    if len(tile_results) == 1:
+        result = tile_results[0]
+    else:
+        result = xr.combine_by_coords(
+            [tile.to_dataset(name="__icclim_bootstrap_tile") for tile in tile_results],
+            combine_attrs="override",
+        )["__icclim_bootstrap_tile"]
+    result.attrs.update(tile_results[-1].attrs)
+    _profile_bootstrap_add(
+        "bootstrap_safe_total_seconds",
+        perf_counter() - safe_start,
+    )
+    return result
+
+
+def _should_use_safe_count_bootstrap(climate_var: ClimateVariable) -> bool:
+    if climate_var.bootstrap is False:
+        return False
+    if os.environ.get("ICCLIM_BOOTSTRAP_MODE") == "default":
+        return False
+    from xclim.core.utils import uses_dask  # noqa: PLC0415
+
+    return uses_dask(climate_var.studied_data)
+
+
+def _get_safe_bootstrap_max_cells(
+    study: DataArray,
+    threshold: PercentileThreshold,
+    resample_freq: Frequency,
+) -> int:
+    if max_cells := os.environ.get("ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS"):
+        return max(1, int(max_cells))
+    max_mem = _parse_byte_size(
+        os.environ.get(
+            "ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY",
+            _DEFAULT_BOOTSTRAP_SAFE_TILE_MEMORY,
+        )
+    )
+    bytes_per_cell = _estimate_bootstrap_working_bytes_per_cell(
+        study,
+        threshold,
+        resample_freq,
+    )
+    _profile_bootstrap_set("bootstrap_safe_tile_memory_bytes", max_mem)
+    _profile_bootstrap_set("bootstrap_safe_estimated_bytes_per_cell", bytes_per_cell)
+    return max(1, max_mem // bytes_per_cell)
+
+
+def _estimate_bootstrap_working_bytes_per_cell(
+    study: DataArray,
+    threshold: PercentileThreshold,
+    resample_freq: Frequency,
+) -> int:
+    clim = threshold.value.attrs["climatology_bounds"]
+    overlap_da = study.sel(time=slice(*clim))
+    overlap_groups = overlap_da.resample(
+        time=_get_bootstrap_freq(resample_freq.pandas_freq)
+    ).groups
+    n_bootstrap = max(1, len(overlap_groups) - 1)
+    itemsize = getattr(study.dtype, "itemsize", 8)
+    raw_bootstrap_bytes = max(1, overlap_da.sizes["time"]) * n_bootstrap * itemsize
+    return raw_bootstrap_bytes * _BOOTSTRAP_SAFE_MEMORY_FACTOR
+
+
+def _get_bootstrap_freq(freq: str) -> str:
+    from xclim.core.calendar import parse_offset  # noqa: PLC0415
+
+    _, base, start_anchor, anchor = parse_offset(freq)
+    bfreq = "YS" if start_anchor else "YE"
+    if base in ["A", "Y", "Q"] and anchor is not None:
+        bfreq = f"{bfreq}-{anchor}"
+    return bfreq
+
+
+def _parse_byte_size(value: str) -> int:
+    normalized = value.strip().lower().replace(" ", "")
+    units = {
+        "b": 1,
+        "kb": 1000,
+        "kib": 1024,
+        "mb": 1000**2,
+        "mib": 1024**2,
+        "gb": 1000**3,
+        "gib": 1024**3,
+    }
+    for unit, multiplier in sorted(
+        units.items(), key=lambda item: len(item[0]), reverse=True
+    ):
+        if normalized.endswith(unit):
+            return max(1, int(float(normalized.removesuffix(unit)) * multiplier))
+    return max(1, int(float(normalized)))
+
+
+def _iter_spatial_tiles(
+    da: DataArray,
+    max_cells: int,
+) -> list[dict[str, slice]]:
+    spatial_dims = [dim for dim in da.dims if dim != "time"]
+    if not spatial_dims:
+        return [{}]
+
+    tile_lengths = {dim: da.sizes[dim] for dim in spatial_dims}
+    product = 1
+    for dim in spatial_dims:
+        product *= tile_lengths[dim]
+    while product > max_cells:
+        dim = max(tile_lengths, key=tile_lengths.get)
+        old = tile_lengths[dim]
+        tile_lengths[dim] = max(1, old // 2)
+        product = 1
+        for value in tile_lengths.values():
+            product *= value
+        if tile_lengths[dim] == old:
+            break
+
+    tiles: list[dict[str, slice]] = [{}]
+    for dim in spatial_dims:
+        dim_tiles = [
+            slice(start, min(start + tile_lengths[dim], da.sizes[dim]))
+            for start in range(0, da.sizes[dim], tile_lengths[dim])
+        ]
+        tiles = [
+            {**prefix, dim: dim_tile} for prefix in tiles for dim_tile in dim_tiles
+        ]
+    return tiles
+
+
+def _slice_threshold_for_tile(
+    threshold: PercentileThreshold,
+    tile_indexers: dict[str, slice],
+) -> PercentileThreshold:
+    sliced = copy(threshold)
+    value = threshold.value
+    value_indexers = {
+        dim: indexer for dim, indexer in tile_indexers.items() if dim in value.dims
+    }
+    if value_indexers:
+        sliced._prepared_value = value.isel(value_indexers)  # noqa: SLF001
+    return sliced
+
+
+def _is_memory_like_bootstrap_error(err: BaseException) -> bool:
+    if isinstance(err, MemoryError):
+        return True
+    err_type = type(err).__name__.lower()
+    memory_error_types = {
+        "arraymemoryerror",
+        "killedworker",
+        "nannyrestart",
+        "reschedule",
+        "workerlost",
+        "workerkilled",
+    }
+    if err_type in memory_error_types:
+        return True
+    message = str(err).lower()
+    memory_fragments = (
+        "failed to allocate",
+        "killed worker",
+        "malloc",
+        "memoryerror",
+        "out of memory",
+        "oom",
+        "worker died",
+        "worker exceeded",
+    )
+    return any(fragment in message for fragment in memory_fragments)
 
 
 def get_couple_of_var(

--- a/src/icclim/main.py
+++ b/src/icclim/main.py
@@ -334,7 +334,15 @@ def index(
         ``optional`` Override bootstrap behavior for day-of-year percentile thresholds.
         Use ``None`` (default) to rely on icclim's overlap-based bootstrap logic,
         ``False`` to disable bootstrap, or ``True`` to force it when supported by the
-        threshold type.
+        threshold type. For dask-backed percentile count indices, icclim automatically
+        uses bounded spatial tiles so users do not have to find a working dask chunking
+        strategy by trial and error. The safe path derives its spatial tile size from
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY`` (default: ``2GB``), unless
+        ``ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS`` is set as an expert override.
+        Set ``ICCLIM_BOOTSTRAP_MODE=default`` only for diagnostics to keep the legacy
+        dask graph path. ``bootstrap=False`` should only be used as an explicit user
+        shortcut for fast exploratory assessments, because disabling bootstrap removes
+        the overlap correction and can bias percentile-based results.
     doy_window_width: int
         ``optional`` Window width used to aggreagte day of year values when computing
         day of year percentiles (doy_per)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -14,6 +14,7 @@ import xarray as xr
 import icclim
 from icclim import __version__ as icclim_version
 from icclim._core.constants import PART_OF_A_WHOLE_UNIT, REFERENCE_PERIOD_ID, UNITS_KEY
+from icclim._core.generic import functions as generic_functions
 from icclim._core.model.index_group import IndexGroupRegistry
 from icclim.ecad.registry import EcadIndexRegistry
 from icclim.exception import InvalidIcclimArgumentError
@@ -750,6 +751,118 @@ class TestIntegration:
             slice_mode="ms",
         )
         assert REFERENCE_PERIOD_ID not in res.TX90p.attrs
+
+    def test_index_tx90p__bootstrap_true_keeps_overlap_guard(self) -> None:
+        tas = stub_tas(tas_value=27 + K2C).chunk({"time": 365, "lat": 1, "lon": 1})
+        res = icclim.index(
+            index_name="tx90p",
+            in_files=tas,
+            doy_window_width=5,
+            base_period_time_range=("2042-01-01", "2042-12-31"),
+            time_range=("2042-01-01", "2045-12-31"),
+            bootstrap=True,
+            out_file=self.OUTPUT_FILE,
+            slice_mode="ms",
+        )
+
+        assert REFERENCE_PERIOD_ID not in res.TX90p.attrs
+
+    def test_index_tx90p__dask_bootstrap_uses_safe_tiled_path(
+        self,
+        monkeypatch,
+    ) -> None:
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS", "1")
+        tas = stub_tas(tas_value=27 + K2C, lat_length=2, lon_length=2)
+        tas[5:10] = 0
+        tas = tas.chunk({"time": 365, "lat": 1, "lon": 1})
+        common_kwargs = {
+            "index_name": "tx90p",
+            "in_files": tas,
+            "doy_window_width": 1,
+            "time_range": ("2042-01-01", "2045-12-31"),
+            "base_period_time_range": ("2042-01-01", "2043-12-31"),
+            "out_file": self.OUTPUT_FILE,
+            "slice_mode": "ms",
+        }
+
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_MODE", "default")
+        legacy = icclim.index(**common_kwargs).compute()
+        monkeypatch.delenv("ICCLIM_BOOTSTRAP_MODE")
+        generic_functions.reset_bootstrap_profile()
+
+        default = icclim.index(**common_kwargs)
+        profile = generic_functions.get_bootstrap_profile()
+
+        assert not hasattr(default.TX90p.data, "__dask_graph__")
+        assert profile["bootstrap_safe_tile_count"] == 4
+        xr.testing.assert_allclose(default.TX90p, legacy.TX90p)
+
+    def test_index_tx90p__safe_bootstrap_uses_memory_budget(self, monkeypatch) -> None:
+        monkeypatch.delenv("ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS", raising=False)
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY", "1B")
+        tas = stub_tas(tas_value=27 + K2C, lat_length=2, lon_length=2)
+        tas[5:10] = 0
+        tas = tas.chunk({"time": 365, "lat": 1, "lon": 1})
+
+        generic_functions.reset_bootstrap_profile()
+        res = icclim.index(
+            index_name="tx90p",
+            in_files=tas,
+            doy_window_width=1,
+            time_range=("2042-01-01", "2045-12-31"),
+            base_period_time_range=("2042-01-01", "2043-12-31"),
+            out_file=self.OUTPUT_FILE,
+            slice_mode="ms",
+        )
+        profile = generic_functions.get_bootstrap_profile()
+
+        assert not hasattr(res.TX90p.data, "__dask_graph__")
+        assert profile["bootstrap_safe_max_tile_cells"] == 1
+        assert profile["bootstrap_safe_tile_count"] == 4
+
+    def test_index_tx90p__safe_bootstrap_retries_on_memory_error(
+        self,
+        monkeypatch,
+    ) -> None:
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS", "4")
+        tas = stub_tas(tas_value=27 + K2C, lat_length=2, lon_length=2)
+        tas[5:10] = 0
+        tas = tas.chunk({"time": 365, "lat": 1, "lon": 1})
+        original_compute_exceedance = generic_functions._compute_exceedance
+
+        def fail_until_single_cell(*args, **kwargs):
+            study = args[0]
+            spatial_cells = 1
+            for dim, size in study.sizes.items():
+                if dim != "time":
+                    spatial_cells *= size
+            if spatial_cells > 1:
+                msg = "simulated bootstrap tile memory pressure"
+                raise MemoryError(msg)
+            return original_compute_exceedance(*args, **kwargs)
+
+        monkeypatch.setattr(
+            generic_functions,
+            "_compute_exceedance",
+            fail_until_single_cell,
+        )
+        generic_functions.reset_bootstrap_profile()
+
+        res = icclim.index(
+            index_name="tx90p",
+            in_files=tas,
+            doy_window_width=1,
+            time_range=("2042-01-01", "2045-12-31"),
+            base_period_time_range=("2042-01-01", "2043-12-31"),
+            out_file=self.OUTPUT_FILE,
+            slice_mode="ms",
+        )
+        profile = generic_functions.get_bootstrap_profile()
+
+        assert not hasattr(res.TX90p.data, "__dask_graph__")
+        assert profile["bootstrap_safe_memory_retry_count"] == 2
+        assert profile["bootstrap_safe_max_tile_cells"] == 1
+        assert profile["bootstrap_safe_tile_count"] == 4
 
     def test_index_wsdi__no_bootstrap_because_no_overlap(self) -> None:
         tas = stub_tas(tas_value=27 + K2C)


### PR DESCRIPTION
## Summary

- Make Dask-backed percentile count bootstrap use a bounded tiled reliability path by default when bootstrap is actually needed.
- Size safe-bootstrap spatial tiles from a memory budget: `ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY` defaults to `2GB`; `ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS` remains an expert/test override.
- If a safe tile fails with a memory-like error, automatically halve the tile size and retry, down to one spatial cell per tile before raising a clear error.
- Keep the public `bootstrap` API unchanged: `None` means automatic bootstrap behavior, `False` disables bootstrap, and `True` requests bootstrap only when the overlap structure is valid.
- Document that `bootstrap=False` is only a fast exploratory shortcut because it disables the overlap correction and can bias percentile-index results.

## Why

This PR is intentionally minimal and replaces the broader experimental bootstrap branch. It keeps the useful reliability behavior and drops benchmark scripts, archive notes, native-bootstrap experiments, generated-wrapper churn, and spell-index changes.

Large Dask-backed percentile bootstrap jobs can fail before users get any result: graph construction can become effectively unbounded, or execution can exhaust memory. Users should not have to trial-and-error chunking strategies to make scientifically required bootstrap run.

## Scope

- Applies automatically to Dask-backed percentile count indices such as TG90P/TX90P/TN90P.
- Does not change spell/run-length percentile index bootstrap behavior.
- Does not replace xclim/native percentile bootstrap internals; each bounded tile still uses the existing bootstrap computation.

## Validation

- `pre-commit run --all-files`
- `pytest tests/test_main.py -k 'bootstrap or tg90p or tx90p or wsdi or csdi' tests/test_generic_functions.py tests/test_generated_api.py -q`
- Added focused tests for automatic Dask safe tiling, memory-budget tiling, retry/downshift on simulated memory pressure, and preserving the overlap guard for `bootstrap=True`.

## Notes

- This is a reliability PR, not a speed PR.
- Smaller memory budgets create more tiles and can be slower.
- `ICCLIM_BOOTSTRAP_MODE=default` is for diagnostics only, to compare against the legacy Dask graph path.
