### PR TITLE
Add bootstrap family routing and validation matrix

### DIFF
--- a/doc/source/dev/add_climate_index.rst
+++ b/doc/source/dev/add_climate_index.rst
@@ -236,6 +236,9 @@ follow this path:
    - one query string such as ``"> 30 degC"``;
    - two thresholds plus a logical link;
    - explicit components such as ``operator``, ``value`` and ``unit``.
+   Shared percentile options such as ``reference_period`` are now
+   propagated to bounded-threshold children when the child threshold is a
+   percentile query string.
 3. The factory turns that specification into one threshold family:
    - :class:`~icclim._core.generic.threshold.basic.BasicThreshold`
    - :class:`~icclim._core.generic.threshold.percentile.PercentileThreshold`

--- a/doc/source/dev/add_climate_index.rst
+++ b/doc/source/dev/add_climate_index.rst
@@ -134,7 +134,7 @@ Instead:
 1. identify the bootstrap family;
 2. route the family explicitly in
    ``src/icclim/_core/generic/bootstrap_capability.py``;
-3. keep the exact tiled path as the semantic oracle;
+3. keep the exact tiled path as the reference bootstrap implementation;
 4. only enable the optimized path after exact validation.
 
 For percentile-bootstrap work, read the bootstrap architecture note
@@ -325,7 +325,7 @@ Every new climate-index contribution should answer these tests:
 2. If it uses thresholds, are unit conversions correct?
 3. If it uses bootstrap, does routing pick the expected execution path?
 4. If bootstrap semantics changed, is the exact tiled path still the
-   oracle?
+   reference bootstrap implementation?
 5. If the change is performance-related, was it validated on real data
    rather than only synthetic arrays?
 

--- a/doc/source/dev/bootstrap_architecture.rst
+++ b/doc/source/dev/bootstrap_architecture.rst
@@ -177,6 +177,17 @@ boolean. For example, it should carry:
   ``optimized_bootstrap``, ``exact_tiled_bootstrap``, ``unsupported``, ``not_required``;
 - a short reason code for logs, tests and debugging.
 
+As of July 30, 2026, this classifier exists in
+``src/icclim/_core/generic/bootstrap_capability.py`` for the current
+generic indicator families:
+
+- day-of-year percentile count;
+- filtered day-of-year percentile count;
+- value aggregates such as ``fraction_of_total``;
+- spell reducers such as ``sum_of_spell_lengths``;
+- bounded percentile compositions that currently stay on the reference
+  bootstrap path.
+
 Reusable bootstrap primitives
 =============================
 

--- a/doc/source/dev/bootstrap_architecture.rst
+++ b/doc/source/dev/bootstrap_architecture.rst
@@ -18,7 +18,7 @@ Design goals
 
 Bootstrap code should be:
 
-- exact with respect to the safe reference implementation;
+- exact with respect to the safe reference bootstrap implementation;
 - explicit about what is supported, what falls back, and what is still
   unsupported;
 - organized around a small number of reusable calculations rather than a
@@ -42,7 +42,7 @@ Use the following rules when extending bootstrap support:
 
 - Separate threshold generation from result aggregation.
 - Classify support by mathematical family, not by index short name.
-- Keep the safe tiled path as the semantic oracle for every new optimized
+- Keep the safe tiled path as the reference bootstrap implementation for every new optimized
   implementation.
 - Prefer a small number of well-named helpers over large mixed-purpose
   functions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,6 +187,7 @@ ignore = [
   "PTH207", # Glob patterns match the input datasets already staged on Kraken.
   "PLC0415", # Repo-local imports are resolved after injecting the checked-out src path.
   "PLR0911", # Workload dispatch uses one explicit return per case.
+  "PLR0912", # Workload dispatch keeps one readable branch per validation case.
   "S110", # Warmup failures are intentionally ignored in the benchmarking harness.
   "S603", # Git subprocess calls use fixed local commands in the harness.
   "S607", # The harness intentionally relies on the environment's git executable.

--- a/src/icclim/_core/climate_variable.py
+++ b/src/icclim/_core/climate_variable.py
@@ -383,19 +383,21 @@ def must_run_bootstrap(
     # TODO @bzah: Don't run bootstrap when not on extreme percentile
     #       (run only below 20? 10? and above 80? 90?)
     # https://github.com/cerfacs-globc/icclim/issues/289
-    if (
-        threshold is None
-        or not isinstance(threshold, PercentileThreshold)
-        or (
-            isinstance(threshold, PercentileThreshold)
-            and not threshold.is_doy_per_threshold
+    if threshold is None:
+        return False
+    from icclim._core.generic.threshold.bounded import BoundedThreshold  # noqa: PLC0415
+
+    if isinstance(threshold, BoundedThreshold):
+        child_thresholds = (
+            threshold.left_threshold,
+            threshold.right_threshold,
         )
-    ):
+        return any(
+            must_run_bootstrap(da, child, bootstrap) for child in child_thresholds
+        )
+    if not _is_day_of_year_percentile_threshold(threshold):
         return False
-    if bootstrap is False:
-        return False
-    time_index = da.indexes.get("time")
-    if time_index is None:
+    if bootstrap is False or (time_index := da.indexes.get("time")) is None:
         return False
     study_years = np.unique(time_index.year)
     ref_slice = _get_ref_period_slice_from_percentile_threshold(threshold, da)
@@ -404,6 +406,12 @@ def must_run_bootstrap(
         return False
     overlapping_years = np.unique(ref_idx.year)
     return 1 < len(overlapping_years) < len(study_years)
+
+
+def _is_day_of_year_percentile_threshold(
+    threshold: Threshold,
+) -> bool:
+    return isinstance(threshold, PercentileThreshold) and threshold.is_doy_per_threshold
 
 
 def _standard_index_needs_ref(
@@ -481,6 +489,8 @@ def _prepare_climate_variable_threshold(
     original_data: DataArray,
     conversion_unit: str,
 ) -> Threshold:
+    from icclim._core.generic.threshold.bounded import BoundedThreshold  # noqa: PLC0415
+
     res: Threshold
     if isinstance(climate_var_thresh, str):
         res = build_threshold(climate_var_thresh)
@@ -489,6 +499,18 @@ def _prepare_climate_variable_threshold(
     else:
         res = climate_var_thresh
 
+    if isinstance(res, BoundedThreshold):
+        res.left_threshold = _prepare_climate_variable_threshold(
+            res.left_threshold,
+            original_data,
+            conversion_unit,
+        )
+        res.right_threshold = _prepare_climate_variable_threshold(
+            res.right_threshold,
+            original_data,
+            conversion_unit,
+        )
+        return res
     if isinstance(res, PercentileThreshold) and not res.is_ready:
         res.set_prepare_context(original_data, conversion_unit)
         return res

--- a/src/icclim/_core/generic/bootstrap_capability.py
+++ b/src/icclim/_core/generic/bootstrap_capability.py
@@ -51,6 +51,39 @@ class BootstrapComputationFamily(StrEnum):
     NOT_APPLICABLE = "not_applicable"
     DAY_OF_YEAR_PERCENTILE_COUNT = "day_of_year_percentile_count"
     FILTERED_DAY_OF_YEAR_PERCENTILE_COUNT = "filtered_day_of_year_percentile_count"
+    DAY_OF_YEAR_PERCENTILE_VALUE_AGGREGATE = "day_of_year_percentile_value_aggregate"
+    FILTERED_DAY_OF_YEAR_PERCENTILE_VALUE_AGGREGATE = (
+        "filtered_day_of_year_percentile_value_aggregate"
+    )
+    DAY_OF_YEAR_PERCENTILE_SPELL = "day_of_year_percentile_spell"
+    FILTERED_DAY_OF_YEAR_PERCENTILE_SPELL = "filtered_day_of_year_percentile_spell"
+    DAY_OF_YEAR_PERCENTILE_COMPOUND = "day_of_year_percentile_compound"
+    FILTERED_DAY_OF_YEAR_PERCENTILE_COMPOUND = (
+        "filtered_day_of_year_percentile_compound"
+    )
+
+
+class BootstrapReducerKind(StrEnum):
+    """Reducer families that affect bootstrap routing."""
+
+    NOT_APPLICABLE = "not_applicable"
+    COUNT = "count"
+    VALUE_AGGREGATE = "value_aggregate"
+    SPELL = "spell"
+
+
+@dataclass(frozen=True)
+class BootstrapThresholdInventory:
+    """Summarize bootstrap-relevant threshold facts for one computation."""
+
+    required_percentile_thresholds: tuple[PercentileThreshold, ...]
+    has_bounded_threshold: bool
+    has_filtered_percentile: bool
+    has_bootstrap_disabled_percentile: bool
+
+    @property
+    def bootstrap_required(self) -> bool:
+        return bool(self.required_percentile_thresholds)
 
 
 class BootstrapExecutionKind(StrEnum):
@@ -148,6 +181,49 @@ def _classify_required_count_bootstrap(
     )
 
 
+def classify_generic_indicator_bootstrap(
+    *,
+    indicator_name: str,
+    climate_vars: list[ClimateVariable],
+    resample_frequency: Frequency,
+    date_event: bool = False,
+) -> BootstrapCapability:
+    """Classify bootstrap routing for a generic indicator computation."""
+    inventory = _build_bootstrap_threshold_inventory(climate_vars)
+    if not inventory.bootstrap_required:
+        if inventory.has_bootstrap_disabled_percentile:
+            return _not_required("bootstrap_disabled_by_user")
+        return _not_required("bootstrap_not_required_for_indicator")
+
+    reducer_kind = _classify_bootstrap_reducer_kind(indicator_name)
+    if reducer_kind == BootstrapReducerKind.NOT_APPLICABLE:
+        return _not_required("indicator_has_no_bootstrap_family")
+
+    family = _classify_generic_bootstrap_family(
+        reducer_kind=reducer_kind,
+        inventory=inventory,
+    )
+    if _uses_specialized_count_routing(
+        reducer_kind=reducer_kind,
+        climate_vars=climate_vars,
+        date_event=date_event,
+        inventory=inventory,
+    ):
+        return classify_doy_percentile_count_bootstrap(
+            climate_var=climate_vars[0],
+            resample_frequency=resample_frequency,
+        )
+    return _reference_bootstrap_path(
+        family,
+        _reference_bootstrap_reason_code(
+            reducer_kind=reducer_kind,
+            climate_vars=climate_vars,
+            date_event=date_event,
+            inventory=inventory,
+        ),
+    )
+
+
 def is_optimized_doy_percentile_count_supported(
     study: DataArray,
     threshold_spec: PercentileThreshold,
@@ -180,6 +256,161 @@ def _classify_count_family(
     if threshold_spec.threshold_min_value is not None:
         return BootstrapComputationFamily.FILTERED_DAY_OF_YEAR_PERCENTILE_COUNT
     return BootstrapComputationFamily.DAY_OF_YEAR_PERCENTILE_COUNT
+
+
+def _classify_bootstrap_reducer_kind(
+    indicator_name: str,
+) -> BootstrapReducerKind:
+    if indicator_name == "count_occurrences":
+        return BootstrapReducerKind.COUNT
+    if indicator_name in {
+        "fraction_of_total",
+        "excess",
+        "deficit",
+        "maximum",
+        "minimum",
+        "average",
+        "sum",
+        "standard_deviation",
+        "max_of_rolling_sum",
+        "min_of_rolling_sum",
+        "max_of_rolling_average",
+        "min_of_rolling_average",
+    }:
+        return BootstrapReducerKind.VALUE_AGGREGATE
+    if indicator_name in {
+        "max_consecutive_occurrence",
+        "sum_of_spell_lengths",
+    }:
+        return BootstrapReducerKind.SPELL
+    return BootstrapReducerKind.NOT_APPLICABLE
+
+
+def _build_bootstrap_threshold_inventory(
+    climate_vars: list[ClimateVariable],
+) -> BootstrapThresholdInventory:
+    required_thresholds: list[PercentileThreshold] = []
+    has_bounded_threshold = False
+    has_filtered_percentile = False
+    has_bootstrap_disabled_percentile = False
+    for climate_var in climate_vars:
+        threshold_spec = climate_var.threshold
+        if threshold_spec is None:
+            continue
+        if isinstance(threshold_spec, BoundedThreshold):
+            has_bounded_threshold = True
+        for percentile_threshold in _iter_percentile_thresholds(threshold_spec):
+            if percentile_threshold.threshold_min_value is not None:
+                has_filtered_percentile = True
+            if must_run_bootstrap(
+                climate_var.studied_data,
+                percentile_threshold,
+                climate_var.bootstrap,
+            ):
+                required_thresholds.append(percentile_threshold)
+            elif climate_var.bootstrap is False and must_run_bootstrap(
+                climate_var.studied_data,
+                percentile_threshold,
+                bootstrap=None,
+            ):
+                has_bootstrap_disabled_percentile = True
+    return BootstrapThresholdInventory(
+        required_percentile_thresholds=tuple(required_thresholds),
+        has_bounded_threshold=has_bounded_threshold,
+        has_filtered_percentile=has_filtered_percentile,
+        has_bootstrap_disabled_percentile=has_bootstrap_disabled_percentile,
+    )
+
+
+def _iter_percentile_thresholds(
+    threshold_spec: Threshold,
+) -> tuple[PercentileThreshold, ...]:
+    if isinstance(threshold_spec, PercentileThreshold):
+        return (threshold_spec,)
+    if isinstance(threshold_spec, BoundedThreshold):
+        return (
+            *_iter_percentile_thresholds(threshold_spec.left_threshold),
+            *_iter_percentile_thresholds(threshold_spec.right_threshold),
+        )
+    return ()
+
+
+def _classify_generic_bootstrap_family(
+    *,
+    reducer_kind: BootstrapReducerKind,
+    inventory: BootstrapThresholdInventory,
+) -> BootstrapComputationFamily:
+    if inventory.has_bounded_threshold:
+        family_group = "compound"
+    elif reducer_kind == BootstrapReducerKind.COUNT:
+        family_group = "count"
+    elif reducer_kind == BootstrapReducerKind.VALUE_AGGREGATE:
+        family_group = "value_aggregate"
+    else:
+        family_group = "spell"
+    family_map = {
+        (False, "compound"): BootstrapComputationFamily.DAY_OF_YEAR_PERCENTILE_COMPOUND,
+        (
+            True,
+            "compound",
+        ): BootstrapComputationFamily.FILTERED_DAY_OF_YEAR_PERCENTILE_COMPOUND,
+        (False, "count"): BootstrapComputationFamily.DAY_OF_YEAR_PERCENTILE_COUNT,
+        (
+            True,
+            "count",
+        ): BootstrapComputationFamily.FILTERED_DAY_OF_YEAR_PERCENTILE_COUNT,
+        (
+            False,
+            "value_aggregate",
+        ): BootstrapComputationFamily.DAY_OF_YEAR_PERCENTILE_VALUE_AGGREGATE,
+        (
+            True,
+            "value_aggregate",
+        ): BootstrapComputationFamily.FILTERED_DAY_OF_YEAR_PERCENTILE_VALUE_AGGREGATE,
+        (False, "spell"): BootstrapComputationFamily.DAY_OF_YEAR_PERCENTILE_SPELL,
+        (
+            True,
+            "spell",
+        ): BootstrapComputationFamily.FILTERED_DAY_OF_YEAR_PERCENTILE_SPELL,
+    }
+    return family_map[(inventory.has_filtered_percentile, family_group)]
+
+
+def _uses_specialized_count_routing(
+    *,
+    reducer_kind: BootstrapReducerKind,
+    climate_vars: list[ClimateVariable],
+    date_event: bool,
+    inventory: BootstrapThresholdInventory,
+) -> bool:
+    if reducer_kind != BootstrapReducerKind.COUNT:
+        return False
+    if date_event or len(climate_vars) != 1 or inventory.has_bounded_threshold:
+        return False
+    threshold_spec = climate_vars[0].threshold
+    return isinstance(threshold_spec, PercentileThreshold) and bool(
+        inventory.required_percentile_thresholds
+    )
+
+
+def _reference_bootstrap_reason_code(
+    *,
+    reducer_kind: BootstrapReducerKind,
+    climate_vars: list[ClimateVariable],
+    date_event: bool,
+    inventory: BootstrapThresholdInventory,
+) -> str:
+    if inventory.has_bounded_threshold:
+        return "bounded_threshold_uses_reference_bootstrap_path"
+    if len(climate_vars) > 1:
+        return "multiple_climate_variables_use_reference_bootstrap_path"
+    if date_event:
+        return "date_event_uses_reference_bootstrap_path"
+    if reducer_kind == BootstrapReducerKind.VALUE_AGGREGATE:
+        return "value_aggregate_uses_reference_bootstrap_path"
+    if reducer_kind == BootstrapReducerKind.SPELL:
+        return "spell_uses_reference_bootstrap_path"
+    return "count_uses_reference_bootstrap_path"
 
 
 def _count_bootstrap_not_required_reason(

--- a/src/icclim/_core/generic/functions.py
+++ b/src/icclim/_core/generic/functions.py
@@ -50,6 +50,7 @@ from icclim._core.constants import (
 from icclim._core.generic.bootstrap_capability import (
     BootstrapExecutionKind,
     classify_doy_percentile_count_bootstrap,
+    classify_generic_indicator_bootstrap,
 )
 from icclim._core.input_parsing import PercentileDataArray
 from icclim._core.model.cf_calendar import CfCalendarRegistry
@@ -156,6 +157,12 @@ def count_occurrences(
     >>> int(result.count_occurrences.isel(time=0).values)
     365
     """
+    _note_generic_bootstrap_capability(
+        indicator_name="count_occurrences",
+        climate_vars=climate_vars,
+        resample_freq=resample_freq,
+        date_event=date_event,
+    )
     if len(climate_vars) == 1 and not date_event:
         safe_bootstrapped = _compute_safe_tiled_count_occurrences(
             climate_vars[0],
@@ -249,6 +256,11 @@ def max_consecutive_occurrence(
     >>> int(result.max_consecutive_occurrence.isel(time=0).values)
     365
     """
+    _note_generic_bootstrap_capability(
+        indicator_name="max_consecutive_occurrence",
+        climate_vars=climate_vars,
+        resample_freq=resample_freq,
+    )
     combined_exceedance_mask = _compute_combined_exceedance_mask(
         climate_vars,
         resample_freq.pandas_freq,
@@ -305,6 +317,11 @@ def sum_of_spell_lengths(
     DataArray
         The sum of the lengths of all spells in the data.
     """
+    _note_generic_bootstrap_capability(
+        indicator_name="sum_of_spell_lengths",
+        climate_vars=climate_vars,
+        resample_freq=resample_freq,
+    )
     combined_exceedance_mask = _compute_combined_exceedance_mask(
         climate_vars,
         resample_freq.pandas_freq,
@@ -448,6 +465,11 @@ def fraction_of_total(
     the units will be set to "%". Otherwise, the units will be set to the value of
     PART_OF_A_WHOLE_UNIT, which is 1.
     """
+    _note_generic_bootstrap_capability(
+        indicator_name="fraction_of_total",
+        climate_vars=climate_vars,
+        resample_freq=resample_freq,
+    )
     study, threshold = get_single_var(climate_vars)
     if threshold is None:
         msg = "No threshold found"
@@ -1269,6 +1291,33 @@ def _compute_exceedance_mask(
         if climatology_bounds is not None:
             exceedance_mask.attrs[REFERENCE_PERIOD_ID] = climatology_bounds
     return exceedance_mask
+
+
+def _note_generic_bootstrap_capability(
+    *,
+    indicator_name: str,
+    climate_vars: list[ClimateVariable],
+    resample_freq: Frequency,
+    date_event: bool = False,
+) -> None:
+    capability = classify_generic_indicator_bootstrap(
+        indicator_name=indicator_name,
+        climate_vars=climate_vars,
+        resample_frequency=resample_freq,
+        date_event=date_event,
+    )
+    _profile_bootstrap_note(
+        "bootstrap_execution_kind",
+        capability.execution_kind.value,
+    )
+    _profile_bootstrap_note(
+        "bootstrap_reason_code",
+        capability.reason_code,
+    )
+    _profile_bootstrap_note(
+        "bootstrap_family",
+        capability.family.value,
+    )
 
 
 def _compute_safe_tiled_count_occurrences(  # noqa: C901

--- a/src/icclim/threshold/factory.py
+++ b/src/icclim/threshold/factory.py
@@ -252,7 +252,15 @@ def _build_threshold_builder_input(
         and thresholds is not None
         and logical_link is not None
     ):
-        return _build_bounded_threshold_input(thresholds, logical_link)
+        return _build_bounded_threshold_input(
+            thresholds,
+            logical_link,
+            _shared_bounded_threshold_builder_kwargs(
+                threshold_min_value=threshold_min_value,
+                offset=offset,
+                **kwargs,
+            ),
+        )
     if operator is not None:
         return _build_threshold_input_from_components(
             operator=operator,
@@ -286,11 +294,17 @@ def _build_threshold_instance(
 def _build_bounded_threshold_input(
     thresholds: Sequence[Threshold | str],
     logical_link: LogicalLink | str,
+    shared_child_kwargs: ThresholdBuilderInput,
 ) -> ThresholdBuilderInput:
     acc: list[ThresholdBuilderInput | Threshold] = []
     for t in thresholds:
         if isinstance(t, str):
-            acc.append(_build_threshold_builder_input(t))
+            acc.append(
+                _build_threshold_builder_input(
+                    t,
+                    **_bounded_child_builder_kwargs(t, shared_child_kwargs),
+                )
+            )
         elif isinstance(t, Threshold):
             acc.append(t)
         else:
@@ -309,6 +323,37 @@ def _build_bounded_threshold_input(
         ),
         "logical_link": logical_link,
     }
+
+
+def _shared_bounded_threshold_builder_kwargs(
+    threshold_min_value: str | float | pint.Quantity | None = None,
+    offset: str | float | pint.Quantity | None = None,
+    **kwargs,
+) -> ThresholdBuilderInput:
+    shared_keys = {
+        "reference_period",
+        "doy_window_width",
+        "only_leap_years",
+        "interpolation",
+    }
+    shared_kwargs = {key: value for key, value in kwargs.items() if key in shared_keys}
+    if threshold_min_value is not None:
+        shared_kwargs["threshold_min_value"] = threshold_min_value
+    if offset is not None:
+        shared_kwargs["offset"] = offset
+    return cast("ThresholdBuilderInput", shared_kwargs)
+
+
+def _bounded_child_builder_kwargs(
+    threshold_query: str,
+    shared_child_kwargs: ThresholdBuilderInput,
+) -> ThresholdBuilderInput:
+    if (
+        DOY_PERCENTILE_UNIT in threshold_query
+        or PERIOD_PERCENTILE_UNIT in threshold_query
+    ):
+        return shared_child_kwargs
+    return {}
 
 
 def _build_threshold_input_from_query(

--- a/tests/test_bootstrap_capability.py
+++ b/tests/test_bootstrap_capability.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from icclim._core.climate_variable import ClimateVariable
+from icclim._core.climate_variable import ClimateVariable, must_run_bootstrap
 from icclim._core.generic.bootstrap_capability import (
     BootstrapComputationFamily,
     BootstrapExecutionKind,
     BootstrapThresholdKind,
     classify_doy_percentile_count_bootstrap,
+    classify_generic_indicator_bootstrap,
     classify_threshold_kind,
 )
 from icclim._core.model.standard_variable import StandardVariableRegistry
@@ -193,3 +194,85 @@ def test_bounded_threshold_is_not_routed_through_count_fast_path() -> None:
 
     assert decision.execution_kind == BootstrapExecutionKind.NOT_REQUIRED
     assert decision.reason_code == "threshold_is_compound"
+
+
+def test_generic_fraction_of_total_routes_to_reference_bootstrap() -> None:
+    pr = stub_tas(5.0).rename("pr")
+    pr.attrs["units"] = "mm/day"
+    pr = pr.chunk({"time": 365, "lat": 1, "lon": 1})
+    climate_var = _build_climate_variable(
+        pr,
+        {
+            "query": "> 90 doy_per",
+            "threshold_min_value": "1 mm/day",
+            "reference_period": ("2042-01-01", "2043-12-31"),
+        },
+    )
+
+    decision = classify_generic_indicator_bootstrap(
+        indicator_name="fraction_of_total",
+        climate_vars=[climate_var],
+        resample_frequency=FrequencyRegistry.YEAR,
+    )
+
+    assert (
+        decision.family
+        == BootstrapComputationFamily.FILTERED_DAY_OF_YEAR_PERCENTILE_VALUE_AGGREGATE
+    )
+    assert decision.execution_kind == BootstrapExecutionKind.REFERENCE_BOOTSTRAP
+    assert decision.reason_code == "value_aggregate_uses_reference_bootstrap_path"
+
+
+def test_generic_spell_routes_to_reference_bootstrap() -> None:
+    tas = stub_tas(27 + K2C).chunk({"time": 365, "lat": 1, "lon": 1})
+    climate_var = _build_climate_variable(
+        tas,
+        {
+            "query": "> 90 doy_per",
+            "doy_window_width": 1,
+            "reference_period": ("2042-01-01", "2043-12-31"),
+        },
+    )
+
+    decision = classify_generic_indicator_bootstrap(
+        indicator_name="sum_of_spell_lengths",
+        climate_vars=[climate_var],
+        resample_frequency=FrequencyRegistry.YEAR,
+    )
+
+    assert decision.family == BootstrapComputationFamily.DAY_OF_YEAR_PERCENTILE_SPELL
+    assert decision.execution_kind == BootstrapExecutionKind.REFERENCE_BOOTSTRAP
+    assert decision.reason_code == "spell_uses_reference_bootstrap_path"
+
+
+def test_bounded_threshold_bootstrap_routes_to_reference_path() -> None:
+    tas = stub_tas(27 + K2C).chunk({"time": 365, "lat": 1, "lon": 1})
+    climate_var = _build_climate_variable(
+        tas,
+        {
+            "thresholds": ["> 90 doy_per", "<= 30 degC"],
+            "logical_link": "and",
+            "reference_period": ("2042-01-01", "2043-12-31"),
+        },
+    )
+
+    decision = classify_generic_indicator_bootstrap(
+        indicator_name="count_occurrences",
+        climate_vars=[climate_var],
+        resample_frequency=FrequencyRegistry.YEAR,
+    )
+
+    assert decision.family == BootstrapComputationFamily.DAY_OF_YEAR_PERCENTILE_COMPOUND
+    assert decision.execution_kind == BootstrapExecutionKind.REFERENCE_BOOTSTRAP
+    assert decision.reason_code == "bounded_threshold_uses_reference_bootstrap_path"
+
+
+def test_bounded_threshold_recursively_requires_bootstrap() -> None:
+    tas = stub_tas(27 + K2C).chunk({"time": 365, "lat": 1, "lon": 1})
+    threshold = build_threshold(
+        thresholds=["> 90 doy_per", "<= 30 degC"],
+        logical_link="and",
+        reference_period=("2042-01-01", "2043-12-31"),
+    )
+
+    assert must_run_bootstrap(tas, threshold)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -939,6 +939,46 @@ class TestIntegration:
         assert profile["bootstrap_safe_tile_count"] == 4
         xr.testing.assert_allclose(default.count_occurrences, legacy.count_occurrences)
 
+    def test_count_occurrences__bounded_percentile_bootstrap_uses_reference_path(
+        self,
+        monkeypatch,
+    ) -> None:
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS", "1")
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_FAST_TILE_CELLS", "1")
+        tas = stub_tas(tas_value=27 + K2C, lat_length=2, lon_length=2)
+        tas[5:10] = 0
+        tas = tas.chunk({"time": 365, "lat": 1, "lon": 1})
+        common_kwargs = {
+            "in_files": tas,
+            "var_name": "tas",
+            "threshold": build_threshold(
+                thresholds=["> 90 doy_per", "<= 30 degC"],
+                logical_link="and",
+                reference_period=("2042-01-01", "2043-12-31"),
+            ),
+            "time_range": ("2042-01-01", "2045-12-31"),
+            "out_file": self.OUTPUT_FILE,
+            "slice_mode": "year",
+        }
+
+        eager = icclim.count_occurrences(
+            **{**common_kwargs, "in_files": tas.compute()}
+        ).compute()
+        generic_functions.reset_bootstrap_profile()
+
+        default = icclim.count_occurrences(**common_kwargs)
+        profile = generic_functions.get_bootstrap_profile()
+
+        assert profile["bootstrap_execution_kind"] == "reference_bootstrap"
+        assert (
+            profile["bootstrap_reason_code"]
+            == "bounded_threshold_uses_reference_bootstrap_path"
+        )
+        assert profile["bootstrap_family"] == "day_of_year_percentile_compound"
+        xr.testing.assert_allclose(
+            default.count_occurrences.load(), eager.count_occurrences
+        )
+
     def test_count_occurrences__optimized_bootstrap_defers_threshold_materialization(
         self,
         monkeypatch,

--- a/tests/test_threshold.py
+++ b/tests/test_threshold.py
@@ -128,6 +128,21 @@ def test_build_bounded_threshold__from_args() -> None:
     assert t3.right_threshold.initial_value == [12]
 
 
+def test_build_bounded_threshold__propagates_shared_percentile_kwargs() -> None:
+    threshold = build_threshold(
+        thresholds=["> 12 doy_per", "<= 30 degC"],
+        logical_link="and",
+        reference_period=("2042-01-01", "2043-12-31"),
+        doy_window_width=7,
+    )
+
+    assert isinstance(threshold, BoundedThreshold)
+    assert isinstance(threshold.left_threshold, PercentileThreshold)
+    assert threshold.left_threshold.reference_period == ("2042-01-01", "2043-12-31")
+    assert threshold.left_threshold.doy_window_width == 7
+    assert isinstance(threshold.right_threshold, BasicThreshold)
+
+
 def test_basic_threshold_eq() -> None:
     a = build_threshold(">10degC")
     b = build_threshold(">10degC")

--- a/tools/run_real_data_validation.py
+++ b/tools/run_real_data_validation.py
@@ -141,6 +141,48 @@ def _build_workload(icclim, workload: str) -> xr.Dataset:
             slice_mode="month",
             date_event=True,
         )
+    if workload == "generic_tas_bounded_count_yearly":
+        tas = _open_var(TAS_GLOB, "tas")
+        percentile_threshold = icclim.threshold.build_threshold(
+            "> 90 doy_per",
+            reference_period=BASE_PERIOD,
+        )
+        return icclim.count_occurrences(
+            in_files=tas,
+            var_name="tas",
+            threshold=icclim.threshold.build_threshold(
+                thresholds=[percentile_threshold, "<= 30 degC"],
+                logical_link="and",
+            ),
+            time_range=TIME_RANGE,
+            slice_mode="year",
+        )
+    if workload == "generic_pr_fraction_bootstrap_yearly":
+        pr = _open_var(PR_GLOB, "pr")
+        return icclim.fraction_of_total(
+            in_files=pr,
+            var_name="pr",
+            threshold=icclim.threshold.build_threshold(
+                "> 95 doy_per",
+                threshold_min_value="1 mm/day",
+                reference_period=BASE_PERIOD,
+            ),
+            time_range=TIME_RANGE,
+            slice_mode="year",
+        )
+    if workload == "generic_tas_spell_bootstrap_yearly":
+        tas = _open_var(TAS_GLOB, "tas")
+        return icclim.sum_of_spell_lengths(
+            in_files=tas,
+            var_name="tas",
+            threshold=icclim.threshold.build_threshold(
+                "> 90 doy_per",
+                reference_period=BASE_PERIOD,
+            ),
+            time_range=TIME_RANGE,
+            slice_mode="year",
+            min_spell_length=6,
+        )
     if workload == "tg90p_save_thresholds_monthly":
         tas = _open_var(TAS_GLOB, "tas")
         return icclim.index(

--- a/tools/run_real_data_validation.py
+++ b/tools/run_real_data_validation.py
@@ -126,7 +126,8 @@ def _build_workload(icclim, workload: str) -> xr.Dataset:
         )
     if workload == "generic_tas_count_date_event_monthly":
         # A smaller real-data subset keeps this generic date-event validation
-        # representative without turning the oracle run into an overnight job.
+        # representative without turning the trusted-baseline run into an
+        # overnight job.
         tas = _open_var(
             TAS_GLOB,
             "tas",
@@ -198,7 +199,7 @@ def _build_workload(icclim, workload: str) -> xr.Dataset:
         # Compound logical-link indices currently exercise xarray boolean
         # operations that behave differently on lazy arrays across versions.
         # Loading the subset keeps this as a real-data validation while making
-        # the oracle path executable.
+        # the trusted baseline executable on this workload.
         ds = _open_combined_dataset(eager=True)
         return icclim.index(
             index_name="CD",
@@ -210,8 +211,8 @@ def _build_workload(icclim, workload: str) -> xr.Dataset:
     if workload == "indices_mixed_yearly":
         ds = _open_combined_dataset(eager=True)
         # Keep the mixed multi-index validation on the tas+pr pair, but avoid
-        # compound logical-link indices here because the oracle release itself
-        # is currently blocked by an upstream xarray boolean-operation issue.
+        # compound logical-link indices here because the trusted baseline is
+        # currently blocked by an upstream xarray boolean-operation issue.
         return icclim.indices(
             index_group=["TG", "RR1", "PRCPTOT", "TG90p"],
             in_files=ds,

--- a/tools/run_real_data_validation.py
+++ b/tools/run_real_data_validation.py
@@ -143,14 +143,14 @@ def _build_workload(icclim, workload: str) -> xr.Dataset:
         )
     if workload == "generic_tas_bounded_count_yearly":
         tas = _open_var(TAS_GLOB, "tas")
-        percentile_threshold = icclim.threshold.build_threshold(
+        percentile_threshold = icclim.build_threshold(
             "> 90 doy_per",
             reference_period=BASE_PERIOD,
         )
         return icclim.count_occurrences(
             in_files=tas,
             var_name="tas",
-            threshold=icclim.threshold.build_threshold(
+            threshold=icclim.build_threshold(
                 thresholds=[percentile_threshold, "<= 30 degC"],
                 logical_link="and",
             ),
@@ -162,7 +162,7 @@ def _build_workload(icclim, workload: str) -> xr.Dataset:
         return icclim.fraction_of_total(
             in_files=pr,
             var_name="pr",
-            threshold=icclim.threshold.build_threshold(
+            threshold=icclim.build_threshold(
                 "> 95 doy_per",
                 threshold_min_value="1 mm/day",
                 reference_period=BASE_PERIOD,
@@ -175,7 +175,7 @@ def _build_workload(icclim, workload: str) -> xr.Dataset:
         return icclim.sum_of_spell_lengths(
             in_files=tas,
             var_name="tas",
-            threshold=icclim.threshold.build_threshold(
+            threshold=icclim.build_threshold(
                 "> 90 doy_per",
                 reference_period=BASE_PERIOD,
             ),

--- a/tools/summarize_real_data_validation.py
+++ b/tools/summarize_real_data_validation.py
@@ -1,0 +1,287 @@
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class RunSummary:
+    workload: str
+    label: str
+    duration_seconds: float
+    path: Path
+
+
+@dataclass(frozen=True)
+class ComparisonSummary:
+    current_label: str
+    baseline_label: str
+    workload: str
+    path: Path
+    all_data_vars_equal: bool
+    total_changed_cells: int
+    max_abs_diff: float
+
+
+def _parse_summary_file(path: Path) -> RunSummary:
+    payload = json.loads(path.read_text())
+    return RunSummary(
+        workload=payload["workload"],
+        label=payload["label"],
+        duration_seconds=float(payload["duration_seconds"]),
+        path=path,
+    )
+
+
+def _parse_compare_file(path: Path) -> ComparisonSummary:
+    payload = json.loads(path.read_text())
+    filename = path.name.removesuffix(".compare.json")
+    current_prefix = "current-vs-"
+    if filename.startswith(current_prefix):
+        remainder = filename.removeprefix(current_prefix)
+        if remainder.startswith("master-bounded-hotfix-"):
+            baseline_label = "master"
+            workload = remainder.removeprefix("master-bounded-hotfix-")
+        elif remainder.startswith("v717-bounded-hotfix-"):
+            baseline_label = "v717"
+            workload = remainder.removeprefix("v717-bounded-hotfix-")
+        elif remainder.startswith("master-"):
+            baseline_label = "master"
+            workload = remainder.removeprefix("master-")
+        elif remainder.startswith("v717-"):
+            baseline_label = "v717"
+            workload = remainder.removeprefix("v717-")
+        else:
+            msg = f"Unsupported compare filename: {path.name}"
+            raise ValueError(msg)
+        current_label = "current"
+    elif filename.startswith("master-vs-v717-"):
+        current_label = "master"
+        baseline_label = "v717"
+        workload = filename.removeprefix("master-vs-v717-")
+    else:
+        msg = f"Unsupported compare filename: {path.name}"
+        raise ValueError(msg)
+    data_var_results = payload.get("data_var_comparison", {})
+    all_equal = True
+    total_changed_cells = 0
+    max_abs_diff = 0.0
+    for result in data_var_results.values():
+        equal = bool(result.get("equal", False))
+        all_equal = all_equal and equal
+        total_changed_cells += int(result.get("changed_cells", 0))
+        max_abs_diff = max(max_abs_diff, float(result.get("max_abs_diff", 0.0) or 0.0))
+    return ComparisonSummary(
+        current_label=current_label,
+        baseline_label=baseline_label,
+        workload=workload,
+        path=path,
+        all_data_vars_equal=all_equal,
+        total_changed_cells=total_changed_cells,
+        max_abs_diff=max_abs_diff,
+    )
+
+
+def _load_run_summaries(result_dir: Path) -> dict[tuple[str, str], RunSummary]:
+    return {
+        (summary.label, summary.workload): summary
+        for summary in (
+            _parse_summary_file(path)
+            for path in sorted(result_dir.glob("*.summary.json"))
+        )
+    }
+
+
+def _load_compare_summaries(
+    result_dir: Path,
+) -> dict[tuple[str, str, str], ComparisonSummary]:
+    return {
+        (summary.current_label, summary.baseline_label, summary.workload): summary
+        for summary in (
+            _parse_compare_file(path)
+            for path in sorted(result_dir.glob("*.compare.json"))
+        )
+    }
+
+
+def _format_seconds(value: float | None) -> str:
+    if value is None:
+        return "pending"
+    return f"{value:.2f}"
+
+
+def _format_ratio(current: float | None, baseline: float | None) -> str:
+    if current is None or baseline is None or current == 0:
+        return "pending"
+    return f"{baseline / current:.2f}x"
+
+
+def _format_percent_change(current: float | None, baseline: float | None) -> str:
+    if current is None or baseline is None or baseline == 0:
+        return "pending"
+    change = ((current - baseline) / baseline) * 100
+    return f"{change:+.1f}%"
+
+
+def _format_validation_status(
+    comparison: ComparisonSummary | None,
+) -> tuple[str, str, str]:
+    if comparison is None:
+        return ("pending", "pending", "pending")
+    if comparison.all_data_vars_equal:
+        return ("exact", "0", "0.0")
+    return (
+        "differs",
+        str(comparison.total_changed_cells),
+        f"{comparison.max_abs_diff:g}",
+    )
+
+
+def _workload_notes(workload: str) -> str:
+    notes = {
+        "generic_tas_bounded_count_yearly": (
+            "bounded percentile count; raw older baselines need recursive-threshold"
+            " hotfix, and v7.1.7 also needs logical-link hotfix"
+        ),
+        "generic_pr_fraction_bootstrap_yearly": (
+            "filtered value aggregate; wet-day style threshold_min_value"
+        ),
+        "generic_tas_spell_bootstrap_yearly": (
+            "spell reducer; raw v7.1.7 differs from current and master"
+        ),
+        "generic_tas_count_date_event_monthly": "date_event count control path",
+    }
+    return notes.get(workload, "")
+
+
+def _historical_validation_note(
+    workload: str,
+    comparisons: dict[tuple[str, str, str], ComparisonSummary],
+) -> str:
+    current_vs_master = comparisons.get(("current", "master", workload))
+    current_vs_v717 = comparisons.get(("current", "v717", workload))
+    master_vs_v717 = comparisons.get(("master", "v717", workload))
+    if (
+        current_vs_master is not None
+        and current_vs_master.all_data_vars_equal
+        and current_vs_v717 is not None
+        and not current_vs_v717.all_data_vars_equal
+        and master_vs_v717 is not None
+        and not master_vs_v717.all_data_vars_equal
+    ):
+        return "historical master/v7.1.7 difference confirmed"
+    return ""
+
+
+def _build_validation_table(
+    workloads: list[str],
+    comparisons: dict[tuple[str, str, str], ComparisonSummary],
+) -> str:
+    lines = [
+        "| Workload | Current vs master | Changed cells | Max abs diff | Current vs v7.1.7 | Changed cells | Max abs diff | Notes |",
+        "| --- | --- | ---: | ---: | --- | ---: | ---: | --- |",
+    ]
+    for workload in workloads:
+        master_status = _format_validation_status(
+            comparisons.get(("current", "master", workload))
+        )
+        v717_status = _format_validation_status(
+            comparisons.get(("current", "v717", workload))
+        )
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    workload,
+                    master_status[0],
+                    master_status[1],
+                    master_status[2],
+                    v717_status[0],
+                    v717_status[1],
+                    v717_status[2],
+                    " ; ".join(
+                        part
+                        for part in [
+                            _workload_notes(workload),
+                            _historical_validation_note(workload, comparisons),
+                        ]
+                        if part
+                    ),
+                ]
+            )
+            + " |"
+        )
+    return "\n".join(lines)
+
+
+def _build_performance_table(
+    workloads: list[str],
+    runs: dict[tuple[str, str], RunSummary],
+) -> str:
+    lines = [
+        "| Workload | Current (s) | Master (s) | Delta vs master | Speedup vs master | v7.1.7 (s) | Delta vs v7.1.7 | Speedup vs v7.1.7 | Notes |",
+        "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |",
+    ]
+    for workload in workloads:
+        current = runs.get(("current", workload))
+        master = runs.get(("baseline-master", workload))
+        v717 = runs.get(("baseline717", workload))
+        if workload == "generic_tas_bounded_count_yearly":
+            master = runs.get(("baseline-master-bounded-hotfix", workload), master)
+            v717 = runs.get(("baseline717-bounded-hotfix", workload), v717)
+        current_s = current.duration_seconds if current is not None else None
+        master_s = master.duration_seconds if master is not None else None
+        v717_s = v717.duration_seconds if v717 is not None else None
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    workload,
+                    _format_seconds(current_s),
+                    _format_seconds(master_s),
+                    _format_percent_change(current_s, master_s),
+                    _format_ratio(current_s, master_s),
+                    _format_seconds(v717_s),
+                    _format_percent_change(current_s, v717_s),
+                    _format_ratio(current_s, v717_s),
+                    _workload_notes(workload),
+                ]
+            )
+            + " |"
+        )
+    return "\n".join(lines)
+
+
+def _build_summary_document(result_dir: Path, expected_workloads: list[str]) -> str:
+    runs = _load_run_summaries(result_dir)
+    comparisons = _load_compare_summaries(result_dir)
+    workloads = sorted({workload for _, workload in runs} | set(expected_workloads))
+    validation_table = _build_validation_table(workloads, comparisons)
+    performance_table = _build_performance_table(workloads, runs)
+    return (
+        "# Real-data bootstrap validation summary\n\n"
+        "## Validation\n\n"
+        f"{validation_table}\n\n"
+        "## Performance\n\n"
+        f"{performance_table}"
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--result-dir", required=True)
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--expected-workload", action="append", default=[])
+    args = parser.parse_args()
+
+    result_dir = Path(args.result_dir)
+    out = Path(args.out)
+    summary = _build_summary_document(result_dir, args.expected_workload)
+    out.write_text(summary)
+    print(summary)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

This PR advances bootstrap support before any new optimization work by making generic bootstrap routing explicit, improving bounded-threshold bootstrap preparation, and adding real-data validation and performance diagnostics for the newly covered families.

Main changes:
- classify generic bootstrap computations by family instead of treating bootstrap as count-only routing
- recursively prepare bounded percentile thresholds so bootstrap and metadata work correctly for compound thresholds
- propagate shared percentile build arguments to bounded percentile children
- record generic bootstrap execution kind, reason code, and family in the bootstrap profile
- extend the Kraken real-data validation harness for bounded count, filtered value aggregate, spell, and date-event workloads
- add a reusable Markdown summary tool for validation and performance diagnostics

## Bootstrap scope in this PR

This PR does **not** introduce a new optimized bootstrap kernel beyond the existing count-path work.

Instead, it establishes the next-step foundation:
- explicit family classification
- readable routing for generic indicators
- broader real-data validation coverage
- performance baselines before future optimization work

Families covered by the new validation matrix:
- bounded percentile count
- filtered percentile value aggregate
- percentile spell reducer
- date_event count control path

## Kraken validation

Validated on real Kraken data on **Thursday, July 30, 2026**.

Exact against `master`:
- `generic_pr_fraction_bootstrap_yearly`
- `generic_tas_bounded_count_yearly` against the minimal hotfix trusted baseline
- `generic_tas_spell_bootstrap_yearly`
- `generic_tas_count_date_event_monthly`

Exact against `v7.1.7`:
- `generic_pr_fraction_bootstrap_yearly`
- `generic_tas_bounded_count_yearly` against the minimal `v7.1.7` hotfix trusted baseline
- `generic_tas_count_date_event_monthly`

Historical difference confirmed, not introduced by this branch:
- `generic_tas_spell_bootstrap_yearly`
  - `current vs master`: exact
  - `current vs v7.1.7`: differs
  - `master vs v7.1.7`: same difference

## Kraken performance summary

Performance is effectively identical before optimization work:

| Workload | Current (s) | Master (s) | Delta vs master | v7.1.7 (s) | Delta vs v7.1.7 |
| --- | ---: | ---: | ---: | ---: | ---: |
| `generic_pr_fraction_bootstrap_yearly` | 91.43 | 90.25 | +1.3% | 90.55 | +1.0% |
| `generic_tas_bounded_count_yearly` | 109.72 | 109.99 | -0.3% | 107.89 | +1.7% |
| `generic_tas_count_date_event_monthly` | 4494.81 | 4491.93 | +0.1% | 4473.42 | +0.5% |
| `generic_tas_spell_bootstrap_yearly` | 108.02 | 110.65 | -2.4% | 107.27 | +0.7% |

## Notes on trusted-baseline hotfixes

Two older trusted-baseline limitations had to be isolated so the validation stayed scientifically meaningful:
- bounded percentile count on older baselines needed recursive bounded-threshold preparation
- raw `v7.1.7` bounded logical-link validation also needed the older logical-link boolean hotfix

These hotfixes were used only to make the older trusted baseline executable for comparison; they are not new behavioral regressions from this branch.

## Local verification

- `pre-commit run --files pyproject.toml doc/source/dev/add_climate_index.rst doc/source/dev/bootstrap_architecture.rst src/icclim/_core/climate_variable.py src/icclim/_core/generic/bootstrap_capability.py src/icclim/_core/generic/functions.py src/icclim/threshold/factory.py tests/test_bootstrap_capability.py tests/test_main.py tests/test_threshold.py tools/run_real_data_validation.py tools/summarize_real_data_validation.py`
- `pytest -q tests/test_bootstrap_capability.py tests/test_threshold.py tests/test_generic_functions.py tests/test_main.py -k 'bootstrap or threshold or logical_link or count_occurrences or fraction_of_total or sum_of_spell_lengths'`
