### PR TITLE
Prepare release 7.1.4

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,14 +8,14 @@ authors:
   - family-names: "Aoun"
     given-names: "Abel"
 title: "icclim: Index Calculation CLIMate"
-version: 7.1.3
+version: 7.1.4
 doi: 10.5281/zenodo.6046052
-date-released: 2026-07-20
+date-released: 2026-07-22
 url: "https://github.com/cerfacs-globc/icclim"
 repository-code: "https://github.com/cerfacs-globc/icclim"
 identifiers:
   - type: url
-    value: "https://github.com/cerfacs-globc/icclim/tree/v7.1.3"
+    value: "https://github.com/cerfacs-globc/icclim/tree/v7.1.4"
     description: "Specific version source code"
 keywords:
   - "climate"

--- a/doc/source/references/release_notes.rst
+++ b/doc/source/references/release_notes.rst
@@ -3,6 +3,21 @@
 #################
 
 ******
+7.1.4
+******
+
+date: 2026-07-22
+
+
+Details
+-------
+
+-  [enh] Speed up annual percentile bootstrap counts with a compiled rank-select path for day-of-year percentile count indices such as ``TG90p``, ``TX90p`` and ``TN90p``. Unsupported cases keep using the existing safe tiled bootstrap path.
+-  [enh] Add separate memory-based tiling controls for the compiled bootstrap path, while preserving the reliable xclim-based fallback and ``ICCLIM_BOOTSTRAP_MODE=safe`` escape hatch.
+-  [fix] Prepare temperature percentile thresholds from the full Celsius-normalized input series, so Kelvin input and explicitly Celsius input follow the same scientific path and produce identical saved thresholds.
+-  [maint] Update generated API documentation after the bootstrap reliability changes.
+
+******
 7.1.3
 ******
 

--- a/doc/source/references/release_notes.rst
+++ b/doc/source/references/release_notes.rst
@@ -9,9 +9,6 @@
 date: 2026-07-22
 
 
-Details
--------
-
 -  [enh] Speed up annual percentile bootstrap counts with a compiled rank-select path for day-of-year percentile count indices such as ``TG90p``, ``TX90p`` and ``TN90p``. Unsupported cases keep using the existing safe tiled bootstrap path.
 -  [enh] Add separate memory-based tiling controls for the compiled bootstrap path, while preserving the reliable xclim-based fallback and ``ICCLIM_BOOTSTRAP_MODE=safe`` escape hatch.
 -  [fix] Prepare temperature percentile thresholds from the full Celsius-normalized input series, so Kelvin input and explicitly Celsius input follow the same scientific path and produce identical saved thresholds.

--- a/src/icclim/__init__.py
+++ b/src/icclim/__init__.py
@@ -23,7 +23,7 @@ __all__ = [
     "indices",  # noqa: F405
 ]
 
-__version__ = "7.1.3"
+__version__ = "7.1.4"
 
 
 def __getattr__(name: str) -> Callable:


### PR DESCRIPTION
## Summary
- bump icclim version metadata to `7.1.4`
- update `CITATION.cff` for the `v7.1.4` tag and release date
- add release notes for the Celsius-first percentile fix and the fast annual percentile bootstrap count path

## Validation
- `ruff check src/icclim/__init__.py`
- `python -m py_compile src/icclim/__init__.py`
- `git diff --check`
- `PYTHONPATH=src python -c "import icclim; assert icclim.__version__ == '7.1.4'"`
