### PR TITLE
PERF: enable fast bootstrap for seasonal counts

### DIFF
--- a/doc/source/dev/percentile_bootstrap.rst
+++ b/doc/source/dev/percentile_bootstrap.rst
@@ -86,6 +86,15 @@ case: about 247 seconds instead of about 155 seconds on the same ``rome``
 node. The retained strategy computes those nominal thresholds in the
 compiled path and reuses each yearly threshold across monthly groups.
 
+Seasonal validation on the same 65-year ACCESS-CM2 subset showed that
+anchored annual seasonal outputs match eager in-memory references exactly
+while keeping the fast path graph-free:
+
+- ``JJA`` ``TG90p``: eager reference 16 seconds; fast dask path 12
+  seconds; maximum absolute difference ``0``;
+- ``ONDJFM`` ``TG90p``: eager reference 22 seconds; fast dask path 22
+  seconds; maximum absolute difference ``0``.
+
 So the robust statement is that the fast path bounds memory and avoids
 giant dask graphs. It is much faster than the reliable safe tiled
 fallback, but it is not guaranteed to beat the old graph path on cases

--- a/doc/source/dev/percentile_bootstrap.rst
+++ b/doc/source/dev/percentile_bootstrap.rst
@@ -34,7 +34,8 @@ does not call xclim's generic bootstrap decorator. Instead it:
 
 Fast path currently supports:
 
-- annual ``YS`` and monthly ``MS`` output periods;
+- annual ``YS``, monthly ``MS`` and anchored annual ``YS-*`` seasonal
+  output periods;
 - single day-of-year percentile thresholds;
 - simple count operators: ``>``, ``>=``, ``<`` and ``<=``;
 - no ``threshold_min_value``;
@@ -47,8 +48,6 @@ Unsupported cases
 Unsupported cases intentionally fall back to the safe tiled path. The
 most useful future extensions are likely:
 
-- seasonal output periods, after validating that resample grouping and
-  donor-year substitution are scientifically coherent for seasons;
 - precipitation wet-day percentile thresholds using
   ``threshold_min_value``;
 - non-standard calendars, once cftime grouping and leap handling are

--- a/src/icclim/_core/generic/functions.py
+++ b/src/icclim/_core/generic/functions.py
@@ -1370,7 +1370,7 @@ def _compute_fast_tiled_count_occurrences(
 ) -> DataArray | None:
     if os.environ.get("ICCLIM_BOOTSTRAP_MODE") == "safe":
         return None
-    if resample_freq.pandas_freq not in {"YS", "MS"}:
+    if not _is_fast_bootstrap_frequency(resample_freq.pandas_freq):
         return None
     from icclim._core.generic.bootstrap import (  # noqa: PLC0415
         compute_doy_percentile_bootstrap_count,
@@ -1400,6 +1400,10 @@ def _compute_fast_tiled_count_occurrences(
     result.attrs.update(tile_results[-1].attrs)
     _profile_bootstrap_add("bootstrap_fast_total_seconds", perf_counter() - fast_start)
     return result
+
+
+def _is_fast_bootstrap_frequency(freq: str) -> bool:
+    return freq in {"MS", "YS"} or freq.startswith("YS-")
 
 
 def _should_use_safe_count_bootstrap(climate_var: ClimateVariable) -> bool:

--- a/src/icclim/_core/generic/indicator.py
+++ b/src/icclim/_core/generic/indicator.py
@@ -555,13 +555,16 @@ class GenericIndicator(Indicator):
         """
         from xclim.core.missing import MISSING_METHODS  # noqa: PLC0415
 
-        missing_class = MISSING_METHODS[self.missing]  # Get the class
-        missing_obj = missing_class()  # Instantiate with no args
+        missing_class = MISSING_METHODS[self.missing]
 
         # We flag periods according to the missing method. Skip variables without a time coordinate.
         miss = (
-            missing_obj(
-                da, freq=resample_freq, src_timestep=src_freq, **(indexer or {})
+            self._compute_missing_mask(
+                missing_class,
+                da,
+                resample_freq,
+                src_freq,
+                indexer or {},
             )
             for da in (in_data if isinstance(in_data, Sequence) else [in_data])
             if "time" in da.coords
@@ -587,6 +590,33 @@ class GenericIndicator(Indicator):
             mask = xr.where(mask.time == mask.time[-1], False, mask)
 
         return out_data.where(~mask)
+
+    def _compute_missing_mask(
+        self,
+        missing_class: type,
+        da: DataArray,
+        resample_freq: str | None,
+        src_freq: str | None,
+        indexer: dict[Any, Any],
+    ) -> DataArray:
+        missing_options = self.missing_options or {}
+        try:
+            missing_obj = missing_class(**missing_options)
+        except TypeError:
+            missing_obj = missing_class(
+                da,
+                freq=resample_freq,
+                src_timestep=src_freq,
+                **indexer,
+                **missing_options,
+            )
+            return missing_obj()
+        return missing_obj(
+            da,
+            freq=resample_freq,
+            src_timestep=src_freq,
+            **indexer,
+        )
 
 
 def _same_freq_for_all(climate_vars: list[ClimateVariable]) -> bool:

--- a/tests/test_generic_functions.py
+++ b/tests/test_generic_functions.py
@@ -1,4 +1,5 @@
 import pytest
+import xarray as xr
 
 from icclim._core.climate_variable import ClimateVariable
 from icclim._core.constants import GROUP_BY_METHOD
@@ -15,6 +16,7 @@ from icclim._core.generic.functions import (
 from icclim._core.model.logical_link import LogicalLinkRegistry
 from icclim._core.model.standard_variable import StandardVariableRegistry
 from icclim.frequency import FrequencyRegistry
+from icclim.generic.registry import GenericIndicatorRegistry
 from icclim.threshold.factory import build_threshold
 from tests.testing_utils import stub_tas
 
@@ -50,6 +52,28 @@ def test_percentile() -> None:
         is_compared_to_reference=False,
     )
     assert result[0] == -5
+
+
+def test_missing_mask_supports_latest_xclim_constructor_style() -> None:
+    class NewStyleMissing:
+        def __init__(self, da, freq=None, src_timestep=None, **indexer):
+            self.da = da
+            self.freq = freq
+            self.src_timestep = src_timestep
+            self.indexer = indexer
+
+        def __call__(self):
+            return xr.zeros_like(self.da, dtype=bool)
+
+    tas = stub_tas()
+    mask = GenericIndicatorRegistry.CountOccurrences._compute_missing_mask(
+        NewStyleMissing,
+        tas,
+        "YS-JUN",
+        "D",
+        {"month": [6, 7, 8]},
+    )
+    assert not bool(mask.any())
 
 
 def test_average() -> None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -866,6 +866,37 @@ class TestIntegration:
         assert profile["bootstrap_fast_tile_count"] == 4
         xr.testing.assert_allclose(default.TX90p, legacy.TX90p)
 
+    @pytest.mark.parametrize("slice_mode", ["JJA", "ONDJFM"])
+    def test_index_tx90p__dask_bootstrap_uses_fast_tiled_seasonal_path(
+        self,
+        slice_mode,
+        monkeypatch,
+    ) -> None:
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS", "1")
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_FAST_TILE_CELLS", "1")
+        tas = stub_tas(tas_value=27 + K2C, lat_length=2, lon_length=2)
+        tas[160:165] = 0
+        tas[340:345] = 0
+        tas = tas.chunk({"time": 365, "lat": 1, "lon": 1})
+        common_kwargs = {
+            "index_name": "tx90p",
+            "in_files": tas,
+            "doy_window_width": 1,
+            "time_range": ("2042-01-01", "2045-12-31"),
+            "base_period_time_range": ("2042-01-01", "2043-12-31"),
+            "out_file": self.OUTPUT_FILE,
+            "slice_mode": slice_mode,
+        }
+
+        eager = icclim.index(**{**common_kwargs, "in_files": tas.compute()}).compute()
+        generic_functions.reset_bootstrap_profile()
+
+        default = icclim.index(**common_kwargs)
+        profile = generic_functions.get_bootstrap_profile()
+
+        assert profile["bootstrap_fast_tile_count"] == 4
+        xr.testing.assert_allclose(default.TX90p.load(), eager.TX90p)
+
     def test_index_tx90p__safe_bootstrap_uses_memory_budget(self, monkeypatch) -> None:
         monkeypatch.delenv("ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS", raising=False)
         monkeypatch.setenv("ICCLIM_BOOTSTRAP_MODE", "safe")


### PR DESCRIPTION
## Summary

Extend the reliable compiled percentile-bootstrap count path to anchored annual seasonal outputs (`YS-*`), such as `JJA` and cross-year `ONDJFM`.

This also fixes compatibility with latest xclim missing-value classes, whose constructor now receives `da`, `freq`, and `src_timestep` directly. Without that fix, seasonal postprocessing failed on Kraken/latest dependencies before bootstrap validation could complete.

## Validation

Local:

- `ruff check src/icclim/_core/generic/indicator.py src/icclim/_core/generic/functions.py tests/test_main.py tests/test_generic_functions.py`
- `pytest tests/test_generic_functions.py::test_missing_mask_supports_latest_xclim_constructor_style tests/test_generated_api.py::test_txx__season_slice_mode tests/test_main.py::TestIntegration::test_index_tx90p__dask_bootstrap_uses_fast_tiled_seasonal_path -q`

Kraken seasonal validation, ACCESS-CM2, 65 years, 16 latitudes, 11 longitudes, commit `771c13e`:

- `JJA` `TG90p`: eager reference 16.1 s, fast dask path 12.0 s, graph tasks 0, `max_abs_diff = 0`, `changed_cells_gt_1e-9 = 0`.
- `ONDJFM` `TG90p`: eager reference 22.4 s, fast dask path 22.5 s, graph tasks 0, `max_abs_diff = 0`, `changed_cells_gt_1e-9 = 0`.

## Notes

The old dask/xclim graph path fails locally for seasonal dask bootstrap with a `dayofyear` index mismatch. This PR compares the new fast dask path against the eager in-memory reference instead.
