### PR TITLE
Prepare release 7.1.6

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,14 +8,14 @@ authors:
   - family-names: "Aoun"
     given-names: "Abel"
 title: "icclim: Index Calculation CLIMate"
-version: 7.1.5
+version: 7.1.6
 doi: 10.5281/zenodo.6046052
 date-released: 2026-07-22
 url: "https://github.com/cerfacs-globc/icclim"
 repository-code: "https://github.com/cerfacs-globc/icclim"
 identifiers:
   - type: url
-    value: "https://github.com/cerfacs-globc/icclim/tree/v7.1.5"
+    value: "https://github.com/cerfacs-globc/icclim/tree/v7.1.6"
     description: "Specific version source code"
 keywords:
   - "climate"

--- a/doc/source/references/release_notes.rst
+++ b/doc/source/references/release_notes.rst
@@ -3,6 +3,17 @@
 #################
 
 ******
+7.1.6
+******
+
+date: 2026-07-22
+
+
+-  [enh] Extend the compiled percentile bootstrap count path to anchored annual seasonal outputs such as ``JJA`` and ``ONDJFM``.
+-  [fix] Support the latest ``xclim`` missing-value method API during seasonal post-processing.
+-  [doc] Add seasonal bootstrap validation results showing exact agreement against eager references on Kraken.
+
+******
 7.1.5
 ******
 

--- a/src/icclim/__init__.py
+++ b/src/icclim/__init__.py
@@ -23,7 +23,7 @@ __all__ = [
     "indices",  # noqa: F405
 ]
 
-__version__ = "7.1.5"
+__version__ = "7.1.6"
 
 
 def __getattr__(name: str) -> Callable:


### PR DESCRIPTION
## Summary

Prepare icclim `7.1.6` after merging seasonal bootstrap reliability work from #430.

## Included changes

- Fast compiled percentile bootstrap count path now supports anchored annual seasonal outputs such as `JJA` and `ONDJFM`.
- Seasonal post-processing supports the latest `xclim` missing-value method API.
- Developer documentation records seasonal Kraken validation.

## Validation

- `python - <<'PY'\nimport icclim\nprint(icclim.__version__)\nPY` returned `7.1.6`
- `python -m py_compile src/icclim/__init__.py`
- `git diff --check`
