### PR TITLE
Fix temperature percentile thresholds to use canonical Celsius units

### DIFF
--- a/src/icclim/_core/climate_variable.py
+++ b/src/icclim/_core/climate_variable.py
@@ -305,11 +305,18 @@ def build_climate_var(
         time_range,
         ignore_feb29th,
         standard_var.default_units if standard_var else None,
+        standard_var=standard_var,
     )
     if climate_var_thresh is not None:
+        threshold_prepare_data = _build_threshold_prepare_data(
+            original_data=study_ds[climate_var_name],
+            studied_data=studied_data,
+            ignore_feb29th=ignore_feb29th,
+            standard_var=standard_var,
+        )
         climate_var_thresh = _build_threshold(
             climate_var_thresh=climate_var_thresh,
-            original_data=study_ds[climate_var_name],
+            original_data=threshold_prepare_data,
             conversion_unit=studied_data.attrs[UNITS_KEY],
         )
     if "time" in studied_data.coords:
@@ -470,6 +477,23 @@ def _build_threshold(
         res.prepare(original_data)
     res.unit = conversion_unit
     return res
+
+
+def _build_threshold_prepare_data(
+    original_data: DataArray,
+    studied_data: DataArray,
+    ignore_feb29th: bool,
+    standard_var: StandardVariable | None,
+) -> DataArray:
+    if standard_var is None or standard_var.default_units != "degree_Celsius":
+        return original_data
+    return build_studied_data(
+        original_data,
+        time_range=None,
+        ignore_feb29th=ignore_feb29th,
+        default_units=studied_data.attrs.get(UNITS_KEY, None),
+        standard_var=standard_var,
+    )
 
 
 def _get_ref_period_slice(da: DataArray) -> slice:

--- a/src/icclim/_core/input_parsing.py
+++ b/src/icclim/_core/input_parsing.py
@@ -499,6 +499,7 @@ def build_studied_data(
     time_range: Sequence[datetime | str] | None,
     ignore_feb29th: bool,
     default_units: str | None,
+    standard_var: StandardVariable | None = None,
 ) -> DataArray:
     """
     Preprocesss the input data to select the period of interest.
@@ -515,6 +516,9 @@ def build_studied_data(
     default_units : str | None
         The default units to use for the data array if it is uniteless.
         If None and the data array is uniteless, "units" attribute remains unset.
+    standard_var : StandardVariable | None
+        Known standard variable for the data array. If unset, icclim guesses from
+        the data metadata.
 
     Returns
     -------
@@ -547,7 +551,7 @@ def build_studied_data(
         da = da.convert_calendar(CfCalendarRegistry.NO_LEAP.name)
     if da.attrs.get(UNITS_KEY, None) is None and default_units is not None:
         da.attrs[UNITS_KEY] = default_units
-    std_var = guess_standard_variable(da)
+    std_var = standard_var or guess_standard_variable(da)
     if (
         std_var is not None
         and std_var.default_units == "degree_Celsius"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -10,6 +10,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
+from xclim.core.units import convert_units_to
 
 import icclim
 from icclim import __version__ as icclim_version
@@ -718,6 +719,42 @@ class TestIntegration:
         assert REFERENCE_PERIOD_ID not in res.TX90p.attrs
         # resample_doy add a day where 90th per is below tas
         assert res.TX90p.isel(time=0) == 6
+
+    def test_index_tx90p__temperature_percentiles_use_celsius_first_path(
+        self,
+    ) -> None:
+        tas_k = stub_tas(tas_value=27 + K2C)
+        tas_k = tas_k.astype("float32")
+        tas_k[5:10] = np.float32(0)
+        tas_c = convert_units_to(tas_k, "degree_Celsius", context="hydro")
+
+        common_kwargs = {
+            "index_name": "tx90p",
+            "doy_window_width": 1,
+            "time_range": ("2043-01-01", "2045-12-31"),
+            "base_period_time_range": ("2042-01-01", "2042-12-31"),
+            "out_file": self.OUTPUT_FILE,
+            "slice_mode": "ms",
+            "save_thresholds": True,
+            "bootstrap": False,
+        }
+
+        from_kelvin = icclim.index(in_files=tas_k, **common_kwargs).load()
+        from_celsius = icclim.index(in_files=tas_c, **common_kwargs).load()
+        threshold_name = next(
+            name for name in from_kelvin.data_vars if name.endswith("_thresholds")
+        )
+
+        xr.testing.assert_identical(from_kelvin.TX90p, from_celsius.TX90p)
+        xr.testing.assert_allclose(
+            from_kelvin[threshold_name],
+            from_celsius[threshold_name],
+            rtol=0,
+            atol=0,
+        )
+        assert normalize_unit(from_kelvin[threshold_name].attrs[UNITS_KEY]) == (
+            normalize_unit("degree_Celsius")
+        )
 
     def test_index_tx90p__bootstrap_2_years(self) -> None:
         tas = stub_tas(tas_value=27 + K2C)


### PR DESCRIPTION
## Summary
- use the known standard variable while preprocessing studied data, instead of relying only on metadata/name guessing
- prepare temperature percentile thresholds from the full Celsius-normalized input series, including reference periods outside `time_range`
- add a regression test proving Kelvin input and explicitly Celsius input produce identical TX90p values and saved thresholds

## Why
Temperature percentile indices should follow one coherent unit path. Before this change, base thresholds could be prepared from raw-unit data while bootstrap recomputed thresholds from normalized comparison data. That produced microdegree-C threshold differences and occasional one-day strict-boundary count flips.

This PR does not change the broader bootstrap reliability/performance work. It only fixes the unit consistency issue discovered during that investigation.

## Validation
- `ruff check src/icclim/_core/input_parsing.py src/icclim/_core/climate_variable.py tests/test_main.py`
- `git diff --check`
- `pytest tests/test_main.py::TestIntegration::test_index_tx90p__temperature_percentiles_use_celsius_first_path tests/test_main.py::TestIntegration::test_index_tx90p__no_bootstrap_because_no_overlap tests/test_main.py::TestIntegration::test_index_tx90p__bootstrap_2_years -q`
- `pytest tests/test_main.py -q` -> 71 passed
- Slurm validation on ACCESS-CM2 TG90p subset: Kelvin input vs explicit Celsius input gave `max_abs_diff_days=0.0` and `changed_values_gt_1e-9=0`
