### PR TITLE
PERF: extend reliable fast bootstrap to monthly counts

### DIFF
--- a/doc/source/dev/index.rst
+++ b/doc/source/dev/index.rst
@@ -4,7 +4,7 @@
  Development
 #############
 
-Here are some guidelines for those who which to contribute to icclim
+Here are some guidelines for those who wish to contribute to icclim
 development.
 
 .. toctree::
@@ -13,5 +13,6 @@ development.
 
    release_process
    ci
+   percentile_bootstrap
    contributing
    climpact_comparison_protocol

--- a/doc/source/dev/percentile_bootstrap.rst
+++ b/doc/source/dev/percentile_bootstrap.rst
@@ -19,6 +19,18 @@ The goal is reliability first: users should not have to guess a dask
 chunking strategy, and icclim should avoid both memory exhaustion and
 very large dask graphs.
 
+The fast path is specialised for percentile-based count indices. It
+does not call xclim's generic bootstrap decorator. Instead it:
+
+- tiles the spatial domain according to an explicit memory budget;
+- loads one tile at a time, avoiding a large dask bootstrap graph;
+- uses the already-prepared nominal percentile threshold for
+  non-overlapping years;
+- recomputes donor-year bootstrap thresholds only for years overlapping
+  the reference period;
+- reuses each yearly donor threshold across all output groups in that
+  year, so monthly output does not recompute thresholds twelve times.
+
 Fast path currently supports:
 
 - annual ``YS`` and monthly ``MS`` output periods;
@@ -46,9 +58,31 @@ most useful future extensions are likely:
 Performance notes
 =================
 
-Kraken benchmarks showed that the compiled annual path is about 10 times
-faster than the safe tiled path on a representative TG90p case, with
-bitwise-equivalent counts up to floating-point noise.
+Kraken benchmarks showed that the compiled annual path can be about 10
+times faster than the safe tiled fallback on a representative TG90p case,
+with bitwise-equivalent counts up to floating-point noise:
+
+- safe tiled fallback: about 1473 seconds;
+- production fast path: about 146 seconds;
+- maximum absolute difference: about ``5.7e-14``.
+
+Compared to the old xclim/dask graph path, performance is
+case-dependent when the old path succeeds. On the ACCESS-CM2 validation
+subset (65 years, 28 latitudes, 21 longitudes), the fast path was close
+to the legacy path in wall-clock time, but removed the multi-million-task
+dask graph:
+
+- annual ``TG90p``: legacy 204 seconds and 4,691,198 graph tasks; fast
+  212 seconds and 0 graph tasks; maximum absolute difference
+  ``8.6e-14``; MaxRSS about 4.4 GB;
+- monthly ``TG90p``: legacy 212 seconds and 4,696,205 graph tasks; fast
+  212 seconds and 0 graph tasks; maximum absolute difference
+  ``7.2e-15``; MaxRSS about 4.0 GB.
+
+So the robust statement is that the fast path bounds memory and avoids
+giant dask graphs. It is much faster than the reliable safe tiled
+fallback, but it is not guaranteed to beat the old graph path on cases
+where that graph path happens to complete.
 
 Further large speedups are more likely to come from reducing Python,
 xarray and dask preparation overhead than from micro-optimising the Numba
@@ -57,8 +91,8 @@ kernel. Promising areas:
 - avoid preparing percentile thresholds twice before the fast path;
 - load each spatial tile exactly once and keep unit-normalised values
   contiguous before entering the kernel;
-- profile monthly and seasonal cases separately, because output grouping
-  changes the amount of count work but not the bootstrap threshold work.
+- profile seasonal cases separately, because output grouping changes the
+  amount of count work but not the bootstrap threshold work.
 
 Validation rules
 ================

--- a/doc/source/dev/percentile_bootstrap.rst
+++ b/doc/source/dev/percentile_bootstrap.rst
@@ -1,0 +1,73 @@
+.. _dev_percentile_bootstrap:
+
+####################
+ Percentile bootstrap
+####################
+
+This note records the bootstrap optimisation state after icclim 7.1.4.
+It is meant for maintainers changing the percentile-based count indices.
+
+Current strategy
+================
+
+For dask-backed percentile count indices with bootstrap enabled, icclim
+first tries a compiled fast path. If the case is unsupported, or if the
+user sets ``ICCLIM_BOOTSTRAP_MODE=safe``, icclim falls back to the safe
+tiled xclim path.
+
+The goal is reliability first: users should not have to guess a dask
+chunking strategy, and icclim should avoid both memory exhaustion and
+very large dask graphs.
+
+Fast path currently supports:
+
+- annual ``YS`` and monthly ``MS`` output periods;
+- single day-of-year percentile thresholds;
+- simple count operators: ``>``, ``>=``, ``<`` and ``<=``;
+- no ``threshold_min_value``;
+- no ``only_leap_years``;
+- pandas-compatible calendars.
+
+Unsupported cases
+=================
+
+Unsupported cases intentionally fall back to the safe tiled path. The
+most useful future extensions are likely:
+
+- seasonal output periods, after validating that resample grouping and
+  donor-year substitution are scientifically coherent for seasons;
+- precipitation wet-day percentile thresholds using
+  ``threshold_min_value``;
+- non-standard calendars, once cftime grouping and leap handling are
+  explicitly tested;
+- spell/run-length indices, which likely need a different algorithm
+  because the bootstrap cannot be reduced to independent daily counts.
+
+Performance notes
+=================
+
+Kraken benchmarks showed that the compiled annual path is about 10 times
+faster than the safe tiled path on a representative TG90p case, with
+bitwise-equivalent counts up to floating-point noise.
+
+Further large speedups are more likely to come from reducing Python,
+xarray and dask preparation overhead than from micro-optimising the Numba
+kernel. Promising areas:
+
+- avoid preparing percentile thresholds twice before the fast path;
+- load each spatial tile exactly once and keep unit-normalised values
+  contiguous before entering the kernel;
+- profile monthly and seasonal cases separately, because output grouping
+  changes the amount of count work but not the bootstrap threshold work.
+
+Validation rules
+================
+
+Do not validate bootstrap changes using mean differences only. Always
+compare the full field against the safe reference path and report at
+least:
+
+- maximum absolute difference;
+- number of cells above a tight tolerance such as ``1e-9``;
+- dimensions, coordinates and attributes;
+- memory and wall-clock time for both paths.

--- a/doc/source/dev/percentile_bootstrap.rst
+++ b/doc/source/dev/percentile_bootstrap.rst
@@ -1,8 +1,8 @@
 .. _dev_percentile_bootstrap:
 
-####################
- Percentile bootstrap
-####################
+#####################
+Percentile bootstrap
+#####################
 
 This note records the bootstrap optimisation state after icclim 7.1.4.
 It is meant for maintainers changing the percentile-based count indices.
@@ -83,7 +83,7 @@ dask graph:
 An intermediate experiment materialized the nominal percentile threshold
 for non-overlapping years before entering the kernel. It was exact, but
 large benchmarks showed a clear regression on the 65-year ACCESS-CM2
-case: about 247 seconds instead of about 157 seconds on the same ``rome``
+case: about 247 seconds instead of about 155 seconds on the same ``rome``
 node. The retained strategy computes those nominal thresholds in the
 compiled path and reuses each yearly threshold across monthly groups.
 

--- a/doc/source/dev/percentile_bootstrap.rst
+++ b/doc/source/dev/percentile_bootstrap.rst
@@ -24,8 +24,9 @@ does not call xclim's generic bootstrap decorator. Instead it:
 
 - tiles the spatial domain according to an explicit memory budget;
 - loads one tile at a time, avoiding a large dask bootstrap graph;
-- uses the already-prepared nominal percentile threshold for
-  non-overlapping years;
+- computes nominal thresholds inside the compiled path for
+  non-overlapping years, avoiding an expensive materialized xarray
+  threshold field;
 - recomputes donor-year bootstrap thresholds only for years overlapping
   the reference period;
 - reuses each yearly donor threshold across all output groups in that
@@ -78,6 +79,13 @@ dask graph:
 - monthly ``TG90p``: legacy 212 seconds and 4,696,205 graph tasks; fast
   212 seconds and 0 graph tasks; maximum absolute difference
   ``7.2e-15``; MaxRSS about 4.0 GB.
+
+An intermediate experiment materialized the nominal percentile threshold
+for non-overlapping years before entering the kernel. It was exact, but
+large benchmarks showed a clear regression on the 65-year ACCESS-CM2
+case: about 247 seconds instead of about 157 seconds on the same ``rome``
+node. The retained strategy computes those nominal thresholds in the
+compiled path and reuses each yearly threshold across monthly groups.
 
 So the robust statement is that the fast path bounds memory and avoids
 giant dask graphs. It is much faster than the reliable safe tiled

--- a/src/icclim/_core/generic/bootstrap.py
+++ b/src/icclim/_core/generic/bootstrap.py
@@ -69,6 +69,12 @@ def compute_doy_percentile_bootstrap_count(
         ref.sizes["time"],
         -1,
     )
+    nominal_threshold = _nominal_threshold(threshold)
+    nominal_source_doy_count = nominal_threshold.sizes["dayofyear"]
+    flat_nominal = np.asarray(
+        nominal_threshold.transpose("dayofyear", ...).data,
+        dtype=np.float64,
+    ).reshape(nominal_source_doy_count, -1)
     sample_indices = _rolling_sample_index_matrix(
         ref_time,
         window=threshold.doy_window_width,
@@ -81,6 +87,7 @@ def compute_doy_percentile_bootstrap_count(
     result = _bootstrap_count_kernel(
         flat_ref,
         flat,
+        flat_nominal,
         sample_indices,
         index_year,
         index_pos,
@@ -94,6 +101,7 @@ def compute_doy_percentile_bootstrap_count(
         float(threshold.interpolation.alpha),
         float(threshold.interpolation.beta),
         _operator_code(threshold.operator),
+        nominal_source_doy_count,
     )
     data = result.reshape((len(output_group_labels), *loaded.shape[1:]))
     out = xr.DataArray(
@@ -128,6 +136,15 @@ def _can_compute_fast_bootstrap(
     )
 
 
+def _nominal_threshold(
+    threshold: PercentileThreshold,
+) -> DataArray:
+    nominal = threshold.value
+    if "percentiles" in nominal.dims:
+        nominal = nominal.squeeze("percentiles", drop=True)
+    return nominal
+
+
 def _operator_code(operator: Operator | str) -> int:
     operand = operator.operand if isinstance(operator, Operator) else str(operator)
     return {">": 0, ">=": 1, "<": 2, "<=": 3}.get(operand, -1)
@@ -146,6 +163,7 @@ if njit is not None:
     def _bootstrap_count_kernel(
         flat_ref,
         flat_study,
+        flat_nominal,
         sample_indices,
         index_year,
         index_pos,
@@ -159,6 +177,7 @@ if njit is not None:
         alpha,
         beta,
         op_code,
+        nominal_source_doy_count,
     ):
         n_years = len(study_starts)
         n_cells = flat_study.shape[1]
@@ -173,33 +192,16 @@ if njit is not None:
             start = study_starts[year_i]
             length = study_lengths[year_i]
             if target_ref_i < 0:
-                q = np.empty(365, dtype=np.float64)
-                buf = np.empty(max_samples, dtype=np.float64)
-                for doy_i in range(365):
-                    q[doy_i] = _quantile_for_doy_cell(
-                        flat_ref,
-                        sample_indices,
-                        index_year,
-                        index_pos,
-                        donor_aligned,
-                        -1,
-                        -1,
-                        doy_i,
-                        cell,
-                        buf,
-                        quantile,
-                        alpha,
-                        beta,
-                    )
-                out[year_i, cell] = _count_exceedances(
+                out[year_i, cell] = _count_exceedances_with_nominal_threshold(
                     flat_study,
-                    q,
+                    flat_nominal,
                     study_doys,
                     start,
                     length,
                     cell,
                     max_target_doy,
                     op_code,
+                    nominal_source_doy_count,
                 )
             else:
                 donor_total = 0.0
@@ -238,6 +240,57 @@ if njit is not None:
                     donor_count += 1
                 out[year_i, cell] = donor_total / donor_count
         return out
+
+    @njit(cache=True)
+    def _count_exceedances_with_nominal_threshold(
+        flat_study,
+        flat_nominal,
+        study_doys,
+        start,
+        length,
+        cell,
+        max_target_doy,
+        op_code,
+        nominal_source_doy_count,
+    ):
+        count = 0.0
+        for offset in range(length):
+            doy = study_doys[start + offset]
+            value = flat_study[start + offset, cell]
+            threshold = _adjusted_nominal_threshold(
+                flat_nominal,
+                doy,
+                cell,
+                max_target_doy,
+                nominal_source_doy_count,
+            )
+            if _compare(value, threshold, op_code):
+                count += 1.0
+        return count
+
+    @njit(cache=True)
+    def _adjusted_nominal_threshold(
+        flat_nominal,
+        doy,
+        cell,
+        max_target_doy,
+        nominal_source_doy_count,
+    ):
+        if nominal_source_doy_count == max_target_doy:
+            return flat_nominal[doy - 1, cell]
+        position = (doy - 1.0) * (nominal_source_doy_count - 1.0) / (
+            max_target_doy - 1.0
+        )
+        lower = int(np.floor(position))
+        if lower >= nominal_source_doy_count - 1:
+            return flat_nominal[nominal_source_doy_count - 1, cell]
+        gamma = position - lower
+        left = flat_nominal[lower, cell]
+        right = flat_nominal[lower + 1, cell]
+        diff = right - left
+        if gamma >= 0.5:
+            return right - diff * (1.0 - gamma)
+        return left + diff * gamma
 
     @njit(cache=True)
     def _quantile_for_doy_cell(

--- a/src/icclim/_core/generic/bootstrap.py
+++ b/src/icclim/_core/generic/bootstrap.py
@@ -79,12 +79,6 @@ def compute_doy_percentile_bootstrap_count(
         ref.sizes["time"],
         -1,
     )
-    nominal_threshold = _nominal_threshold(threshold)
-    nominal_source_doy_count = nominal_threshold.sizes["dayofyear"]
-    flat_nominal = np.asarray(
-        nominal_threshold.transpose("dayofyear", ...).data,
-        dtype=np.float64,
-    ).reshape(nominal_source_doy_count, -1)
     sample_indices = _rolling_sample_index_matrix(
         ref_time,
         window=threshold.doy_window_width,
@@ -97,7 +91,6 @@ def compute_doy_percentile_bootstrap_count(
     result = _bootstrap_count_kernel(
         flat_ref,
         flat,
-        flat_nominal,
         sample_indices,
         index_year,
         index_pos,
@@ -113,7 +106,6 @@ def compute_doy_percentile_bootstrap_count(
         float(threshold.interpolation.alpha),
         float(threshold.interpolation.beta),
         _operator_code(threshold.operator),
-        nominal_source_doy_count,
     )
     data = result.reshape((len(output_group_labels), *loaded.shape[1:]))
     out = xr.DataArray(
@@ -148,15 +140,6 @@ def _can_compute_fast_bootstrap(
     )
 
 
-def _nominal_threshold(
-    threshold: PercentileThreshold,
-) -> DataArray:
-    nominal = threshold.value
-    if "percentiles" in nominal.dims:
-        nominal = nominal.squeeze("percentiles", drop=True)
-    return nominal
-
-
 def _operator_code(operator: Operator | str) -> int:
     operand = operator.operand if isinstance(operator, Operator) else str(operator)
     return {">": 0, ">=": 1, "<": 2, "<=": 3}.get(operand, -1)
@@ -175,7 +158,6 @@ if njit is not None:
     def _bootstrap_count_kernel(
         flat_ref,
         flat_study,
-        flat_nominal,
         sample_indices,
         index_year,
         index_pos,
@@ -191,7 +173,6 @@ if njit is not None:
         alpha,
         beta,
         op_code,
-        nominal_source_doy_count,
     ):
         n_years = len(year_to_ref)
         n_groups = len(study_starts)
@@ -207,17 +188,30 @@ if njit is not None:
             group_start = year_group_starts[year_i]
             group_stop = year_group_stops[year_i]
             if target_ref_i < 0:
+                q = _quantiles_for_cell(
+                    flat_ref,
+                    sample_indices,
+                    index_year,
+                    index_pos,
+                    donor_aligned,
+                    -1,
+                    -1,
+                    cell,
+                    max_samples,
+                    quantile,
+                    alpha,
+                    beta,
+                )
                 for group_i in range(group_start, group_stop):
-                    out[group_i, cell] = _count_exceedances_with_nominal_threshold(
+                    out[group_i, cell] = _count_exceedances(
                         flat_study,
-                        flat_nominal,
+                        q,
                         study_doys,
                         study_starts[group_i],
                         study_lengths[group_i],
                         cell,
                         max_target_doy,
                         op_code,
-                        nominal_source_doy_count,
                     )
             else:
                 for group_i in range(group_start, group_stop):
@@ -226,24 +220,20 @@ if njit is not None:
                 for donor_i in range(n_ref_years):
                     if donor_i == target_ref_i:
                         continue
-                    q = np.empty(365, dtype=np.float64)
-                    buf = np.empty(max_samples, dtype=np.float64)
-                    for doy_i in range(365):
-                        q[doy_i] = _quantile_for_doy_cell(
-                            flat_ref,
-                            sample_indices,
-                            index_year,
-                            index_pos,
-                            donor_aligned,
-                            target_ref_i,
-                            donor_i,
-                            doy_i,
-                            cell,
-                            buf,
-                            quantile,
-                            alpha,
-                            beta,
-                        )
+                    q = _quantiles_for_cell(
+                        flat_ref,
+                        sample_indices,
+                        index_year,
+                        index_pos,
+                        donor_aligned,
+                        target_ref_i,
+                        donor_i,
+                        cell,
+                        max_samples,
+                        quantile,
+                        alpha,
+                        beta,
+                    )
                     for group_i in range(group_start, group_stop):
                         out[group_i, cell] += _count_exceedances(
                             flat_study,
@@ -261,55 +251,39 @@ if njit is not None:
         return out
 
     @njit(cache=True)
-    def _count_exceedances_with_nominal_threshold(
-        flat_study,
-        flat_nominal,
-        study_doys,
-        start,
-        length,
+    def _quantiles_for_cell(
+        flat_ref,
+        sample_indices,
+        index_year,
+        index_pos,
+        donor_aligned,
+        target_ref_i,
+        donor_i,
         cell,
-        max_target_doy,
-        op_code,
-        nominal_source_doy_count,
+        max_samples,
+        quantile,
+        alpha,
+        beta,
     ):
-        count = 0.0
-        for offset in range(length):
-            doy = study_doys[start + offset]
-            value = flat_study[start + offset, cell]
-            threshold = _adjusted_nominal_threshold(
-                flat_nominal,
-                doy,
+        q = np.empty(365, dtype=np.float64)
+        buf = np.empty(max_samples, dtype=np.float64)
+        for doy_i in range(365):
+            q[doy_i] = _quantile_for_doy_cell(
+                flat_ref,
+                sample_indices,
+                index_year,
+                index_pos,
+                donor_aligned,
+                target_ref_i,
+                donor_i,
+                doy_i,
                 cell,
-                max_target_doy,
-                nominal_source_doy_count,
+                buf,
+                quantile,
+                alpha,
+                beta,
             )
-            if _compare(value, threshold, op_code):
-                count += 1.0
-        return count
-
-    @njit(cache=True)
-    def _adjusted_nominal_threshold(
-        flat_nominal,
-        doy,
-        cell,
-        max_target_doy,
-        nominal_source_doy_count,
-    ):
-        if nominal_source_doy_count == max_target_doy:
-            return flat_nominal[doy - 1, cell]
-        position = (
-            (doy - 1.0) * (nominal_source_doy_count - 1.0) / (max_target_doy - 1.0)
-        )
-        lower = int(np.floor(position))
-        if lower >= nominal_source_doy_count - 1:
-            return flat_nominal[nominal_source_doy_count - 1, cell]
-        gamma = position - lower
-        left = flat_nominal[lower, cell]
-        right = flat_nominal[lower + 1, cell]
-        diff = right - left
-        if gamma >= 0.5:
-            return right - diff * (1.0 - gamma)
-        return left + diff * gamma
+        return q
 
     @njit(cache=True)
     def _quantile_for_doy_cell(

--- a/src/icclim/_core/generic/bootstrap.py
+++ b/src/icclim/_core/generic/bootstrap.py
@@ -49,15 +49,23 @@ def compute_doy_percentile_bootstrap_count(
         year: source_max_doy if source_max_doy == 366 else int(study_time[indices].dayofyear.max())
         for year, indices in study_year_indices.items()
     }
-    output_years = [int(study_time[indices[0]].year) for indices in output_group_indices.values()]
-    output_max_doys = np.asarray(
-        [study_year_max_doy[year] for year in output_years],
+    output_years = np.asarray(
+        [int(study_time[indices[0]].year) for indices in output_group_indices.values()],
         dtype=np.int64,
     )
-    output_to_ref = np.asarray(
+    bootstrap_years = np.asarray(list(dict.fromkeys(output_years)), dtype=np.int64)
+    year_group_starts, year_group_stops = _group_bounds_by_year(
+        output_years,
+        bootstrap_years,
+    )
+    year_max_doys = np.asarray(
+        [study_year_max_doy[year] for year in bootstrap_years],
+        dtype=np.int64,
+    )
+    year_to_ref = np.asarray(
         [
             int(np.where(ref_years == year)[0][0]) if year in ref_year_indices else -1
-            for year in output_years
+            for year in bootstrap_years
         ],
         dtype=np.int64,
     )
@@ -94,8 +102,10 @@ def compute_doy_percentile_bootstrap_count(
         donor_aligned,
         output_starts,
         output_lengths,
-        output_max_doys,
-        output_to_ref,
+        year_group_starts,
+        year_group_stops,
+        year_max_doys,
+        year_to_ref,
         study_time.dayofyear.to_numpy(dtype=np.int64),
         float(threshold.value.coords["percentiles"].item()) / 100.0,
         float(threshold.interpolation.alpha),
@@ -170,8 +180,10 @@ if njit is not None:
         donor_aligned,
         study_starts,
         study_lengths,
-        study_max_doys,
-        study_to_ref,
+        year_group_starts,
+        year_group_stops,
+        year_max_doys,
+        year_to_ref,
         study_doys,
         quantile,
         alpha,
@@ -179,32 +191,35 @@ if njit is not None:
         op_code,
         nominal_source_doy_count,
     ):
-        n_years = len(study_starts)
+        n_years = len(year_to_ref)
+        n_groups = len(study_starts)
         n_cells = flat_study.shape[1]
-        out = np.empty((n_years, n_cells), dtype=np.float64)
+        out = np.empty((n_groups, n_cells), dtype=np.float64)
         n_ref_years = donor_aligned.shape[1]
         max_samples = sample_indices.shape[1]
         for flat_i in prange(n_years * n_cells):
             year_i = flat_i // n_cells
             cell = flat_i % n_cells
-            target_ref_i = study_to_ref[year_i]
-            max_target_doy = study_max_doys[year_i]
-            start = study_starts[year_i]
-            length = study_lengths[year_i]
+            target_ref_i = year_to_ref[year_i]
+            max_target_doy = year_max_doys[year_i]
+            group_start = year_group_starts[year_i]
+            group_stop = year_group_stops[year_i]
             if target_ref_i < 0:
-                out[year_i, cell] = _count_exceedances_with_nominal_threshold(
-                    flat_study,
-                    flat_nominal,
-                    study_doys,
-                    start,
-                    length,
-                    cell,
-                    max_target_doy,
-                    op_code,
-                    nominal_source_doy_count,
-                )
+                for group_i in range(group_start, group_stop):
+                    out[group_i, cell] = _count_exceedances_with_nominal_threshold(
+                        flat_study,
+                        flat_nominal,
+                        study_doys,
+                        study_starts[group_i],
+                        study_lengths[group_i],
+                        cell,
+                        max_target_doy,
+                        op_code,
+                        nominal_source_doy_count,
+                    )
             else:
-                donor_total = 0.0
+                for group_i in range(group_start, group_stop):
+                    out[group_i, cell] = 0.0
                 donor_count = 0
                 for donor_i in range(n_ref_years):
                     if donor_i == target_ref_i:
@@ -227,18 +242,20 @@ if njit is not None:
                             alpha,
                             beta,
                         )
-                    donor_total += _count_exceedances(
-                        flat_study,
-                        q,
-                        study_doys,
-                        start,
-                        length,
-                        cell,
-                        max_target_doy,
-                        op_code,
-                    )
+                    for group_i in range(group_start, group_stop):
+                        out[group_i, cell] += _count_exceedances(
+                            flat_study,
+                            q,
+                            study_doys,
+                            study_starts[group_i],
+                            study_lengths[group_i],
+                            cell,
+                            max_target_doy,
+                            op_code,
+                        )
                     donor_count += 1
-                out[year_i, cell] = donor_total / donor_count
+                for group_i in range(group_start, group_stop):
+                    out[group_i, cell] /= donor_count
         return out
 
     @njit(cache=True)
@@ -445,6 +462,19 @@ def _indices_by_resample_group(da: DataArray, freq: str) -> dict[np.datetime64, 
             indices = np.asarray(indexer, dtype=np.int64)
         out[np.datetime64(label)] = indices
     return out
+
+
+def _group_bounds_by_year(
+    output_years: np.ndarray,
+    bootstrap_years: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    starts = np.empty(len(bootstrap_years), dtype=np.int64)
+    stops = np.empty(len(bootstrap_years), dtype=np.int64)
+    for i, year in enumerate(bootstrap_years):
+        group_indices = np.where(output_years == year)[0]
+        starts[i] = int(group_indices[0])
+        stops[i] = int(group_indices[-1]) + 1
+    return starts, stops
 
 
 def _rolling_sample_index_matrix(

--- a/src/icclim/_core/generic/bootstrap.py
+++ b/src/icclim/_core/generic/bootstrap.py
@@ -46,7 +46,9 @@ def compute_doy_percentile_bootstrap_count(
     )
     source_max_doy = int(ref_time.dayofyear.max())
     study_year_max_doy = {
-        year: source_max_doy if source_max_doy == 366 else int(study_time[indices].dayofyear.max())
+        year: source_max_doy
+        if source_max_doy == 366
+        else int(study_time[indices].dayofyear.max())
         for year, indices in study_year_indices.items()
     }
     output_years = np.asarray(
@@ -295,8 +297,8 @@ if njit is not None:
     ):
         if nominal_source_doy_count == max_target_doy:
             return flat_nominal[doy - 1, cell]
-        position = (doy - 1.0) * (nominal_source_doy_count - 1.0) / (
-            max_target_doy - 1.0
+        position = (
+            (doy - 1.0) * (nominal_source_doy_count - 1.0) / (max_target_doy - 1.0)
         )
         lower = int(np.floor(position))
         if lower >= nominal_source_doy_count - 1:
@@ -449,7 +451,9 @@ def _indices_by_year(time: pd.DatetimeIndex) -> dict[int, np.ndarray]:
     return {int(year): np.where(time.year == year)[0] for year in np.unique(time.year)}
 
 
-def _indices_by_resample_group(da: DataArray, freq: str) -> dict[np.datetime64, np.ndarray]:
+def _indices_by_resample_group(
+    da: DataArray, freq: str
+) -> dict[np.datetime64, np.ndarray]:
     groups = da.resample(time=freq).groups
     out = {}
     for label, indexer in groups.items():

--- a/src/icclim/_core/generic/bootstrap.py
+++ b/src/icclim/_core/generic/bootstrap.py
@@ -21,8 +21,9 @@ if TYPE_CHECKING:
 def compute_doy_percentile_bootstrap_count(
     study: DataArray,
     threshold: PercentileThreshold,
+    freq: str,
 ) -> DataArray | None:
-    """Compute annual percentile bootstrap counts without building a huge dask graph."""
+    """Compute percentile bootstrap counts without building a huge dask graph."""
     if not _can_compute_fast_bootstrap(study, threshold):
         return None
     loaded = study.load()
@@ -33,29 +34,30 @@ def compute_doy_percentile_bootstrap_count(
     ref_year_indices = _indices_by_year(ref_time)
     study_year_indices = _indices_by_year(study_time)
     ref_years = np.asarray(list(ref_year_indices), dtype=np.int64)
-    study_years = np.asarray(list(study_year_indices), dtype=np.int64)
-    study_starts = np.asarray(
-        [indices[0] for indices in study_year_indices.values()],
+    output_group_indices = _indices_by_resample_group(loaded, freq)
+    output_group_labels = list(output_group_indices)
+    output_starts = np.asarray(
+        [indices[0] for indices in output_group_indices.values()],
         dtype=np.int64,
     )
-    study_lengths = np.asarray(
-        [len(indices) for indices in study_year_indices.values()],
+    output_lengths = np.asarray(
+        [len(indices) for indices in output_group_indices.values()],
         dtype=np.int64,
     )
     source_max_doy = int(ref_time.dayofyear.max())
-    study_max_doys = np.asarray(
-        [
-            source_max_doy
-            if source_max_doy == 366
-            else int(study_time[indices].dayofyear.max())
-            for indices in study_year_indices.values()
-        ],
+    study_year_max_doy = {
+        year: source_max_doy if source_max_doy == 366 else int(study_time[indices].dayofyear.max())
+        for year, indices in study_year_indices.items()
+    }
+    output_years = [int(study_time[indices[0]].year) for indices in output_group_indices.values()]
+    output_max_doys = np.asarray(
+        [study_year_max_doy[year] for year in output_years],
         dtype=np.int64,
     )
-    study_to_ref = np.asarray(
+    output_to_ref = np.asarray(
         [
             int(np.where(ref_years == year)[0][0]) if year in ref_year_indices else -1
-            for year in study_years
+            for year in output_years
         ],
         dtype=np.int64,
     )
@@ -83,22 +85,22 @@ def compute_doy_percentile_bootstrap_count(
         index_year,
         index_pos,
         donor_aligned,
-        study_starts,
-        study_lengths,
-        study_max_doys,
-        study_to_ref,
+        output_starts,
+        output_lengths,
+        output_max_doys,
+        output_to_ref,
         study_time.dayofyear.to_numpy(dtype=np.int64),
         float(threshold.value.coords["percentiles"].item()) / 100.0,
         float(threshold.interpolation.alpha),
         float(threshold.interpolation.beta),
         _operator_code(threshold.operator),
     )
-    data = result.reshape((len(study_years), *loaded.shape[1:]))
+    data = result.reshape((len(output_group_labels), *loaded.shape[1:]))
     out = xr.DataArray(
         data,
         dims=loaded.dims,
         coords={
-            "time": [np.datetime64(f"{year}-01-01") for year in study_years],
+            "time": output_group_labels,
             **{coord: loaded.coords[coord] for coord in loaded.dims if coord != "time"},
         },
         attrs={"units": "d", REFERENCE_PERIOD_ID: climatology_bounds},
@@ -375,6 +377,21 @@ else:
 
 def _indices_by_year(time: pd.DatetimeIndex) -> dict[int, np.ndarray]:
     return {int(year): np.where(time.year == year)[0] for year in np.unique(time.year)}
+
+
+def _indices_by_resample_group(da: DataArray, freq: str) -> dict[np.datetime64, np.ndarray]:
+    groups = da.resample(time=freq).groups
+    out = {}
+    for label, indexer in groups.items():
+        if isinstance(indexer, slice):
+            start = 0 if indexer.start is None else indexer.start
+            stop = da.sizes["time"] if indexer.stop is None else indexer.stop
+            step = 1 if indexer.step is None else indexer.step
+            indices = np.arange(start, stop, step, dtype=np.int64)
+        else:
+            indices = np.asarray(indexer, dtype=np.int64)
+        out[np.datetime64(label)] = indices
+    return out
 
 
 def _rolling_sample_index_matrix(

--- a/src/icclim/_core/generic/functions.py
+++ b/src/icclim/_core/generic/functions.py
@@ -1370,7 +1370,7 @@ def _compute_fast_tiled_count_occurrences(
 ) -> DataArray | None:
     if os.environ.get("ICCLIM_BOOTSTRAP_MODE") == "safe":
         return None
-    if resample_freq.pandas_freq != "YS":
+    if resample_freq.pandas_freq not in {"YS", "MS"}:
         return None
     from icclim._core.generic.bootstrap import (  # noqa: PLC0415
         compute_doy_percentile_bootstrap_count,
@@ -1384,6 +1384,7 @@ def _compute_fast_tiled_count_occurrences(
         tile_result = compute_doy_percentile_bootstrap_count(
             tile_study,
             tile_threshold,
+            resample_freq.pandas_freq,
         )
         if tile_result is None:
             return None

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -835,6 +835,37 @@ class TestIntegration:
         assert profile["bootstrap_fast_tile_count"] == 4
         xr.testing.assert_allclose(default.TX90p, legacy.TX90p)
 
+    def test_index_tx90p__dask_bootstrap_uses_fast_tiled_monthly_path(
+        self,
+        monkeypatch,
+    ) -> None:
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS", "1")
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_FAST_TILE_CELLS", "1")
+        tas = stub_tas(tas_value=27 + K2C, lat_length=2, lon_length=2)
+        tas[5:10] = 0
+        tas = tas.chunk({"time": 365, "lat": 1, "lon": 1})
+        common_kwargs = {
+            "index_name": "tx90p",
+            "in_files": tas,
+            "doy_window_width": 1,
+            "time_range": ("2042-01-01", "2045-12-31"),
+            "base_period_time_range": ("2042-01-01", "2043-12-31"),
+            "out_file": self.OUTPUT_FILE,
+            "slice_mode": "ms",
+        }
+
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_MODE", "default")
+        legacy = icclim.index(**common_kwargs).compute()
+        monkeypatch.delenv("ICCLIM_BOOTSTRAP_MODE")
+        generic_functions.reset_bootstrap_profile()
+
+        default = icclim.index(**common_kwargs)
+        profile = generic_functions.get_bootstrap_profile()
+
+        assert not hasattr(default.TX90p.data, "__dask_graph__")
+        assert profile["bootstrap_fast_tile_count"] == 4
+        xr.testing.assert_allclose(default.TX90p, legacy.TX90p)
+
     def test_index_tx90p__safe_bootstrap_uses_memory_budget(self, monkeypatch) -> None:
         monkeypatch.delenv("ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS", raising=False)
         monkeypatch.setenv("ICCLIM_BOOTSTRAP_MODE", "safe")


### PR DESCRIPTION
## Summary

This PR extends the reliable compiled percentile-bootstrap count path introduced in 7.1.4.

It adds support for monthly (`MS`) percentile count outputs and keeps annual (`YS`) behavior exact. The fast path remains narrowly gated: single day-of-year percentile, simple count operators, no `threshold_min_value`, no `only_leap_years`, and pandas-compatible calendars. Unsupported cases continue to fall back to the safe tiled xclim path.

## Methodology

- Compute nominal thresholds inside the compiled path for non-overlap years, avoiding expensive materialized xarray threshold fields.
- Recompute donor-year bootstrap thresholds only for years overlapping the reference period.
- Reuse each yearly donor threshold across all output groups in that year, so monthly output does not recompute the same bootstrap threshold twelve times.
- Keep fast path eager/tiled to avoid large dask graphs and bound memory use.

## Validation

Local focused tests:

- `ruff check src/icclim/_core/generic/bootstrap.py tests/test_main.py`
- `python -m py_compile src/icclim/_core/generic/bootstrap.py src/icclim/_core/generic/functions.py`
- `pytest tests/test_main.py::TestIntegration::test_index_tx90p__dask_bootstrap_uses_fast_tiled_path tests/test_main.py::TestIntegration::test_index_tx90p__dask_bootstrap_uses_fast_tiled_monthly_path -q`

Local real-data MPI smoke comparison:

- annual and monthly TG90p fast vs legacy: `changed_gt_1e-9 = 0`, `max_abs_diff = 0.0`.

Kraken large ACCESS-CM2 validation: 65 years, 16 latitudes, 11 longitudes.

- safe tiled fallback: 1473 s;
- 7.1.4 old fast path on same `rome` setup: 156.7 s;
- this PR after cleanup: 154.6 s total, 139.5 s in bootstrap fast path, graph tasks 0, MaxRSS about 1.1 GB;
- exact against safe reference within floating-point precision: `max_abs_diff = 5.7e-14`, `changed_cells_gt_1e-9 = 0`.

Kraken ACCESS-CM2 validation subset: 65 years, 28 latitudes, 21 longitudes.

- annual TG90p: legacy 204 s and 4,691,198 graph tasks; fast 212 s and 0 graph tasks; `max_abs_diff = 8.6e-14`; MaxRSS about 4.4 GB.
- monthly TG90p: legacy 212 s and 4,696,205 graph tasks; fast 212 s and 0 graph tasks; `max_abs_diff = 7.2e-15`; MaxRSS about 4.0 GB.

Intermediate rejected experiment:

- materializing nominal thresholds before the kernel was exact but regressed the large case to about 247 s, so it was removed.

## Changelog wording suggestion

Improved reliability of percentile-based count indices with bootstrap on dask-backed data. The optimized bootstrap path now supports annual and monthly outputs, avoids constructing multi-million-task dask graphs, and keeps memory bounded through explicit spatial tiling. Unsupported cases still fall back to the safe tiled bootstrap path. On validated ACCESS-CM2 TG90p annual and monthly cases, the optimized path matched the legacy bootstrap within floating-point precision while reducing graph tasks from about 4.7 million to zero. Against the reliable safe tiled fallback, the large TG90p benchmark improved from about 1473 s to about 155 s.