### PR TITLE
Stabilize percentile bootstrap release scope

### DIFF
--- a/doc/source/dev/bootstrap_architecture.rst
+++ b/doc/source/dev/bootstrap_architecture.rst
@@ -1,0 +1,485 @@
+.. _dev_bootstrap_architecture:
+
+######################
+Bootstrap architecture
+######################
+
+This note describes a maintainable design for percentile bootstrap work
+after the July 29, 2026 Kraken validation round.
+
+It complements :ref:`dev_percentile_bootstrap`, which records the
+current production behavior and benchmark results. This document is
+about structure: which bootstrap families exist, which reusable
+functions they should share, and how to keep the implementation readable
+as support grows.
+
+Design goals
+============
+
+Bootstrap code should be:
+
+- exact with respect to the safe reference implementation;
+- explicit about what is supported, what falls back, and what is still
+  unsupported;
+- organized around a small number of reusable calculations rather than a
+  growing list of special cases;
+- easy for maintainers to read, debug and extend.
+
+Readability matters as much as raw performance. The implementation
+should prefer clear control flow, descriptive variable names and small
+helpers with stable responsibilities over clever compression of several
+steps into one function.
+
+This is also aligned with FAIR for Research Software (FAIR4RS). In this
+context, readable code is not only a style preference. It directly
+supports software reuse, inspection, onboarding and reliable extension
+by future maintainers.
+
+Guiding principles
+==================
+
+Use the following rules when extending bootstrap support:
+
+- Separate threshold generation from result aggregation.
+- Classify support by mathematical family, not by index short name.
+- Keep the safe tiled path as the semantic oracle for every new fast
+  implementation.
+- Prefer a small number of well-named helpers over large mixed-purpose
+  functions.
+- Make routing decisions explicit in one place rather than scattering
+  eligibility checks across reducers.
+
+Bootstrap families
+==================
+
+Bootstrap support should be described in terms of algorithm families.
+Named indices and generic indices can then map onto those families.
+
+Percentile count family
+-----------------------
+
+This family covers indices where bootstrap means:
+
+- recompute a percentile threshold with donor-year substitution;
+- compare daily values to that threshold;
+- aggregate the daily boolean mask as counts.
+
+Examples:
+
+- ``TG90p``, ``TN90p``, ``TX90p``;
+- ``TG10p``, ``TN10p``, ``TX10p``;
+- generic ``count_occurrences`` with one percentile threshold.
+
+Percentile filtered-count family
+--------------------------------
+
+This family is similar to the count family, but the percentile sample is
+filtered before percentile computation.
+
+Examples:
+
+- ``R75p``, ``R95p``, ``R99p``;
+- generic percentile counts using ``threshold_min_value``.
+
+The Kraken validation showed that this family cannot be treated as a
+minor variant of the plain count family. Its donor-year semantics must
+be matched exactly before any compiled fast path is enabled.
+
+Percentile amount and fraction family
+-------------------------------------
+
+This family uses percentile bootstrap to define exceedance days, but the
+final result is not a count. Instead it aggregates the values on those
+days.
+
+Examples:
+
+- ``R75pTOT``, ``R95pTOT``, ``R99pTOT``;
+- generic ``sum``, ``average``, ``fraction_of_total``, ``maximum`` or
+  ``minimum`` with percentile thresholds.
+
+Percentile spell family
+-----------------------
+
+This family depends on temporal structure after thresholding. It cannot
+be reduced to independent daywise counts.
+
+Examples:
+
+- ``WSDI``, ``CSDI``;
+- generic spell or consecutive-event indicators using percentile
+  thresholds.
+
+Percentile compound family
+--------------------------
+
+This family combines several threshold conditions, possibly across
+variables and threshold types.
+
+Examples:
+
+- ``CD``, ``CW``, ``WD``, ``WW``;
+- generic multi-threshold percentile compositions.
+
+Non-bootstrap family
+--------------------
+
+Some indices do not need percentile bootstrap at all.
+
+Examples:
+
+- scalar-threshold counts such as ``SU``, ``TR``, ``RR1``;
+- scalar-threshold spells such as ``CDD`` and ``CWD``;
+- simple sums, means and extrema such as ``TG``, ``RR`` and
+  ``RX1day``.
+
+These should be classified as ``bootstrap_not_required`` rather than
+mixed into unsupported cases.
+
+Capability matrix
+=================
+
+Every percentile-based generic index should be routed through one
+classifier that answers four questions:
+
+1. Is bootstrap required?
+2. If it is required, which family does the index belong to?
+3. Can the fast implementation be used?
+4. If not, should icclim fall back to the safe tiled path or reject the
+   request as unsupported?
+
+The classifier should use explicit fields rather than index names:
+
+- threshold kind:
+  ``basic``, ``doy_percentile``, ``period_percentile``,
+  ``multiple_thresholds``;
+- threshold filter:
+  none or ``threshold_min_value``;
+- operator:
+  ``>``, ``>=``, ``<``, ``<=`` or other;
+- reducer family:
+  count, masked-value aggregate, spell, consecutive-event, compound;
+- number of input variables:
+  one or many;
+- calendar type:
+  pandas-compatible, Gregorian-like ``cftime``, other ``cftime``;
+- output frequency:
+  annual, monthly, anchored seasonal, other;
+- threshold count:
+  one or many.
+
+The classifier result should be a small explicit object rather than a
+boolean. For example, it should carry:
+
+- whether bootstrap is required;
+- the bootstrap family;
+- the chosen execution path:
+  ``fast``, ``safe_fallback``, ``unsupported``, ``not_required``;
+- a short reason code for logs, tests and debugging.
+
+Reusable bootstrap primitives
+=============================
+
+The long-term goal is to make each bootstrap algorithm a composition of
+shared primitives rather than a separate stack.
+
+Reference sample preparation
+----------------------------
+
+One helper should own:
+
+- extracting the reference-period subset;
+- converting units needed for percentile computation;
+- applying optional sample filtering such as ``threshold_min_value``;
+- exposing year and day lookup data used by donor-year logic.
+
+Suggested names:
+
+- ``reference_sample``
+- ``filtered_reference_sample``
+- ``reference_year_index``
+- ``reference_day_of_year``
+
+Avoid short names such as ``ref2`` or ``idx_map`` when the longer name
+removes ambiguity.
+
+Bootstrap threshold generation
+------------------------------
+
+One threshold engine should own:
+
+- donor-year substitution rules;
+- day-of-year percentile logic;
+- period percentile logic;
+- interpolation behavior;
+- calendar-aware alignment between study days and reference days.
+
+This is the most important reusable layer. Count, amount, fraction and
+spell reducers should all consume the same threshold semantics.
+
+Suggested helper responsibilities:
+
+- ``build_bootstrap_thresholds_for_year``
+- ``build_nominal_thresholds``
+- ``build_donor_thresholds``
+- ``align_thresholds_to_study_days``
+
+Daily exceedance mask construction
+----------------------------------
+
+One helper should convert values and thresholds into a daily boolean
+mask using a well-defined comparison operator.
+
+Suggested names:
+
+- ``compute_exceedance_mask``
+- ``compare_values_to_thresholds``
+
+This should be shared by all reducer families.
+
+Reducer primitives
+------------------
+
+After a daily exceedance mask exists, the remaining work should be
+handled by separate reducers.
+
+Count reducer
+^^^^^^^^^^^^^
+
+Consumes a daily exceedance mask and returns counts per output period.
+
+Suggested name:
+
+- ``count_masked_days``
+
+Masked value reducer
+^^^^^^^^^^^^^^^^^^^^
+
+Consumes a daily exceedance mask and studied values, then returns sums,
+means or extrema over selected days.
+
+Suggested names:
+
+- ``sum_selected_values``
+- ``mean_selected_values``
+- ``maximum_selected_value``
+- ``minimum_selected_value``
+
+Fraction reducer
+^^^^^^^^^^^^^^^^
+
+Consumes a daily exceedance mask and studied values, then returns the
+selected-value sum divided by the total sum over the same output period.
+
+Suggested name:
+
+- ``fraction_of_selected_values``
+
+Spell reducer
+^^^^^^^^^^^^^
+
+Consumes a daily exceedance mask and computes spell or run-length
+metrics.
+
+Suggested names:
+
+- ``sum_spell_lengths``
+- ``maximum_spell_length``
+- ``spell_event_dates``
+
+Compound mask combiner
+^^^^^^^^^^^^^^^^^^^^^^
+
+Consumes several masks and combines them using explicit logical rules.
+
+Suggested names:
+
+- ``combine_exceedance_masks``
+- ``apply_logical_link_to_masks``
+
+Module boundaries
+=================
+
+The implementation should make it obvious where to look for each kind
+of logic.
+
+Suggested split:
+
+- a capability module that classifies bootstrap requests;
+- a threshold engine module that computes bootstrapped thresholds;
+- a reducer module that turns daily masks into final outputs;
+- a dispatch layer that chooses ``fast`` or ``safe_fallback`` and wires
+  the pieces together.
+
+The important part is not the exact filenames. It is that the code
+should avoid mixing all of these responsibilities in the same function.
+
+Naming and readability rules
+============================
+
+To keep the code understandable for humans:
+
+- prefer ``reference_sample`` over ``ref`` when the longer name makes
+  the role clearer;
+- prefer ``target_year_index`` and ``donor_year_index`` over short loop
+  names that require reading several surrounding lines;
+- prefer ``study_day_of_year`` over ``study_doys`` in higher-level
+  helpers, while compact local names are acceptable inside tight kernels;
+- avoid helpers that both compute thresholds and aggregate results;
+- keep data preparation, routing and numerical kernels visibly separate;
+- write short comments for non-obvious scientific rules, not for obvious
+  control flow.
+
+Compiled kernels may still use shorter local variable names where that
+substantially improves the shape of the loop, but the public Python
+helpers around them should remain descriptive.
+
+Readability beyond bootstrap
+============================
+
+These rules should apply to icclim more broadly, not only to bootstrap
+code.
+
+Function design
+---------------
+
+- Each function should have one main responsibility that can be stated
+  in a short sentence.
+- Functions should return data at a clear level of abstraction. Avoid
+  helpers that partly prepare data, partly dispatch, and partly compute
+  the final scientific result.
+- If a helper needs several boolean flags to change behavior, it is
+  often a sign that the responsibility is too broad.
+
+Naming
+------
+
+- Names should reflect the scientific role of the object, not just its
+  type.
+- Prefer names such as ``reference_period_bounds``,
+  ``bootstrap_thresholds`` or ``exceedance_mask`` over generic names
+  such as ``data2``, ``tmp`` or ``result2``.
+- Variable names should distinguish raw values, filtered values, masks
+  and aggregated outputs.
+
+Structure
+---------
+
+- Keep orchestration code in Python helpers and tight numerical work in
+  focused kernels.
+- Keep threshold semantics, mask semantics and aggregation semantics in
+  different helpers or modules.
+- Prefer explicit small intermediate values over deeply nested
+  expressions when the intermediate names make the scientific meaning
+  clearer.
+
+Comments and documentation
+--------------------------
+
+- Use comments to explain scientific intent, edge cases and constraints.
+- Do not use comments to restate obvious code.
+- When behavior follows an external definition or guideline, reference
+  that definition in a nearby docstring, comment or maintainer note.
+
+Tests as readability support
+----------------------------
+
+- Tests should reveal the intended behavior, not only guard against
+  regressions.
+- Prefer test names that explain the scientific case and the expected
+  routing decision.
+- Where bootstrap dispatch matters, tests should state whether the case
+  is expected to use the fast path, safe fallback, or no bootstrap at
+  all.
+
+FAIR4RS implications
+====================
+
+The FAIR4RS principles are broader than naming and formatting, but they
+do have concrete implications for code structure.
+
+Findable
+--------
+
+The relevant logic should be easy to locate. A maintainer should be able
+to answer:
+
+- where bootstrap routing happens;
+- where percentile semantics are defined;
+- where each reducer family is implemented;
+- where real-data validation rules are documented.
+
+This is much easier when responsibilities are split into explicit
+modules, with stable names and maintainer notes.
+
+Accessible
+----------
+
+The code should be understandable without hidden tribal knowledge.
+Docstrings, developer notes and descriptive function names make the
+implementation accessible to contributors who did not write the original
+feature.
+
+Interoperable
+-------------
+
+Interoperability is not only about file formats and APIs. Internally,
+icclim code should use shared concepts and shared data shapes across
+bootstrap families:
+
+- threshold engine outputs should look consistent across day-of-year and
+  period percentiles;
+- exceedance masks should have one standard meaning;
+- reducers should consume well-defined inputs rather than custom
+  per-index structures.
+
+Reusable
+--------
+
+Reusability is where readability and architecture meet most directly.
+Code becomes easier to reuse when:
+
+- helpers have narrow, stable responsibilities;
+- the same threshold engine can feed several reducers;
+- tests describe the support boundary clearly;
+- capability routing is explicit and inspectable.
+
+In practice, FAIR4RS for this part of icclim means that a future
+maintainer should be able to add one new climate-index family by reusing
+existing primitives rather than reverse-engineering a monolithic
+bootstrap implementation.
+
+Recommended implementation order
+================================
+
+The best coverage-per-effort order is:
+
+1. implement the capability classifier;
+2. extract the reusable threshold-generation layer;
+3. keep the current count reducer on top of that shared layer;
+4. add masked-value and fraction reducers for ``R*pTOT``-style indices;
+5. add a spell reducer for ``WSDI`` and ``CSDI``;
+6. add compound-mask composition for indices such as ``CD`` and ``CW``.
+
+At each step:
+
+- compare against the safe tiled reference path;
+- validate on real data, not only synthetic examples;
+- record both performance and field equality;
+- widen dispatch only after Kraken validation is exact.
+
+What success looks like
+=======================
+
+The target state is not a single giant bootstrap implementation. It is a
+small architecture where:
+
+- one classifier explains what path any generic index will take;
+- one threshold engine defines percentile bootstrap semantics;
+- several simple reducers reuse those semantics;
+- fast implementations can be added family by family without rewriting
+  bootstrap logic.
+
+If the code reaches that shape, adding support for new climate indices
+should mostly mean mapping them to an existing family or adding one new
+reducer, not inventing a new bootstrap system each time.

--- a/doc/source/dev/index.rst
+++ b/doc/source/dev/index.rst
@@ -14,5 +14,6 @@ development.
    release_process
    ci
    percentile_bootstrap
+   bootstrap_architecture
    contributing
    climpact_comparison_protocol

--- a/doc/source/dev/percentile_bootstrap.rst
+++ b/doc/source/dev/percentile_bootstrap.rst
@@ -22,6 +22,9 @@ very large dask graphs.
 The fast path is specialised for percentile-based count indices. It
 does not call xclim's generic bootstrap decorator. Instead it:
 
+- defers full percentile-threshold materialization until a path
+  actually needs the threshold field, such as ``save_thresholds`` or
+  the safe tiled fallback;
 - tiles the spatial domain according to an explicit memory budget;
 - loads one tile at a time, avoiding a large dask bootstrap graph;
 - computes nominal thresholds inside the compiled path for
@@ -38,7 +41,6 @@ Fast path currently supports:
   output periods;
 - single day-of-year percentile thresholds;
 - simple count operators: ``>``, ``>=``, ``<`` and ``<=``;
-- no ``threshold_min_value``;
 - no ``only_leap_years``;
 - pandas-compatible calendars.
 
@@ -48,12 +50,25 @@ Unsupported cases
 Unsupported cases intentionally fall back to the safe tiled path. The
 most useful future extensions are likely:
 
-- precipitation wet-day percentile thresholds using
-  ``threshold_min_value``;
-- non-standard calendars, once cftime grouping and leap handling are
-  explicitly tested;
+- percentile thresholds using ``threshold_min_value`` such as wet-day
+  precipitation counts; Kraken validation on July 29, 2026 showed that
+  the experimental fast-path implementation was materially faster but
+  not field-identical to the safe tiled reference, so support remains
+  disabled until donor-year bootstrap semantics are matched exactly;
+- ``cftime`` calendars; Kraken validation on July 29, 2026 found a
+  remaining one-cell mismatch on a Gregorian-like ``cftime`` case, so
+  the release path keeps ``cftime`` on the exact safe tiled fallback
+  until the fast-path semantics are field-identical;
 - spell/run-length indices, which likely need a different algorithm
   because the bootstrap cannot be reduced to independent daily counts.
+
+For spell/run-length work, the likely direction is a two-stage design:
+
+- compute or bootstrap a daily exceedance mask first, reusing the
+  current donor-year percentile machinery;
+- run spell detection on the bootstrapped mask per donor year, then
+  aggregate spell metrics across donors rather than trying to reduce
+  spells to independent daily counts inside the current kernel.
 
 Performance notes
 =================
@@ -104,7 +119,6 @@ Further large speedups are more likely to come from reducing Python,
 xarray and dask preparation overhead than from micro-optimising the Numba
 kernel. Promising areas:
 
-- avoid preparing percentile thresholds twice before the fast path;
 - load each spatial tile exactly once and keep unit-normalised values
   contiguous before entering the kernel;
 - profile seasonal cases separately, because output grouping changes the

--- a/doc/source/references/release_notes.rst
+++ b/doc/source/references/release_notes.rst
@@ -3,6 +3,18 @@
 #################
 
 ******
+7.1.7
+******
+
+date: 2026-07-29
+
+
+-  [perf] Defer percentile-threshold materialization until a bootstrap path actually needs the threshold field, reducing setup overhead for dask-backed day-of-year percentile count indices.
+-  [fix] Keep percentile bootstrap cases using ``threshold_min_value`` on the exact safe tiled path after Kraken validation showed the experimental fast path was not field-identical on real precipitation data.
+-  [fix] Keep ``cftime`` percentile bootstrap cases on the exact safe tiled path after Kraken validation found a remaining one-cell mismatch in the experimental fast path.
+-  [doc] Add maintainer notes for bootstrap architecture, readable implementation boundaries and the validated fast-path support matrix.
+
+******
 7.1.6
 ******
 

--- a/src/icclim/__init__.py
+++ b/src/icclim/__init__.py
@@ -23,7 +23,7 @@ __all__ = [
     "indices",  # noqa: F405
 ]
 
-__version__ = "7.1.6"
+__version__ = "7.1.7"
 
 
 def __getattr__(name: str) -> Callable:

--- a/src/icclim/_core/climate_variable.py
+++ b/src/icclim/_core/climate_variable.py
@@ -378,12 +378,12 @@ def must_run_bootstrap(
         return False
     if bootstrap is False:
         return False
-    reference = threshold.value
     time_index = da.indexes.get("time")
     if time_index is None:
         return False
     study_years = np.unique(time_index.year)
-    ref_idx = da.sel(time=_get_ref_period_slice(reference)).indexes.get("time")
+    ref_slice = _get_ref_period_slice_from_percentile_threshold(threshold, da)
+    ref_idx = da.sel(time=ref_slice).indexes.get("time")
     if ref_idx is None:
         return False
     overlapping_years = np.unique(ref_idx.year)
@@ -473,6 +473,9 @@ def _build_threshold(
     else:
         res = climate_var_thresh
 
+    if isinstance(res, PercentileThreshold) and not res.is_ready:
+        res.set_prepare_context(original_data, conversion_unit)
+        return res
     if res.prepare is not None and not res.is_ready:
         res.prepare(original_data)
     res.unit = conversion_unit
@@ -501,3 +504,10 @@ def _get_ref_period_slice(da: DataArray) -> slice:
         return slice(*bds)
     time_length = len(da.time)
     return slice(*da.time[0 :: time_length - 1].dt.strftime("%Y-%m-%d").to_numpy())
+
+
+def _get_ref_period_slice_from_percentile_threshold(
+    threshold: PercentileThreshold,
+    study_data: DataArray,
+) -> slice:
+    return slice(*threshold.climatology_bounds(study_data))

--- a/src/icclim/_core/generic/bootstrap.py
+++ b/src/icclim/_core/generic/bootstrap.py
@@ -168,6 +168,7 @@ def _threshold_min_value_in_reference_units(
         return float(converted.magnitude)
     return float(converted)
 
+
 def _operator_code(operator: Operator | str) -> int:
     operand = operator.operand if isinstance(operator, Operator) else str(operator)
     return {">": 0, ">=": 1, "<": 2, "<=": 3}.get(operand, -1)
@@ -316,7 +317,9 @@ if njit is not None:
                 alpha,
                 beta,
             )
-            if not np.isnan(min_threshold) and (np.isnan(q_value) or q_value <= min_threshold):
+            if not np.isnan(min_threshold) and (
+                np.isnan(q_value) or q_value <= min_threshold
+            ):
                 q_value = min_threshold
             q[doy_i] = q_value
         return q

--- a/src/icclim/_core/generic/bootstrap.py
+++ b/src/icclim/_core/generic/bootstrap.py
@@ -27,10 +27,14 @@ def compute_doy_percentile_bootstrap_count(
     if not _can_compute_fast_bootstrap(study, threshold):
         return None
     loaded = study.load()
-    climatology_bounds = threshold.value.attrs["climatology_bounds"]
-    ref = loaded.sel(time=slice(*climatology_bounds))
-    study_time = pd.DatetimeIndex(loaded.time.values)
-    ref_time = pd.DatetimeIndex(ref.time.values)
+    climatology_bounds = threshold.climatology_bounds(loaded)
+    ref_raw = loaded.sel(time=slice(*climatology_bounds))
+    min_threshold = _threshold_min_value_in_reference_units(threshold, ref_raw)
+    ref_masked = ref_raw
+    if min_threshold is not None:
+        ref_masked = ref_raw.where(ref_raw >= min_threshold, np.nan)
+    study_time = loaded.indexes["time"]
+    ref_time = ref_raw.indexes["time"]
     ref_year_indices = _indices_by_year(ref_time)
     study_year_indices = _indices_by_year(study_time)
     ref_years = np.asarray(list(ref_year_indices), dtype=np.int64)
@@ -75,8 +79,18 @@ def compute_doy_percentile_bootstrap_count(
         loaded.sizes["time"],
         -1,
     )
-    flat_ref = np.asarray(ref.transpose("time", ...).data, dtype=np.float64).reshape(
-        ref.sizes["time"],
+    flat_ref_raw = np.asarray(
+        ref_raw.transpose("time", ...).data,
+        dtype=np.float64,
+    ).reshape(
+        ref_raw.sizes["time"],
+        -1,
+    )
+    flat_ref_masked = np.asarray(
+        ref_masked.transpose("time", ...).data,
+        dtype=np.float64,
+    ).reshape(
+        ref_masked.sizes["time"],
         -1,
     )
     sample_indices = _rolling_sample_index_matrix(
@@ -89,7 +103,8 @@ def compute_doy_percentile_bootstrap_count(
     )
     donor_aligned = _donor_alignment_matrix(ref_time, ref_year_indices)
     result = _bootstrap_count_kernel(
-        flat_ref,
+        flat_ref_raw,
+        flat_ref_masked,
         flat,
         sample_indices,
         index_year,
@@ -102,10 +117,11 @@ def compute_doy_percentile_bootstrap_count(
         year_max_doys,
         year_to_ref,
         study_time.dayofyear.to_numpy(dtype=np.int64),
-        float(threshold.value.coords["percentiles"].item()) / 100.0,
+        float(threshold.percentile_coord().item()) / 100.0,
         float(threshold.interpolation.alpha),
         float(threshold.interpolation.beta),
         _operator_code(threshold.operator),
+        np.nan if min_threshold is None else float(min_threshold),
     )
     data = result.reshape((len(output_group_labels), *loaded.shape[1:]))
     out = xr.DataArray(
@@ -120,25 +136,37 @@ def compute_doy_percentile_bootstrap_count(
     for coord in loaded.coords:
         if coord not in out.coords and "time" not in loaded[coord].dims:
             out = out.assign_coords({coord: loaded[coord]})
-    return out.assign_coords(percentiles=threshold.value.coords["percentiles"].item())
+    return out.assign_coords(percentiles=threshold.percentile_coord().item())
 
 
 def _can_compute_fast_bootstrap(
     study: DataArray,
     threshold: PercentileThreshold,
 ) -> bool:
-    try:
-        pd.DatetimeIndex(study.time.values)
-    except (TypeError, ValueError):
+    time_index = study.indexes.get("time")
+    if not isinstance(time_index, pd.DatetimeIndex):
         return False
     return (
         njit is not None
-        and threshold.threshold_min_value is None
         and not threshold.only_leap_years
-        and threshold.value.coords["percentiles"].size == 1
+        and threshold.percentile_coord().size == 1
+        and threshold.threshold_min_value is None
         and _operator_code(threshold.operator) >= 0
     )
 
+
+def _threshold_min_value_in_reference_units(
+    threshold: PercentileThreshold,
+    ref: DataArray,
+) -> float | None:
+    if threshold.threshold_min_value is None:
+        return None
+    from xclim.core.units import convert_units_to  # noqa: PLC0415
+
+    converted = convert_units_to(threshold.threshold_min_value, ref, context="hydro")
+    if hasattr(converted, "magnitude"):
+        return float(converted.magnitude)
+    return float(converted)
 
 def _operator_code(operator: Operator | str) -> int:
     operand = operator.operand if isinstance(operator, Operator) else str(operator)
@@ -156,7 +184,8 @@ if njit is not None:
 
     @njit(parallel=True, cache=True)
     def _bootstrap_count_kernel(
-        flat_ref,
+        flat_ref_raw,
+        flat_ref_masked,
         flat_study,
         sample_indices,
         index_year,
@@ -173,6 +202,7 @@ if njit is not None:
         alpha,
         beta,
         op_code,
+        min_threshold,
     ):
         n_years = len(year_to_ref)
         n_groups = len(study_starts)
@@ -189,7 +219,7 @@ if njit is not None:
             group_stop = year_group_stops[year_i]
             if target_ref_i < 0:
                 q = _quantiles_for_cell(
-                    flat_ref,
+                    flat_ref_masked,
                     sample_indices,
                     index_year,
                     index_pos,
@@ -201,6 +231,7 @@ if njit is not None:
                     quantile,
                     alpha,
                     beta,
+                    min_threshold,
                 )
                 for group_i in range(group_start, group_stop):
                     out[group_i, cell] = _count_exceedances(
@@ -221,7 +252,7 @@ if njit is not None:
                     if donor_i == target_ref_i:
                         continue
                     q = _quantiles_for_cell(
-                        flat_ref,
+                        flat_ref_raw,
                         sample_indices,
                         index_year,
                         index_pos,
@@ -233,6 +264,7 @@ if njit is not None:
                         quantile,
                         alpha,
                         beta,
+                        min_threshold,
                     )
                     for group_i in range(group_start, group_stop):
                         out[group_i, cell] += _count_exceedances(
@@ -264,11 +296,12 @@ if njit is not None:
         quantile,
         alpha,
         beta,
+        min_threshold,
     ):
         q = np.empty(365, dtype=np.float64)
         buf = np.empty(max_samples, dtype=np.float64)
         for doy_i in range(365):
-            q[doy_i] = _quantile_for_doy_cell(
+            q_value = _quantile_for_doy_cell(
                 flat_ref,
                 sample_indices,
                 index_year,
@@ -283,6 +316,9 @@ if njit is not None:
                 alpha,
                 beta,
             )
+            if not np.isnan(min_threshold) and (np.isnan(q_value) or q_value <= min_threshold):
+                q_value = min_threshold
+            q[doy_i] = q_value
         return q
 
     @njit(cache=True)

--- a/src/icclim/_core/generic/functions.py
+++ b/src/icclim/_core/generic/functions.py
@@ -1247,8 +1247,8 @@ def _compute_exceedance(
 ) -> DataArray:
     exceedances = threshold.compute(study, freq=freq, bootstrap=bootstrap)
     if bootstrap:
-        climatology_bounds = getattr(threshold.value, "attrs", {}).get(
-            "climatology_bounds", None
+        climatology_bounds = getattr(threshold, "climatology_bounds", lambda *_: None)(
+            study
         )
         if climatology_bounds is not None:
             exceedances.attrs[REFERENCE_PERIOD_ID] = climatology_bounds
@@ -1463,7 +1463,7 @@ def _estimate_bootstrap_working_bytes_per_cell(
     threshold: PercentileThreshold,
     resample_freq: Frequency,
 ) -> int:
-    clim = threshold.value.attrs["climatology_bounds"]
+    clim = threshold.climatology_bounds(study)
     overlap_da = study.sel(time=slice(*clim))
     overlap_groups = overlap_da.resample(
         time=_get_bootstrap_freq(resample_freq.pandas_freq)
@@ -1542,6 +1542,15 @@ def _slice_threshold_for_tile(
     tile_indexers: dict[str, slice],
 ) -> PercentileThreshold:
     sliced = copy(threshold)
+    if not threshold.is_ready:
+        prepare_source = getattr(threshold, "_prepare_source_data", None)
+        prepare_unit = getattr(threshold, "_prepare_output_unit", None)
+        if prepare_source is not None:
+            sliced.set_prepare_context(
+                prepare_source.isel(tile_indexers),
+                prepare_unit,
+            )
+        return sliced
     value = threshold.value
     value_indexers = {
         dim: indexer for dim, indexer in tile_indexers.items() if dim in value.dims

--- a/src/icclim/_core/generic/threshold/percentile.py
+++ b/src/icclim/_core/generic/threshold/percentile.py
@@ -82,6 +82,8 @@ class PercentileThreshold(Threshold):
 
     _prepared_value: PercentileDataArray
     _initial_unit: str | None
+    _prepare_output_unit: str | None
+    _prepare_source_data: DataArray | None
 
     @property  # type: ignore[override]
     def unit(self) -> str | None:
@@ -90,7 +92,7 @@ class PercentileThreshold(Threshold):
         if self.is_ready:
             res = self._prepared_value.attrs.get(UNITS_KEY, None)
         else:
-            res = self._initial_unit
+            res = self._prepare_output_unit or self._initial_unit
         return res.replace("°C", "degC") if res else None
 
     @unit.setter
@@ -179,6 +181,8 @@ class PercentileThreshold(Threshold):
         self.doy_window_width = doy_window_width
         self.only_leap_years = only_leap_years
         self.interpolation = QuantileInterpolationRegistry.lookup(interpolation)
+        self._prepare_output_unit = None
+        self._prepare_source_data = None
         self.unit = unit
         self.is_doy_per_threshold = is_doy_per_threshold
 
@@ -224,6 +228,62 @@ class PercentileThreshold(Threshold):
             raise NotImplementedError(msg)
         self._prepared_value = prepared_data.chunk("auto")
         self.is_ready = True
+        if self._prepare_output_unit is not None:
+            self.unit = self._prepare_output_unit
+
+    def set_prepare_context(
+        self,
+        studied_data: DataArray,
+        conversion_unit: str | None,
+    ) -> None:
+        self._prepare_source_data = studied_data
+        self._prepare_output_unit = conversion_unit
+
+    def ensure_ready(self, comparison_data: DataArray | None = None) -> None:
+        if self.is_ready:
+            return
+        source = (
+            self._prepare_source_data
+            if self._prepare_source_data is not None
+            else comparison_data
+        )
+        if source is None:
+            msg = "PercentileThreshold cannot be prepared without source data."
+            raise RuntimeError(msg)
+        self.prepare(source)
+
+    def climatology_bounds(self, comparison_data: DataArray | None = None) -> list[str]:
+        if self.is_ready:
+            return self.value.attrs["climatology_bounds"]
+        source = (
+            self._prepare_source_data
+            if self._prepare_source_data is not None
+            else comparison_data
+        )
+        if source is None:
+            msg = "PercentileThreshold cannot infer climatology bounds without source data."
+            raise RuntimeError(msg)
+        reference = build_reference_da(
+            source,
+            cast("Sequence[str]", self.reference_period),
+            self.only_leap_years,
+            self.threshold_min_value,
+        )
+        from xclim.core.calendar import build_climatology_bounds  # noqa: PLC0415
+
+        return build_climatology_bounds(reference)
+
+    def percentile_coord(self) -> DataArray:
+        if self.is_ready:
+            return self.value.coords["percentiles"]
+        if self.initial_value is None:
+            msg = "PercentileThreshold must have a percentile value."
+            raise RuntimeError(msg)
+        return xr.DataArray(
+            self.initial_value,
+            dims=["percentiles"],
+            coords={"percentiles": self.initial_value},
+        )
 
     def __eq__(self, other: object) -> bool:
         """
@@ -301,9 +361,9 @@ class PercentileThreshold(Threshold):
         """
         src_freq = kwargs.get("src_freq")
         must_run_bootstrap = kwargs.get("must_run_bootstrap", False)
-        per_coord = self.value.coords["percentiles"]
+        per_coord = self.percentile_coord()
         templates = self._get_metadata_templates(per_coord)
-        climatology_bounds: list[str] = self.value.attrs.get("climatology_bounds", [])
+        climatology_bounds = self.climatology_bounds()
         conf: PercentileTemplateConfig = {
             "climatology_bounds": climatology_bounds,
             "doy_window_width": self.doy_window_width,
@@ -374,12 +434,15 @@ class PercentileThreshold(Threshold):
                 cast("str", kwargs.get("freq", "")),
                 bootstrap=kwargs.get("bootstrap", False),
             )
-        msg = (
-            "This PercentileThreshold is not ready. You must first call `.prepare`"
-            " with a `studied_data` parameter in order to prepare the threshold"
-            " for computation."
+        self.ensure_ready(comparison_data)
+        return self._per_compute(
+            comparison_data,
+            self.value,
+            op_func,
+            self.is_doy_per_threshold,
+            cast("str", kwargs.get("freq", "")),
+            bootstrap=kwargs.get("bootstrap", False),
         )
-        raise RuntimeError(msg)
 
     def _get_metadata_templates(self, per_coord: DataArray) -> ThresholdMetadata:
         if self.is_doy_per_threshold:

--- a/src/icclim/main.py
+++ b/src/icclim/main.py
@@ -1073,7 +1073,10 @@ def _format_thresholds_for_export(climate_vars: list[ClimateVariable]) -> Datase
 
 
 def _format_threshold(cf_var: ClimateVariable) -> DataArray | None:
-    if cf_var.threshold is not None and cf_var.threshold.value is not None:
+    if cf_var.threshold is not None:
+        ensure_ready = getattr(cf_var.threshold, "ensure_ready", None)
+        if ensure_ready is not None:
+            ensure_ready(cf_var.studied_data)
         val = cf_var.threshold.value
         if isinstance(val, xr.DataArray):
             return val.rename(cf_var.name + "_thresholds").reindex()  # type: ignore[return-value]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -866,6 +866,78 @@ class TestIntegration:
         assert profile["bootstrap_fast_tile_count"] == 4
         xr.testing.assert_allclose(default.TX90p, legacy.TX90p)
 
+    def test_count_occurrences__dask_wet_day_bootstrap_falls_back_to_safe_tiled_path(
+        self,
+        monkeypatch,
+    ) -> None:
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS", "1")
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_FAST_TILE_CELLS", "1")
+        time = pd.date_range("2042-01-01", periods=365 * 5 + 1, freq="D")
+        pr = xr.DataArray(
+            np.full((len(time), 2, 2), 0.2, dtype=float),
+            dims=["time", "lat", "lon"],
+            coords={"time": time, "lat": [0, 1], "lon": [0, 1]},
+            attrs={UNITS_KEY: "mm/day"},
+            name="pr",
+        )
+        pr[5:10] = 20.0
+        pr[370:375] = 2.0
+        pr[735:740] = 5.0
+        pr[1100:1105] = 8.0
+        pr = pr.chunk({"time": 365, "lat": 1, "lon": 1})
+        common_kwargs = {
+            "in_files": pr,
+            "var_name": "pr",
+            "threshold": build_threshold(
+                "> 90 doy_per",
+                threshold_min_value="1 mm/day",
+                reference_period=("2042-01-01", "2043-12-31"),
+            ),
+            "time_range": ("2042-01-01", "2045-12-31"),
+            "out_file": self.OUTPUT_FILE,
+            "slice_mode": "year",
+        }
+
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_MODE", "default")
+        legacy = icclim.count_occurrences(**common_kwargs).compute()
+        monkeypatch.delenv("ICCLIM_BOOTSTRAP_MODE")
+        generic_functions.reset_bootstrap_profile()
+
+        default = icclim.count_occurrences(**common_kwargs)
+        profile = generic_functions.get_bootstrap_profile()
+
+        assert not hasattr(default.count_occurrences.data, "__dask_graph__")
+        assert "bootstrap_fast_tile_count" not in profile
+        assert profile["bootstrap_safe_tile_count"] == 4
+        xr.testing.assert_allclose(default.count_occurrences, legacy.count_occurrences)
+
+    def test_count_occurrences__fast_bootstrap_defers_threshold_materialization(
+        self,
+        monkeypatch,
+    ) -> None:
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS", "1")
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_FAST_TILE_CELLS", "1")
+        tas = stub_tas(tas_value=27 + K2C, lat_length=2, lon_length=2)
+        tas[5:10] = 0
+        tas = tas.chunk({"time": 365, "lat": 1, "lon": 1})
+        threshold = build_threshold(
+            "> 90 doy_per",
+            doy_window_width=1,
+            reference_period=("2042-01-01", "2043-12-31"),
+        )
+
+        res = icclim.count_occurrences(
+            in_files=tas,
+            var_name="tas",
+            threshold=threshold,
+            time_range=("2042-01-01", "2045-12-31"),
+            out_file=self.OUTPUT_FILE,
+            slice_mode="year",
+        )
+
+        assert not threshold.is_ready
+        assert not hasattr(res.count_occurrences.data, "__dask_graph__")
+
     @pytest.mark.parametrize("slice_mode", ["JJA", "ONDJFM"])
     def test_index_tx90p__dask_bootstrap_uses_fast_tiled_seasonal_path(
         self,
@@ -895,6 +967,35 @@ class TestIntegration:
         profile = generic_functions.get_bootstrap_profile()
 
         assert profile["bootstrap_fast_tile_count"] == 4
+        xr.testing.assert_allclose(default.TX90p.load(), eager.TX90p)
+
+    def test_index_tx90p__cftime_dask_bootstrap_falls_back_to_safe_tiled_path(
+        self,
+        monkeypatch,
+    ) -> None:
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS", "1")
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_FAST_TILE_CELLS", "1")
+        tas = stub_tas(tas_value=27 + K2C, use_cftime=True, lat_length=2, lon_length=2)
+        tas[5:10] = 0
+        tas = tas.chunk({"time": 365, "lat": 1, "lon": 1})
+        common_kwargs = {
+            "index_name": "tx90p",
+            "in_files": tas,
+            "doy_window_width": 1,
+            "time_range": ("2042-01-01", "2045-12-31"),
+            "base_period_time_range": ("2042-01-01", "2043-12-31"),
+            "out_file": self.OUTPUT_FILE,
+            "slice_mode": "year",
+        }
+
+        eager = icclim.index(**{**common_kwargs, "in_files": tas.compute()}).compute()
+        generic_functions.reset_bootstrap_profile()
+
+        default = icclim.index(**common_kwargs)
+        profile = generic_functions.get_bootstrap_profile()
+
+        assert "bootstrap_fast_tile_count" not in profile
+        assert profile["bootstrap_safe_tile_count"] == 4
         xr.testing.assert_allclose(default.TX90p.load(), eager.TX90p)
 
     def test_index_tx90p__safe_bootstrap_uses_memory_budget(self, monkeypatch) -> None:


### PR DESCRIPTION
## Summary

This PR stabilizes the percentile-bootstrap release boundary before the larger bootstrap refactor.

It ships three things:

- defers percentile-threshold materialization until a bootstrap path actually needs the threshold field;
- keeps unsupported-but-needed bootstrap cases on the exact safe tiled path;
- documents the validated support boundary and the follow-up architecture.

## What changes

- defer preparation of `PercentileThreshold` objects until the fast path, safe fallback, or threshold export actually needs the threshold field;
- keep `threshold_min_value` bootstrap cases such as wet-day precipitation percentiles on the safe tiled path;
- keep `cftime` bootstrap cases on the safe tiled path;
- update bootstrap maintainer notes with the validated support matrix;
- add a separate bootstrap architecture note focused on reusable primitives, readable code structure, and FAIR4RS-oriented maintainability.

## Why this split

On Wednesday, July 29, 2026, Kraken validation showed that the larger architecture direction is good, but two experimental fast-path extensions were not yet safe to ship:

- `threshold_min_value` fast bootstrap was materially faster but not field-identical on real precipitation data;
- Gregorian-like `cftime` fast bootstrap still had a one-cell mismatch on real data.

So this PR keeps the validated performance work while routing those two cases back to the exact safe reference path.

## Kraken validation

Real-data validation used ACCESS-CM2 inputs on Kraken.

Confirmed exact / release-safe outcomes:

- lazy-threshold monthly `TG90p`: exact agreement with baseline;
- wet-day fallback reruns:
  - `wetday_pr90p_yearly`: `changed_gt_1e-9 = 0`, `max_abs_diff = 0.0`
  - `combined_cftime_wetday_yearly`: `changed_gt_1e-9 = 0`, `max_abs_diff = 0.0`

Confirmed deferred outcome:

- `cftime` fast path is intentionally not shipped in this PR because Kraken found one differing cell on July 29, 2026.

## Tests

Ran locally:

- `pytest -q tests/test_main.py -k 'bootstrap'`
  - `16 passed`

Also added/updated regressions covering:

- wet-day bootstrap safe fallback routing;
- lazy threshold materialization for fast bootstrap;
- `cftime` safe fallback routing;
- existing fast monthly / seasonal count paths;
- safe-path memory-budget and retry behavior.

## Deferred to the next phase

- bootstrap capability classifier;
- reusable threshold engine and reducer split;
- exact fast support for `threshold_min_value` cases;
- exact fast support for `cftime` cases;
- spell / run-length and amount / fraction bootstrap families.
