### PR TITLE
Speed up annual percentile bootstrap counts

### DIFF
--- a/src/icclim/_core/generic/bootstrap.py
+++ b/src/icclim/_core/generic/bootstrap.py
@@ -275,9 +275,7 @@ if njit is not None:
             return np.nan
         if n == 1:
             return buf[0]
-        virtual = n * quantile + (
-            alpha + quantile * (1.0 - alpha - beta)
-        ) - 1.0
+        virtual = n * quantile + (alpha + quantile * (1.0 - alpha - beta)) - 1.0
         if virtual >= n - 1:
             return _select_kth(buf, n, n - 1)
         if virtual < 0:

--- a/src/icclim/_core/generic/bootstrap.py
+++ b/src/icclim/_core/generic/bootstrap.py
@@ -1,0 +1,460 @@
+"""Compiled helpers for reliable percentile bootstrap counts."""
+# ruff: noqa: ANN001, ANN202, PLR2004
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+from icclim._core.constants import REFERENCE_PERIOD_ID
+from icclim._core.model.operator import Operator
+
+if TYPE_CHECKING:
+    from xarray import DataArray
+
+    from icclim._core.generic.threshold.percentile import PercentileThreshold
+
+
+def compute_doy_percentile_bootstrap_count(
+    study: DataArray,
+    threshold: PercentileThreshold,
+) -> DataArray | None:
+    """Compute annual percentile bootstrap counts without building a huge dask graph."""
+    if not _can_compute_fast_bootstrap(study, threshold):
+        return None
+    loaded = study.load()
+    climatology_bounds = threshold.value.attrs["climatology_bounds"]
+    ref = loaded.sel(time=slice(*climatology_bounds))
+    study_time = pd.DatetimeIndex(loaded.time.values)
+    ref_time = pd.DatetimeIndex(ref.time.values)
+    ref_year_indices = _indices_by_year(ref_time)
+    study_year_indices = _indices_by_year(study_time)
+    ref_years = np.asarray(list(ref_year_indices), dtype=np.int64)
+    study_years = np.asarray(list(study_year_indices), dtype=np.int64)
+    study_starts = np.asarray(
+        [indices[0] for indices in study_year_indices.values()],
+        dtype=np.int64,
+    )
+    study_lengths = np.asarray(
+        [len(indices) for indices in study_year_indices.values()],
+        dtype=np.int64,
+    )
+    source_max_doy = int(ref_time.dayofyear.max())
+    study_max_doys = np.asarray(
+        [
+            source_max_doy
+            if source_max_doy == 366
+            else int(study_time[indices].dayofyear.max())
+            for indices in study_year_indices.values()
+        ],
+        dtype=np.int64,
+    )
+    study_to_ref = np.asarray(
+        [
+            int(np.where(ref_years == year)[0][0]) if year in ref_year_indices else -1
+            for year in study_years
+        ],
+        dtype=np.int64,
+    )
+    flat = np.asarray(loaded.transpose("time", ...).data, dtype=np.float64).reshape(
+        loaded.sizes["time"],
+        -1,
+    )
+    flat_ref = np.asarray(ref.transpose("time", ...).data, dtype=np.float64).reshape(
+        ref.sizes["time"],
+        -1,
+    )
+    sample_indices = _rolling_sample_index_matrix(
+        ref_time,
+        window=threshold.doy_window_width,
+    )
+    index_year, index_pos = _ref_index_year_and_position(
+        ref_year_indices,
+        len(ref_time),
+    )
+    donor_aligned = _donor_alignment_matrix(ref_time, ref_year_indices)
+    result = _bootstrap_count_kernel(
+        flat_ref,
+        flat,
+        sample_indices,
+        index_year,
+        index_pos,
+        donor_aligned,
+        study_starts,
+        study_lengths,
+        study_max_doys,
+        study_to_ref,
+        study_time.dayofyear.to_numpy(dtype=np.int64),
+        float(threshold.value.coords["percentiles"].item()) / 100.0,
+        float(threshold.interpolation.alpha),
+        float(threshold.interpolation.beta),
+        _operator_code(threshold.operator),
+    )
+    data = result.reshape((len(study_years), *loaded.shape[1:]))
+    out = xr.DataArray(
+        data,
+        dims=loaded.dims,
+        coords={
+            "time": [np.datetime64(f"{year}-01-01") for year in study_years],
+            **{coord: loaded.coords[coord] for coord in loaded.dims if coord != "time"},
+        },
+        attrs={"units": "d", REFERENCE_PERIOD_ID: climatology_bounds},
+    )
+    for coord in loaded.coords:
+        if coord not in out.coords and "time" not in loaded[coord].dims:
+            out = out.assign_coords({coord: loaded[coord]})
+    return out.assign_coords(percentiles=threshold.value.coords["percentiles"].item())
+
+
+def _can_compute_fast_bootstrap(
+    study: DataArray,
+    threshold: PercentileThreshold,
+) -> bool:
+    try:
+        pd.DatetimeIndex(study.time.values)
+    except (TypeError, ValueError):
+        return False
+    return (
+        njit is not None
+        and threshold.threshold_min_value is None
+        and not threshold.only_leap_years
+        and threshold.value.coords["percentiles"].size == 1
+        and _operator_code(threshold.operator) >= 0
+    )
+
+
+def _operator_code(operator: Operator | str) -> int:
+    operand = operator.operand if isinstance(operator, Operator) else str(operator)
+    return {">": 0, ">=": 1, "<": 2, "<=": 3}.get(operand, -1)
+
+
+try:
+    from numba import njit, prange
+except Exception:  # noqa: BLE001
+    njit = None
+    prange = range
+
+
+if njit is not None:
+
+    @njit(parallel=True, cache=True)
+    def _bootstrap_count_kernel(
+        flat_ref,
+        flat_study,
+        sample_indices,
+        index_year,
+        index_pos,
+        donor_aligned,
+        study_starts,
+        study_lengths,
+        study_max_doys,
+        study_to_ref,
+        study_doys,
+        quantile,
+        alpha,
+        beta,
+        op_code,
+    ):
+        n_years = len(study_starts)
+        n_cells = flat_study.shape[1]
+        out = np.empty((n_years, n_cells), dtype=np.float64)
+        n_ref_years = donor_aligned.shape[1]
+        max_samples = sample_indices.shape[1]
+        for flat_i in prange(n_years * n_cells):
+            year_i = flat_i // n_cells
+            cell = flat_i % n_cells
+            target_ref_i = study_to_ref[year_i]
+            max_target_doy = study_max_doys[year_i]
+            start = study_starts[year_i]
+            length = study_lengths[year_i]
+            if target_ref_i < 0:
+                q = np.empty(365, dtype=np.float64)
+                buf = np.empty(max_samples, dtype=np.float64)
+                for doy_i in range(365):
+                    q[doy_i] = _quantile_for_doy_cell(
+                        flat_ref,
+                        sample_indices,
+                        index_year,
+                        index_pos,
+                        donor_aligned,
+                        -1,
+                        -1,
+                        doy_i,
+                        cell,
+                        buf,
+                        quantile,
+                        alpha,
+                        beta,
+                    )
+                out[year_i, cell] = _count_exceedances(
+                    flat_study,
+                    q,
+                    study_doys,
+                    start,
+                    length,
+                    cell,
+                    max_target_doy,
+                    op_code,
+                )
+            else:
+                donor_total = 0.0
+                donor_count = 0
+                for donor_i in range(n_ref_years):
+                    if donor_i == target_ref_i:
+                        continue
+                    q = np.empty(365, dtype=np.float64)
+                    buf = np.empty(max_samples, dtype=np.float64)
+                    for doy_i in range(365):
+                        q[doy_i] = _quantile_for_doy_cell(
+                            flat_ref,
+                            sample_indices,
+                            index_year,
+                            index_pos,
+                            donor_aligned,
+                            target_ref_i,
+                            donor_i,
+                            doy_i,
+                            cell,
+                            buf,
+                            quantile,
+                            alpha,
+                            beta,
+                        )
+                    donor_total += _count_exceedances(
+                        flat_study,
+                        q,
+                        study_doys,
+                        start,
+                        length,
+                        cell,
+                        max_target_doy,
+                        op_code,
+                    )
+                    donor_count += 1
+                out[year_i, cell] = donor_total / donor_count
+        return out
+
+    @njit(cache=True)
+    def _quantile_for_doy_cell(
+        flat_ref,
+        sample_indices,
+        index_year,
+        index_pos,
+        donor_aligned,
+        target_ref_i,
+        donor_i,
+        doy_i,
+        cell,
+        buf,
+        quantile,
+        alpha,
+        beta,
+    ):
+        n = 0
+        for sample_i in range(sample_indices.shape[1]):
+            ref_i = sample_indices[doy_i, sample_i]
+            if ref_i < 0:
+                continue
+            mapped_i = ref_i
+            if target_ref_i >= 0 and index_year[ref_i] == target_ref_i:
+                mapped_i = donor_aligned[target_ref_i, donor_i, index_pos[ref_i]]
+            if mapped_i < 0:
+                continue
+            value = flat_ref[mapped_i, cell]
+            if not np.isnan(value):
+                buf[n] = value
+                n += 1
+        return _method8_quantile_select(buf, n, quantile, alpha, beta)
+
+    @njit(cache=True)
+    def _method8_quantile_select(buf, n, quantile, alpha, beta):
+        if n == 0:
+            return np.nan
+        if n == 1:
+            return buf[0]
+        virtual = n * quantile + (
+            alpha + quantile * (1.0 - alpha - beta)
+        ) - 1.0
+        if virtual >= n - 1:
+            return _select_kth(buf, n, n - 1)
+        if virtual < 0:
+            return _select_kth(buf, n, 0)
+        previous = int(np.floor(virtual))
+        gamma = virtual - previous
+        left = _select_kth(buf, n, previous)
+        right = _select_kth(buf, n, previous + 1)
+        diff = right - left
+        if gamma >= 0.5:
+            return right - diff * (1.0 - gamma)
+        return left + diff * gamma
+
+    @njit(cache=True)
+    def _select_kth(buf, n, k):
+        left = 0
+        right = n - 1
+        while True:
+            if left == right:
+                return buf[left]
+            pivot_index = (left + right) // 2
+            pivot_index = _partition(buf, left, right, pivot_index)
+            if k == pivot_index:
+                return buf[k]
+            if k < pivot_index:
+                right = pivot_index - 1
+            else:
+                left = pivot_index + 1
+
+    @njit(cache=True)
+    def _partition(buf, left, right, pivot_index):
+        pivot_value = buf[pivot_index]
+        _swap(buf, pivot_index, right)
+        store_index = left
+        for i in range(left, right):
+            if buf[i] < pivot_value:
+                _swap(buf, store_index, i)
+                store_index += 1
+        _swap(buf, right, store_index)
+        return store_index
+
+    @njit(cache=True)
+    def _swap(buf, i, j):
+        value = buf[i]
+        buf[i] = buf[j]
+        buf[j] = value
+
+    @njit(cache=True)
+    def _count_exceedances(
+        flat_study,
+        q,
+        study_doys,
+        start,
+        length,
+        cell,
+        max_target_doy,
+        op_code,
+    ):
+        count = 0.0
+        for offset in range(length):
+            doy = study_doys[start + offset]
+            threshold = _adjusted_threshold(q, doy, max_target_doy)
+            value = flat_study[start + offset, cell]
+            if _compare(value, threshold, op_code):
+                count += 1.0
+        return count
+
+    @njit(cache=True)
+    def _compare(value, threshold, op_code):
+        if op_code == 0:
+            return value > threshold
+        if op_code == 1:
+            return value >= threshold
+        if op_code == 2:
+            return value < threshold
+        return value <= threshold
+
+    @njit(cache=True)
+    def _adjusted_threshold(q, doy, max_target_doy):
+        if max_target_doy == 365:
+            return q[doy - 1]
+        position = (doy - 1.0) * 364.0 / 365.0
+        lower = int(np.floor(position))
+        if lower >= 364:
+            return q[364]
+        gamma = position - lower
+        diff = q[lower + 1] - q[lower]
+        if gamma >= 0.5:
+            return q[lower + 1] - diff * (1.0 - gamma)
+        return q[lower] + diff * gamma
+
+else:
+
+    def _bootstrap_count_kernel(*args, **kwargs):  # noqa: ARG001
+        return None
+
+
+def _indices_by_year(time: pd.DatetimeIndex) -> dict[int, np.ndarray]:
+    return {int(year): np.where(time.year == year)[0] for year in np.unique(time.year)}
+
+
+def _rolling_sample_index_matrix(
+    time: pd.DatetimeIndex,
+    *,
+    window: int,
+) -> np.ndarray:
+    half_window = window // 2
+    sample_indices: dict[int, list[int]] = {doy: [] for doy in range(1, 366)}
+    doys = time.dayofyear.to_numpy()
+    for center, doy in enumerate(doys):
+        if doy == 366:
+            continue
+        start = max(0, center - half_window)
+        stop = min(len(time), center + half_window + 1)
+        sample_indices[int(doy)].extend(range(start, stop))
+    max_samples = max(len(indices) for indices in sample_indices.values())
+    matrix = np.full((365, max_samples), -1, dtype=np.int64)
+    for doy, indices in sample_indices.items():
+        matrix[doy - 1, : len(indices)] = indices
+    return matrix
+
+
+def _ref_index_year_and_position(
+    ref_year_indices: dict[int, np.ndarray],
+    n_ref_time: int,
+) -> tuple[np.ndarray, np.ndarray]:
+    index_year = np.full(n_ref_time, -1, dtype=np.int64)
+    index_pos = np.full(n_ref_time, -1, dtype=np.int64)
+    for year_index, indices in enumerate(ref_year_indices.values()):
+        index_year[indices] = year_index
+        index_pos[indices] = np.arange(len(indices), dtype=np.int64)
+    return index_year, index_pos
+
+
+def _donor_alignment_matrix(
+    ref_time: pd.DatetimeIndex,
+    ref_year_indices: dict[int, np.ndarray],
+) -> np.ndarray:
+    max_year_len = max(len(indices) for indices in ref_year_indices.values())
+    n_years = len(ref_year_indices)
+    aligned = np.full((n_years, n_years, max_year_len), -1, dtype=np.int64)
+    years = list(ref_year_indices)
+    for target_i, target_year in enumerate(years):
+        target_indices = ref_year_indices[target_year]
+        target_time = ref_time[target_indices]
+        for donor_i, donor_year in enumerate(years):
+            donor_indices = ref_year_indices[donor_year]
+            aligned[target_i, donor_i, : len(target_indices)] = (
+                _donor_indices_aligned_to_target(
+                    target_time,
+                    ref_time[donor_indices],
+                    donor_indices,
+                )
+            )
+    return aligned
+
+
+def _donor_indices_aligned_to_target(
+    target_time: pd.DatetimeIndex,
+    donor_time: pd.DatetimeIndex,
+    donor_indices: np.ndarray,
+) -> np.ndarray:
+    if len(target_time) == len(donor_time):
+        return donor_indices
+    donor_by_month_day = {
+        (int(month), int(day)): int(index)
+        for month, day, index in zip(
+            donor_time.month,
+            donor_time.day,
+            donor_indices,
+            strict=True,
+        )
+    }
+    return np.asarray(
+        [
+            donor_by_month_day.get((int(month), int(day)), -1)
+            for month, day in zip(target_time.month, target_time.day, strict=True)
+        ],
+        dtype=np.int64,
+    )

--- a/src/icclim/_core/generic/functions.py
+++ b/src/icclim/_core/generic/functions.py
@@ -1283,6 +1283,14 @@ def _compute_safe_tiled_count_occurrences(
         resample_freq,
     )
     _profile_bootstrap_set("bootstrap_safe_max_tile_cells", max_cells)
+    optimized = _compute_fast_tiled_count_occurrences(
+        climate_var,
+        threshold,
+        resample_freq,
+        max_cells,
+    )
+    if optimized is not None:
+        return optimized
     while True:
         try:
             return _compute_safe_tiled_count_occurrences_with_max_cells(
@@ -1349,6 +1357,45 @@ def _compute_safe_tiled_count_occurrences_with_max_cells(
         "bootstrap_safe_total_seconds",
         perf_counter() - safe_start,
     )
+    return result
+
+
+def _compute_fast_tiled_count_occurrences(
+    climate_var: ClimateVariable,
+    threshold: PercentileThreshold,
+    resample_freq: Frequency,
+    max_cells: int,
+) -> DataArray | None:
+    if os.environ.get("ICCLIM_BOOTSTRAP_MODE") == "safe":
+        return None
+    if resample_freq.pandas_freq != "YS":
+        return None
+    from icclim._core.generic.bootstrap import (  # noqa: PLC0415
+        compute_doy_percentile_bootstrap_count,
+    )
+
+    fast_start = perf_counter()
+    tile_results: list[DataArray] = []
+    for tile_indexers in _iter_spatial_tiles(climate_var.studied_data, max_cells):
+        tile_study = climate_var.studied_data.isel(tile_indexers)
+        tile_threshold = _slice_threshold_for_tile(threshold, tile_indexers)
+        tile_result = compute_doy_percentile_bootstrap_count(
+            tile_study,
+            tile_threshold,
+        )
+        if tile_result is None:
+            return None
+        tile_results.append(tile_result)
+        _profile_bootstrap_inc("bootstrap_fast_tile_count")
+    if len(tile_results) == 1:
+        result = tile_results[0]
+    else:
+        result = xr.combine_by_coords(
+            [tile.to_dataset(name="__icclim_bootstrap_tile") for tile in tile_results],
+            combine_attrs="override",
+        )["__icclim_bootstrap_tile"]
+    result.attrs.update(tile_results[-1].attrs)
+    _profile_bootstrap_add("bootstrap_fast_total_seconds", perf_counter() - fast_start)
     return result
 
 

--- a/src/icclim/_core/generic/functions.py
+++ b/src/icclim/_core/generic/functions.py
@@ -70,7 +70,9 @@ if TYPE_CHECKING:
 
 _BOOTSTRAP_PROFILE: dict[str, float | int] = {}
 _DEFAULT_BOOTSTRAP_SAFE_TILE_MEMORY = "2GB"
+_DEFAULT_BOOTSTRAP_FAST_TILE_MEMORY = "2GB"
 _BOOTSTRAP_SAFE_MEMORY_FACTOR = 12
+_BOOTSTRAP_FAST_MEMORY_FACTOR = 4
 
 
 def reset_bootstrap_profile() -> None:
@@ -1287,7 +1289,7 @@ def _compute_safe_tiled_count_occurrences(
         climate_var,
         threshold,
         resample_freq,
-        max_cells,
+        _get_fast_bootstrap_max_cells(climate_var.studied_data),
     )
     if optimized is not None:
         return optimized
@@ -1407,6 +1409,25 @@ def _should_use_safe_count_bootstrap(climate_var: ClimateVariable) -> bool:
     from xclim.core.utils import uses_dask  # noqa: PLC0415
 
     return uses_dask(climate_var.studied_data)
+
+
+def _get_fast_bootstrap_max_cells(study: DataArray) -> int:
+    if max_cells := os.environ.get("ICCLIM_BOOTSTRAP_FAST_TILE_CELLS"):
+        return max(1, int(max_cells))
+    max_mem = _parse_byte_size(
+        os.environ.get(
+            "ICCLIM_BOOTSTRAP_FAST_TILE_MEMORY",
+            _DEFAULT_BOOTSTRAP_FAST_TILE_MEMORY,
+        )
+    )
+    itemsize = getattr(study.dtype, "itemsize", 8)
+    bytes_per_cell = max(1, study.sizes["time"]) * itemsize
+    bytes_per_cell *= _BOOTSTRAP_FAST_MEMORY_FACTOR
+    _profile_bootstrap_set("bootstrap_fast_tile_memory_bytes", max_mem)
+    _profile_bootstrap_set("bootstrap_fast_estimated_bytes_per_cell", bytes_per_cell)
+    max_cells = max(1, max_mem // bytes_per_cell)
+    _profile_bootstrap_set("bootstrap_fast_max_tile_cells", max_cells)
+    return max_cells
 
 
 def _get_safe_bootstrap_max_cells(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -804,7 +804,7 @@ class TestIntegration:
 
         assert REFERENCE_PERIOD_ID not in res.TX90p.attrs
 
-    def test_index_tx90p__dask_bootstrap_uses_safe_tiled_path(
+    def test_index_tx90p__dask_bootstrap_uses_fast_tiled_path(
         self,
         monkeypatch,
     ) -> None:
@@ -819,7 +819,7 @@ class TestIntegration:
             "time_range": ("2042-01-01", "2045-12-31"),
             "base_period_time_range": ("2042-01-01", "2043-12-31"),
             "out_file": self.OUTPUT_FILE,
-            "slice_mode": "ms",
+            "slice_mode": "year",
         }
 
         monkeypatch.setenv("ICCLIM_BOOTSTRAP_MODE", "default")
@@ -831,11 +831,12 @@ class TestIntegration:
         profile = generic_functions.get_bootstrap_profile()
 
         assert not hasattr(default.TX90p.data, "__dask_graph__")
-        assert profile["bootstrap_safe_tile_count"] == 4
+        assert profile["bootstrap_fast_tile_count"] == 4
         xr.testing.assert_allclose(default.TX90p, legacy.TX90p)
 
     def test_index_tx90p__safe_bootstrap_uses_memory_budget(self, monkeypatch) -> None:
         monkeypatch.delenv("ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS", raising=False)
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_MODE", "safe")
         monkeypatch.setenv("ICCLIM_BOOTSTRAP_SAFE_TILE_MEMORY", "1B")
         tas = stub_tas(tas_value=27 + K2C, lat_length=2, lon_length=2)
         tas[5:10] = 0
@@ -861,6 +862,7 @@ class TestIntegration:
         self,
         monkeypatch,
     ) -> None:
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_MODE", "safe")
         monkeypatch.setenv("ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS", "4")
         tas = stub_tas(tas_value=27 + K2C, lat_length=2, lon_length=2)
         tas[5:10] = 0

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -809,6 +809,7 @@ class TestIntegration:
         monkeypatch,
     ) -> None:
         monkeypatch.setenv("ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS", "1")
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_FAST_TILE_CELLS", "1")
         tas = stub_tas(tas_value=27 + K2C, lat_length=2, lon_length=2)
         tas[5:10] = 0
         tas = tas.chunk({"time": 365, "lat": 1, "lon": 1})


### PR DESCRIPTION
## Summary
- add a compiled rank-select bootstrap count path for annual day-of-year percentile count indices
- keep the existing safe xclim tiled path as fallback for unsupported cases and when `ICCLIM_BOOTSTRAP_MODE=safe`
- use a separate memory estimator for the compiled path so it does not inherit the conservative xclim tile size
- update tests to cover the default fast path and explicit safe fallback

## Scope
The fast path is intentionally narrow for this PR:
- annual `YS` output only
- single day-of-year percentile threshold
- simple comparison operators (`>`, `>=`, `<`, `<=`)
- no `threshold_min_value`, no `only_leap_years`, pandas-compatible time indexes

Other cases fall back to the existing safe tiled implementation.

## Validation
Local:
- `ruff check src/icclim/_core/generic/bootstrap.py src/icclim/_core/generic/functions.py tests/test_main.py`
- `python -m py_compile src/icclim/_core/generic/bootstrap.py src/icclim/_core/generic/functions.py`
- `git diff --check`
- `pytest tests/test_main.py -q` -> 71 passed
- `pytest tests/test_threshold.py tests/test_generic_functions.py -q` -> 30 passed

Kraken ACCESS-CM2, `TG90p`, `lat 35:55`, `lon 0:20`, shape `65x16x11`:
- safe tiled reference: `1473.38s`, mean `46.95380094043887`
- production fast path: `146.18s`, mean `46.953800940438875`
- `max_abs_diff=5.68e-14`, `changed_cells_gt_1e-9=0`
