### PR TITLE
Prepare release 7.1.5

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,14 +8,14 @@ authors:
   - family-names: "Aoun"
     given-names: "Abel"
 title: "icclim: Index Calculation CLIMate"
-version: 7.1.4
+version: 7.1.5
 doi: 10.5281/zenodo.6046052
 date-released: 2026-07-22
 url: "https://github.com/cerfacs-globc/icclim"
 repository-code: "https://github.com/cerfacs-globc/icclim"
 identifiers:
   - type: url
-    value: "https://github.com/cerfacs-globc/icclim/tree/v7.1.4"
+    value: "https://github.com/cerfacs-globc/icclim/tree/v7.1.5"
     description: "Specific version source code"
 keywords:
   - "climate"

--- a/doc/source/references/release_notes.rst
+++ b/doc/source/references/release_notes.rst
@@ -3,6 +3,17 @@
 #################
 
 ******
+7.1.5
+******
+
+date: 2026-07-22
+
+
+-  [enh] Extend the compiled percentile bootstrap count path to monthly outputs, so day-of-year percentile count indices such as ``TG90p``, ``TX90p`` and ``TN90p`` can avoid multi-million-task dask graphs for both annual and monthly frequencies.
+-  [perf] Reuse each yearly bootstrap threshold across all output groups in the same year and avoid materializing nominal percentile thresholds, preserving the fast annual performance validated in ``v7.1.4``.
+-  [doc] Document the percentile bootstrap strategy, supported cases, validation rules and Kraken benchmark results for future maintainers.
+
+******
 7.1.4
 ******
 

--- a/src/icclim/__init__.py
+++ b/src/icclim/__init__.py
@@ -23,7 +23,7 @@ __all__ = [
     "indices",  # noqa: F405
 ]
 
-__version__ = "7.1.4"
+__version__ = "7.1.5"
 
 
 def __getattr__(name: str) -> Callable:


### PR DESCRIPTION
## Summary

Prepare icclim `7.1.5` after merging the percentile bootstrap reliability/performance work from #427.

This release includes the monthly compiled percentile-bootstrap count path and documents the validated bootstrap strategy for maintainers.

## Validation

- `python - <<'PY'\nimport icclim\nprint(icclim.__version__)\nPY` returned `7.1.5`
- `python -m py_compile src/icclim/__init__.py`
- `git diff --check`

## Notes

The displayed logo SVGs are intentionally not updated in this PR. The existing `logo-update` workflow handles those after the release bump lands on `master`, as in previous releases.
