### PR TITLE
Extend optimized bootstrap value aggregates to exact average

### DIFF
--- a/doc/source/dev/bootstrap_architecture.rst
+++ b/doc/source/dev/bootstrap_architecture.rst
@@ -271,6 +271,12 @@ useful intermediate step because it makes the scientific boundary
 visible in code before more bootstrap families reuse the same threshold
 generation semantics.
 
+As of Thursday, July 30, 2026, ``fraction_of_total`` is the first
+non-count consumer of this shared threshold generation layer. It still
+uses its own reducer, but it now reuses the same optimized substitute-
+year threshold series as the count family when the threshold is an
+unfiltered day-of-year percentile.
+
 Daily exceedance mask construction
 ----------------------------------
 

--- a/doc/source/dev/bootstrap_architecture.rst
+++ b/doc/source/dev/bootstrap_architecture.rst
@@ -271,11 +271,20 @@ useful intermediate step because it makes the scientific boundary
 visible in code before more bootstrap families reuse the same threshold
 generation semantics.
 
-As of Thursday, July 30, 2026, ``fraction_of_total`` is the first
-non-count consumer of this shared threshold generation layer. It still
-uses its own reducer, but it now reuses the same optimized substitute-
-year threshold series as the count family when the threshold is an
-unfiltered day-of-year percentile.
+As of Friday, July 31, 2026, two non-count consumers of this shared
+threshold generation layer are validated on Kraken real data:
+
+- ``fraction_of_total`` for unfiltered day-of-year percentile bootstrap;
+- generic ``sum`` for unfiltered day-of-year percentile bootstrap.
+
+Those two reducers are exact against the trusted baselines on real data.
+They currently define the validated optimized value-aggregate boundary.
+
+The same validation round also showed that ``average`` cannot be
+derived naively from ``optimized_sum / optimized_count``. A first
+dedicated mean kernel also remained non-identical on Kraken, so
+``average`` stays on the reference bootstrap implementation until its
+substitute-year semantics are matched exactly.
 
 Daily exceedance mask construction
 ----------------------------------

--- a/doc/source/dev/bootstrap_architecture.rst
+++ b/doc/source/dev/bootstrap_architecture.rst
@@ -221,6 +221,7 @@ tested helpers for:
 - ``build_bootstrap_reference_sample``;
 - ``build_bootstrap_temporal_indexing``;
 - ``build_bootstrap_array_inputs``.
+- ``build_bootstrap_output``.
 
 Those helpers keep the bootstrap preparation workflow readable in code:
 

--- a/doc/source/dev/bootstrap_architecture.rst
+++ b/doc/source/dev/bootstrap_architecture.rst
@@ -214,6 +214,26 @@ Suggested names:
 Avoid short names such as ``ref2`` or ``idx_map`` when the longer name
 removes ambiguity.
 
+As of July 30, 2026, this layer now starts to exist in
+``src/icclim/_core/generic/bootstrap_primitives.py`` with explicit,
+tested helpers for:
+
+- ``build_bootstrap_reference_sample``;
+- ``build_bootstrap_temporal_indexing``;
+- ``build_bootstrap_array_inputs``.
+
+Those helpers keep the bootstrap preparation workflow readable in code:
+
+1. prepare the reference-period sample;
+2. prepare year and resampling indexes;
+3. prepare flattened arrays for an optimized kernel;
+4. run the family-specific kernel;
+5. rebuild xarray outputs.
+
+That is still only a first step. Threshold generation itself is not yet
+fully extracted into a reusable engine, but the preparation phases now
+have a stable home and direct unit tests.
+
 Bootstrap threshold generation
 ------------------------------
 

--- a/doc/source/dev/bootstrap_architecture.rst
+++ b/doc/source/dev/bootstrap_architecture.rst
@@ -255,6 +255,21 @@ Suggested helper responsibilities:
 - ``build_substitute_thresholds``
 - ``align_thresholds_to_study_days``
 
+As of July 30, 2026, the optimized day-of-year percentile count path
+now follows this separation inside
+``src/icclim/_core/generic/bootstrap.py``:
+
+- ``_build_bootstrap_threshold_series_for_cell`` computes one
+  substitute-aware threshold series;
+- ``_write_count_groups_for_cell`` and
+  ``_accumulate_count_groups_for_cell`` apply the count reducer to that
+  threshold series.
+
+This is still specific to the current count implementation, but it is a
+useful intermediate step because it makes the scientific boundary
+visible in code before more bootstrap families reuse the same threshold
+generation semantics.
+
 Daily exceedance mask construction
 ----------------------------------
 

--- a/doc/source/dev/bootstrap_architecture.rst
+++ b/doc/source/dev/bootstrap_architecture.rst
@@ -271,20 +271,24 @@ useful intermediate step because it makes the scientific boundary
 visible in code before more bootstrap families reuse the same threshold
 generation semantics.
 
-As of Friday, July 31, 2026, two non-count consumers of this shared
+As of Friday, July 31, 2026, three non-count consumers of this shared
 threshold generation layer are validated on Kraken real data:
 
 - ``fraction_of_total`` for unfiltered day-of-year percentile bootstrap;
 - generic ``sum`` for unfiltered day-of-year percentile bootstrap.
+- ``average`` for unfiltered day-of-year percentile bootstrap.
 
-Those two reducers are exact against the trusted baselines on real data.
+Those reducers are exact against the trusted baselines on real data.
 They currently define the validated optimized value-aggregate boundary.
 
 The same validation round also showed that ``average`` cannot be
 derived naively from ``optimized_sum / optimized_count``. A first
-dedicated mean kernel also remained non-identical on Kraken, so
-``average`` stays on the reference bootstrap implementation until its
-substitute-year semantics are matched exactly.
+dedicated mean kernel also remained non-identical on Kraken. The
+validated optimized implementation instead uses:
+
+- optimized union exceedance sums;
+- optimized union exceedance-day counts;
+- final output casting aligned with the trusted baseline dtype.
 
 Daily exceedance mask construction
 ----------------------------------

--- a/src/icclim/_core/generic/bootstrap.py
+++ b/src/icclim/_core/generic/bootstrap.py
@@ -43,7 +43,7 @@ def compute_doy_percentile_bootstrap_count(
         freq,
         doy_window_width=threshold.doy_window_width,
     )
-    array_inputs = build_bootstrap_array_inputs(reference_sample)
+    array_inputs = build_bootstrap_array_inputs(reference_sample, dtype=np.float32)
     result = _bootstrap_count_kernel(
         array_inputs.flat_reference_raw,
         array_inputs.flat_reference_filtered,
@@ -96,7 +96,7 @@ def compute_doy_percentile_bootstrap_exceedance_sum(
         freq,
         doy_window_width=threshold.doy_window_width,
     )
-    array_inputs = build_bootstrap_array_inputs(reference_sample)
+    array_inputs = build_bootstrap_array_inputs(reference_sample, dtype=np.float32)
     result = _bootstrap_sum_kernel(
         array_inputs.flat_reference_raw,
         array_inputs.flat_reference_filtered,
@@ -129,6 +129,7 @@ def compute_doy_percentile_bootstrap_exceedance_sum(
         spatial_shape=array_inputs.spatial_shape,
         units=reference_sample.study.attrs.get("units", ""),
     )
+    out = out.astype(reference_sample.study.dtype)
     out.attrs[REFERENCE_PERIOD_ID] = reference_sample.climatology_bounds
     del out.attrs["climatology_bounds"]
     return out.assign_coords(percentiles=threshold.percentile_coord().item())
@@ -301,20 +302,22 @@ if njit is not None:
             group_start = year_group_starts[year_i]
             group_stop = year_group_stops[year_i]
             if target_ref_i < 0:
-                thresholds = _build_bootstrap_threshold_series_for_cell(
-                    flat_ref_masked,
-                    sample_indices,
-                    index_year,
-                    index_pos,
-                    substitute_aligned,
-                    -1,
-                    -1,
-                    cell,
-                    max_samples,
-                    quantile,
-                    alpha,
-                    beta,
-                    min_threshold,
+                thresholds = _build_float32_bootstrap_threshold_series_for_cell(
+                    _build_bootstrap_threshold_series_for_cell(
+                        flat_ref_masked,
+                        sample_indices,
+                        index_year,
+                        index_pos,
+                        substitute_aligned,
+                        -1,
+                        -1,
+                        cell,
+                        max_samples,
+                        quantile,
+                        alpha,
+                        beta,
+                        min_threshold,
+                    )
                 )
                 _write_sum_groups_for_cell(
                     out,
@@ -330,47 +333,44 @@ if njit is not None:
                     op_code,
                 )
             else:
-                for group_i in range(group_start, group_stop):
-                    out[group_i, cell] = 0.0
-                substitute_count = 0
+                union_thresholds = _initialize_union_threshold_series(op_code)
                 for substitute_i in range(n_ref_years):
                     if substitute_i == target_ref_i:
                         continue
-                    thresholds = _build_bootstrap_threshold_series_for_cell(
-                        flat_ref_raw,
-                        sample_indices,
-                        index_year,
-                        index_pos,
-                        substitute_aligned,
-                        target_ref_i,
-                        substitute_i,
-                        cell,
-                        max_samples,
-                        quantile,
-                        alpha,
-                        beta,
-                        min_threshold,
+                    thresholds = _build_float32_bootstrap_threshold_series_for_cell(
+                        _build_bootstrap_threshold_series_for_cell(
+                            flat_ref_raw,
+                            sample_indices,
+                            index_year,
+                            index_pos,
+                            substitute_aligned,
+                            target_ref_i,
+                            substitute_i,
+                            cell,
+                            max_samples,
+                            quantile,
+                            alpha,
+                            beta,
+                            min_threshold,
+                        )
                     )
-                    _accumulate_sum_groups_for_cell(
-                        out,
-                        flat_study,
+                    _update_union_threshold_series(
+                        union_thresholds,
                         thresholds,
-                        study_doys,
-                        study_starts,
-                        study_lengths,
-                        group_start,
-                        group_stop,
-                        cell,
-                        year_max_doys[year_i],
                         op_code,
                     )
-                    substitute_count += 1
-                _average_count_groups_for_cell(
+                _write_sum_groups_for_cell(
                     out,
+                    flat_study,
+                    union_thresholds,
+                    study_doys,
+                    study_starts,
+                    study_lengths,
                     group_start,
                     group_stop,
                     cell,
-                    substitute_count,
+                    year_max_doys[year_i],
+                    op_code,
                 )
         return out
 
@@ -534,14 +534,46 @@ if njit is not None:
         max_target_doy,
         op_code,
     ):
-        total = 0.0
+        total = np.float32(0.0)
         for offset in range(length):
             doy = study_doys[start + offset]
             threshold = _adjusted_threshold(thresholds, doy, max_target_doy)
             value = flat_study[start + offset, cell]
             if _compare(value, threshold, op_code):
-                total += value
-        return total
+                total = np.float32(total + np.float32(value))
+        return float(total)
+
+    @njit(cache=True)
+    def _initialize_union_threshold_series(op_code):
+        if op_code in (0, 1):
+            return np.full(
+                NON_LEAP_YEAR_DAY_COUNT, np.float32(np.inf), dtype=np.float32
+            )
+        return np.full(
+            NON_LEAP_YEAR_DAY_COUNT,
+            np.float32(-np.inf),
+            dtype=np.float32,
+        )
+
+    @njit(cache=True)
+    def _build_float32_bootstrap_threshold_series_for_cell(thresholds):
+        converted = np.empty(NON_LEAP_YEAR_DAY_COUNT, dtype=np.float32)
+        for day_i in range(NON_LEAP_YEAR_DAY_COUNT):
+            converted[day_i] = np.float32(thresholds[day_i])
+        return converted
+
+    @njit(cache=True)
+    def _update_union_threshold_series(union_thresholds, thresholds, op_code):
+        for day_i in range(NON_LEAP_YEAR_DAY_COUNT):
+            threshold_value = thresholds[day_i]
+            if np.isnan(threshold_value):
+                continue
+            current_value = union_thresholds[day_i]
+            if op_code in (0, 1):
+                if threshold_value < current_value:
+                    union_thresholds[day_i] = threshold_value
+            elif threshold_value > current_value:
+                union_thresholds[day_i] = threshold_value
 
     @njit(cache=True)
     def _write_count_groups_for_cell(

--- a/src/icclim/_core/generic/bootstrap.py
+++ b/src/icclim/_core/generic/bootstrap.py
@@ -12,10 +12,14 @@ from icclim._core.constants import REFERENCE_PERIOD_ID
 from icclim._core.generic.bootstrap_capability import (
     is_optimized_doy_percentile_count_supported,
 )
+from icclim._core.generic.bootstrap_primitives import (
+    build_bootstrap_array_inputs,
+    build_bootstrap_reference_sample,
+    build_bootstrap_temporal_indexing,
+)
 from icclim._core.model.operator import Operator
 
 if TYPE_CHECKING:
-    import pandas as pd
     from xarray import DataArray
 
     from icclim._core.generic.threshold.percentile import PercentileThreshold
@@ -29,116 +33,61 @@ def compute_doy_percentile_bootstrap_count(
     """Compute percentile bootstrap counts without building a huge dask graph."""
     if not _can_compute_optimized_bootstrap(study, threshold, freq):
         return None
-    loaded = study.load()
-    climatology_bounds = threshold.climatology_bounds(loaded)
-    ref_raw = loaded.sel(time=slice(*climatology_bounds))
-    min_threshold = _threshold_min_value_in_reference_units(threshold, ref_raw)
-    ref_masked = ref_raw
-    if min_threshold is not None:
-        ref_masked = ref_raw.where(ref_raw >= min_threshold, np.nan)
-    study_time = loaded.indexes["time"]
-    ref_time = ref_raw.indexes["time"]
-    ref_year_indices = _indices_by_year(ref_time)
-    study_year_indices = _indices_by_year(study_time)
-    ref_years = np.asarray(list(ref_year_indices), dtype=np.int64)
-    output_group_indices = _indices_by_resample_group(loaded, freq)
-    output_group_labels = list(output_group_indices)
-    output_starts = np.asarray(
-        [indices[0] for indices in output_group_indices.values()],
-        dtype=np.int64,
+    reference_sample = build_bootstrap_reference_sample(study, threshold)
+    temporal_indexing = build_bootstrap_temporal_indexing(
+        reference_sample.study,
+        reference_sample.reference_sample,
+        freq,
+        doy_window_width=threshold.doy_window_width,
     )
-    output_lengths = np.asarray(
-        [len(indices) for indices in output_group_indices.values()],
-        dtype=np.int64,
-    )
-    source_max_doy = int(ref_time.dayofyear.max())
-    study_year_max_doy = {
-        year: source_max_doy
-        if source_max_doy == 366
-        else int(study_time[indices].dayofyear.max())
-        for year, indices in study_year_indices.items()
-    }
-    output_years = np.asarray(
-        [int(study_time[indices[0]].year) for indices in output_group_indices.values()],
-        dtype=np.int64,
-    )
-    bootstrap_years = np.asarray(list(dict.fromkeys(output_years)), dtype=np.int64)
-    year_group_starts, year_group_stops = _group_bounds_by_year(
-        output_years,
-        bootstrap_years,
-    )
-    year_max_doys = np.asarray(
-        [study_year_max_doy[year] for year in bootstrap_years],
-        dtype=np.int64,
-    )
-    year_to_ref = np.asarray(
-        [
-            int(np.where(ref_years == year)[0][0]) if year in ref_year_indices else -1
-            for year in bootstrap_years
-        ],
-        dtype=np.int64,
-    )
-    flat = np.asarray(loaded.transpose("time", ...).data, dtype=np.float64).reshape(
-        loaded.sizes["time"],
-        -1,
-    )
-    flat_ref_raw = np.asarray(
-        ref_raw.transpose("time", ...).data,
-        dtype=np.float64,
-    ).reshape(
-        ref_raw.sizes["time"],
-        -1,
-    )
-    flat_ref_masked = np.asarray(
-        ref_masked.transpose("time", ...).data,
-        dtype=np.float64,
-    ).reshape(
-        ref_masked.sizes["time"],
-        -1,
-    )
-    sample_indices = _rolling_sample_index_matrix(
-        ref_time,
-        window=threshold.doy_window_width,
-    )
-    index_year, index_pos = _ref_index_year_and_position(
-        ref_year_indices,
-        len(ref_time),
-    )
-    substitute_aligned = _substitute_alignment_matrix(ref_time, ref_year_indices)
+    array_inputs = build_bootstrap_array_inputs(reference_sample)
     result = _bootstrap_count_kernel(
-        flat_ref_raw,
-        flat_ref_masked,
-        flat,
-        sample_indices,
-        index_year,
-        index_pos,
-        substitute_aligned,
-        output_starts,
-        output_lengths,
-        year_group_starts,
-        year_group_stops,
-        year_max_doys,
-        year_to_ref,
-        study_time.dayofyear.to_numpy(dtype=np.int64),
+        array_inputs.flat_reference_raw,
+        array_inputs.flat_reference_filtered,
+        array_inputs.flat_study,
+        temporal_indexing.sample_indices_by_day_of_year,
+        temporal_indexing.reference_index_year,
+        temporal_indexing.reference_index_position,
+        temporal_indexing.substitute_alignment,
+        temporal_indexing.output_starts,
+        temporal_indexing.output_lengths,
+        temporal_indexing.year_group_starts,
+        temporal_indexing.year_group_stops,
+        temporal_indexing.year_max_day_of_years,
+        temporal_indexing.year_to_reference_index,
+        temporal_indexing.study_day_of_years,
         float(threshold.percentile_coord().item()) / 100.0,
         float(threshold.interpolation.alpha),
         float(threshold.interpolation.beta),
         _operator_code(threshold.operator),
-        np.nan if min_threshold is None else float(min_threshold),
+        (
+            np.nan
+            if reference_sample.threshold_floor_in_reference_units is None
+            else float(reference_sample.threshold_floor_in_reference_units)
+        ),
     )
-    data = result.reshape((len(output_group_labels), *loaded.shape[1:]))
+    data = result.reshape(
+        (len(temporal_indexing.output_group_labels), *array_inputs.spatial_shape)
+    )
     out = xr.DataArray(
         data,
-        dims=loaded.dims,
+        dims=reference_sample.study.dims,
         coords={
-            "time": output_group_labels,
-            **{coord: loaded.coords[coord] for coord in loaded.dims if coord != "time"},
+            "time": temporal_indexing.output_group_labels,
+            **{
+                coord: reference_sample.study.coords[coord]
+                for coord in reference_sample.study.dims
+                if coord != "time"
+            },
         },
-        attrs={"units": "d", REFERENCE_PERIOD_ID: climatology_bounds},
+        attrs={
+            "units": "d",
+            REFERENCE_PERIOD_ID: reference_sample.climatology_bounds,
+        },
     )
-    for coord in loaded.coords:
-        if coord not in out.coords and "time" not in loaded[coord].dims:
-            out = out.assign_coords({coord: loaded[coord]})
+    for coord in reference_sample.study.coords:
+        if coord not in out.coords and "time" not in reference_sample.study[coord].dims:
+            out = out.assign_coords({coord: reference_sample.study[coord]})
     return out.assign_coords(percentiles=threshold.percentile_coord().item())
 
 
@@ -148,20 +97,6 @@ def _can_compute_optimized_bootstrap(
     freq: str,
 ) -> bool:
     return is_optimized_doy_percentile_count_supported(study, threshold, freq)
-
-
-def _threshold_min_value_in_reference_units(
-    threshold: PercentileThreshold,
-    ref: DataArray,
-) -> float | None:
-    if threshold.threshold_min_value is None:
-        return None
-    from xclim.core.units import convert_units_to  # noqa: PLC0415
-
-    converted = convert_units_to(threshold.threshold_min_value, ref, context="hydro")
-    if hasattr(converted, "magnitude"):
-        return float(converted.magnitude)
-    return float(converted)
 
 
 def _operator_code(operator: Operator | str) -> int:
@@ -455,118 +390,3 @@ else:
 
     def _bootstrap_count_kernel(*args, **kwargs):  # noqa: ARG001
         return None
-
-
-def _indices_by_year(time: pd.DatetimeIndex) -> dict[int, np.ndarray]:
-    return {int(year): np.where(time.year == year)[0] for year in np.unique(time.year)}
-
-
-def _indices_by_resample_group(
-    da: DataArray, freq: str
-) -> dict[np.datetime64, np.ndarray]:
-    groups = da.resample(time=freq).groups
-    out = {}
-    for label, indexer in groups.items():
-        if isinstance(indexer, slice):
-            start = 0 if indexer.start is None else indexer.start
-            stop = da.sizes["time"] if indexer.stop is None else indexer.stop
-            step = 1 if indexer.step is None else indexer.step
-            indices = np.arange(start, stop, step, dtype=np.int64)
-        else:
-            indices = np.asarray(indexer, dtype=np.int64)
-        out[np.datetime64(label)] = indices
-    return out
-
-
-def _group_bounds_by_year(
-    output_years: np.ndarray,
-    bootstrap_years: np.ndarray,
-) -> tuple[np.ndarray, np.ndarray]:
-    starts = np.empty(len(bootstrap_years), dtype=np.int64)
-    stops = np.empty(len(bootstrap_years), dtype=np.int64)
-    for i, year in enumerate(bootstrap_years):
-        group_indices = np.where(output_years == year)[0]
-        starts[i] = int(group_indices[0])
-        stops[i] = int(group_indices[-1]) + 1
-    return starts, stops
-
-
-def _rolling_sample_index_matrix(
-    time: pd.DatetimeIndex,
-    *,
-    window: int,
-) -> np.ndarray:
-    half_window = window // 2
-    sample_indices: dict[int, list[int]] = {doy: [] for doy in range(1, 366)}
-    doys = time.dayofyear.to_numpy()
-    for center, doy in enumerate(doys):
-        if doy == 366:
-            continue
-        start = max(0, center - half_window)
-        stop = min(len(time), center + half_window + 1)
-        sample_indices[int(doy)].extend(range(start, stop))
-    max_samples = max(len(indices) for indices in sample_indices.values())
-    matrix = np.full((365, max_samples), -1, dtype=np.int64)
-    for doy, indices in sample_indices.items():
-        matrix[doy - 1, : len(indices)] = indices
-    return matrix
-
-
-def _ref_index_year_and_position(
-    ref_year_indices: dict[int, np.ndarray],
-    n_ref_time: int,
-) -> tuple[np.ndarray, np.ndarray]:
-    index_year = np.full(n_ref_time, -1, dtype=np.int64)
-    index_pos = np.full(n_ref_time, -1, dtype=np.int64)
-    for year_index, indices in enumerate(ref_year_indices.values()):
-        index_year[indices] = year_index
-        index_pos[indices] = np.arange(len(indices), dtype=np.int64)
-    return index_year, index_pos
-
-
-def _substitute_alignment_matrix(
-    ref_time: pd.DatetimeIndex,
-    ref_year_indices: dict[int, np.ndarray],
-) -> np.ndarray:
-    max_year_len = max(len(indices) for indices in ref_year_indices.values())
-    n_years = len(ref_year_indices)
-    aligned = np.full((n_years, n_years, max_year_len), -1, dtype=np.int64)
-    years = list(ref_year_indices)
-    for target_i, target_year in enumerate(years):
-        target_indices = ref_year_indices[target_year]
-        target_time = ref_time[target_indices]
-        for substitute_i, substitute_year in enumerate(years):
-            substitute_indices = ref_year_indices[substitute_year]
-            aligned[target_i, substitute_i, : len(target_indices)] = (
-                _substitute_indices_aligned_to_target(
-                    target_time,
-                    ref_time[substitute_indices],
-                    substitute_indices,
-                )
-            )
-    return aligned
-
-
-def _substitute_indices_aligned_to_target(
-    target_time: pd.DatetimeIndex,
-    substitute_time: pd.DatetimeIndex,
-    substitute_indices: np.ndarray,
-) -> np.ndarray:
-    if len(target_time) == len(substitute_time):
-        return substitute_indices
-    substitute_by_month_day = {
-        (int(month), int(day)): int(index)
-        for month, day, index in zip(
-            substitute_time.month,
-            substitute_time.day,
-            substitute_indices,
-            strict=True,
-        )
-    }
-    return np.asarray(
-        [
-            substitute_by_month_day.get((int(month), int(day)), -1)
-            for month, day in zip(target_time.month, target_time.day, strict=True)
-        ],
-        dtype=np.int64,
-    )

--- a/src/icclim/_core/generic/bootstrap.py
+++ b/src/icclim/_core/generic/bootstrap.py
@@ -81,6 +81,59 @@ def compute_doy_percentile_bootstrap_count(
     return out.assign_coords(percentiles=threshold.percentile_coord().item())
 
 
+def compute_doy_percentile_bootstrap_exceedance_sum(
+    study: DataArray,
+    threshold: PercentileThreshold,
+    freq: str,
+) -> DataArray | None:
+    """Compute bootstrap sums of exceedance-day values with the optimized path."""
+    if not _can_compute_optimized_bootstrap(study, threshold, freq):
+        return None
+    reference_sample = build_bootstrap_reference_sample(study, threshold)
+    temporal_indexing = build_bootstrap_temporal_indexing(
+        reference_sample.study,
+        reference_sample.reference_sample,
+        freq,
+        doy_window_width=threshold.doy_window_width,
+    )
+    array_inputs = build_bootstrap_array_inputs(reference_sample)
+    result = _bootstrap_sum_kernel(
+        array_inputs.flat_reference_raw,
+        array_inputs.flat_reference_filtered,
+        array_inputs.flat_study,
+        temporal_indexing.sample_indices_by_day_of_year,
+        temporal_indexing.reference_index_year,
+        temporal_indexing.reference_index_position,
+        temporal_indexing.substitute_alignment,
+        temporal_indexing.output_starts,
+        temporal_indexing.output_lengths,
+        temporal_indexing.year_group_starts,
+        temporal_indexing.year_group_stops,
+        temporal_indexing.year_max_day_of_years,
+        temporal_indexing.year_to_reference_index,
+        temporal_indexing.study_day_of_years,
+        float(threshold.percentile_coord().item()) / 100.0,
+        float(threshold.interpolation.alpha),
+        float(threshold.interpolation.beta),
+        _operator_code(threshold.operator),
+        (
+            np.nan
+            if reference_sample.threshold_floor_in_reference_units is None
+            else float(reference_sample.threshold_floor_in_reference_units)
+        ),
+    )
+    out = build_bootstrap_output(
+        flat_result=result,
+        reference_sample=reference_sample,
+        temporal_indexing=temporal_indexing,
+        spatial_shape=array_inputs.spatial_shape,
+        units=reference_sample.study.attrs.get("units", ""),
+    )
+    out.attrs[REFERENCE_PERIOD_ID] = reference_sample.climatology_bounds
+    del out.attrs["climatology_bounds"]
+    return out.assign_coords(percentiles=threshold.percentile_coord().item())
+
+
 def _can_compute_optimized_bootstrap(
     study: DataArray,
     threshold: PercentileThreshold,
@@ -190,6 +243,115 @@ if njit is not None:
                         min_threshold,
                     )
                     _accumulate_count_groups_for_cell(
+                        out,
+                        flat_study,
+                        thresholds,
+                        study_doys,
+                        study_starts,
+                        study_lengths,
+                        group_start,
+                        group_stop,
+                        cell,
+                        year_max_doys[year_i],
+                        op_code,
+                    )
+                    substitute_count += 1
+                _average_count_groups_for_cell(
+                    out,
+                    group_start,
+                    group_stop,
+                    cell,
+                    substitute_count,
+                )
+        return out
+
+    @njit(parallel=True, cache=True)
+    def _bootstrap_sum_kernel(
+        flat_ref_raw,
+        flat_ref_masked,
+        flat_study,
+        sample_indices,
+        index_year,
+        index_pos,
+        substitute_aligned,
+        study_starts,
+        study_lengths,
+        year_group_starts,
+        year_group_stops,
+        year_max_doys,
+        year_to_ref,
+        study_doys,
+        quantile,
+        alpha,
+        beta,
+        op_code,
+        min_threshold,
+    ):
+        """Compute yearly bootstrap exceedance sums from shared thresholds."""
+        n_years = len(year_to_ref)
+        n_groups = len(study_starts)
+        n_cells = flat_study.shape[1]
+        out = np.empty((n_groups, n_cells), dtype=np.float64)
+        n_ref_years = substitute_aligned.shape[1]
+        max_samples = sample_indices.shape[1]
+        for flat_i in prange(n_years * n_cells):
+            year_i = flat_i // n_cells
+            cell = flat_i % n_cells
+            target_ref_i = year_to_ref[year_i]
+            group_start = year_group_starts[year_i]
+            group_stop = year_group_stops[year_i]
+            if target_ref_i < 0:
+                thresholds = _build_bootstrap_threshold_series_for_cell(
+                    flat_ref_masked,
+                    sample_indices,
+                    index_year,
+                    index_pos,
+                    substitute_aligned,
+                    -1,
+                    -1,
+                    cell,
+                    max_samples,
+                    quantile,
+                    alpha,
+                    beta,
+                    min_threshold,
+                )
+                _write_sum_groups_for_cell(
+                    out,
+                    flat_study,
+                    thresholds,
+                    study_doys,
+                    study_starts,
+                    study_lengths,
+                    group_start,
+                    group_stop,
+                    cell,
+                    year_max_doys[year_i],
+                    op_code,
+                )
+            else:
+                for group_i in range(group_start, group_stop):
+                    out[group_i, cell] = 0.0
+                substitute_count = 0
+                for substitute_i in range(n_ref_years):
+                    if substitute_i == target_ref_i:
+                        continue
+                    thresholds = _build_bootstrap_threshold_series_for_cell(
+                        flat_ref_raw,
+                        sample_indices,
+                        index_year,
+                        index_pos,
+                        substitute_aligned,
+                        target_ref_i,
+                        substitute_i,
+                        cell,
+                        max_samples,
+                        quantile,
+                        alpha,
+                        beta,
+                        min_threshold,
+                    )
+                    _accumulate_sum_groups_for_cell(
                         out,
                         flat_study,
                         thresholds,
@@ -362,6 +524,26 @@ if njit is not None:
         return count
 
     @njit(cache=True)
+    def _sum_exceedances(
+        flat_study,
+        thresholds,
+        study_doys,
+        start,
+        length,
+        cell,
+        max_target_doy,
+        op_code,
+    ):
+        total = 0.0
+        for offset in range(length):
+            doy = study_doys[start + offset]
+            threshold = _adjusted_threshold(thresholds, doy, max_target_doy)
+            value = flat_study[start + offset, cell]
+            if _compare(value, threshold, op_code):
+                total += value
+        return total
+
+    @njit(cache=True)
     def _write_count_groups_for_cell(
         out,
         flat_study,
@@ -414,6 +596,58 @@ if njit is not None:
             )
 
     @njit(cache=True)
+    def _write_sum_groups_for_cell(
+        out,
+        flat_study,
+        thresholds,
+        study_doys,
+        study_starts,
+        study_lengths,
+        group_start,
+        group_stop,
+        cell,
+        max_target_doy,
+        op_code,
+    ):
+        for group_i in range(group_start, group_stop):
+            out[group_i, cell] = _sum_exceedances(
+                flat_study,
+                thresholds,
+                study_doys,
+                study_starts[group_i],
+                study_lengths[group_i],
+                cell,
+                max_target_doy,
+                op_code,
+            )
+
+    @njit(cache=True)
+    def _accumulate_sum_groups_for_cell(
+        out,
+        flat_study,
+        thresholds,
+        study_doys,
+        study_starts,
+        study_lengths,
+        group_start,
+        group_stop,
+        cell,
+        max_target_doy,
+        op_code,
+    ):
+        for group_i in range(group_start, group_stop):
+            out[group_i, cell] += _sum_exceedances(
+                flat_study,
+                thresholds,
+                study_doys,
+                study_starts[group_i],
+                study_lengths[group_i],
+                cell,
+                max_target_doy,
+                op_code,
+            )
+
+    @njit(cache=True)
     def _average_count_groups_for_cell(
         out,
         group_start,
@@ -451,4 +685,7 @@ if njit is not None:
 else:
 
     def _bootstrap_count_kernel(*args, **kwargs):  # noqa: ARG001
+        return None
+
+    def _bootstrap_sum_kernel(*args, **kwargs):  # noqa: ARG001
         return None

--- a/src/icclim/_core/generic/bootstrap.py
+++ b/src/icclim/_core/generic/bootstrap.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import numpy as np
-import xarray as xr
 
 from icclim._core.constants import REFERENCE_PERIOD_ID
 from icclim._core.generic.bootstrap_capability import (
@@ -14,6 +13,7 @@ from icclim._core.generic.bootstrap_capability import (
 )
 from icclim._core.generic.bootstrap_primitives import (
     build_bootstrap_array_inputs,
+    build_bootstrap_output,
     build_bootstrap_reference_sample,
     build_bootstrap_temporal_indexing,
 )
@@ -69,28 +69,15 @@ def compute_doy_percentile_bootstrap_count(
             else float(reference_sample.threshold_floor_in_reference_units)
         ),
     )
-    data = result.reshape(
-        (len(temporal_indexing.output_group_labels), *array_inputs.spatial_shape)
+    out = build_bootstrap_output(
+        flat_result=result,
+        reference_sample=reference_sample,
+        temporal_indexing=temporal_indexing,
+        spatial_shape=array_inputs.spatial_shape,
+        units="d",
     )
-    out = xr.DataArray(
-        data,
-        dims=reference_sample.study.dims,
-        coords={
-            "time": temporal_indexing.output_group_labels,
-            **{
-                coord: reference_sample.study.coords[coord]
-                for coord in reference_sample.study.dims
-                if coord != "time"
-            },
-        },
-        attrs={
-            "units": "d",
-            REFERENCE_PERIOD_ID: reference_sample.climatology_bounds,
-        },
-    )
-    for coord in reference_sample.study.coords:
-        if coord not in out.coords and "time" not in reference_sample.study[coord].dims:
-            out = out.assign_coords({coord: reference_sample.study[coord]})
+    out.attrs[REFERENCE_PERIOD_ID] = reference_sample.climatology_bounds
+    del out.attrs["climatology_bounds"]
     return out.assign_coords(percentiles=threshold.percentile_coord().item())
 
 

--- a/src/icclim/_core/generic/bootstrap.py
+++ b/src/icclim/_core/generic/bootstrap.py
@@ -188,6 +188,114 @@ def compute_doy_percentile_bootstrap_union_exceedance_count(
     return out.assign_coords(percentiles=threshold.percentile_coord().item())
 
 
+def compute_doy_percentile_bootstrap_exceedance_average(
+    study: DataArray,
+    threshold: PercentileThreshold,
+    freq: str,
+) -> DataArray | None:
+    """Compute bootstrap averages of exceedance-day values with the optimized path."""
+    if not _can_compute_optimized_bootstrap(study, threshold, freq):
+        return None
+    reference_sample = build_bootstrap_reference_sample(study, threshold)
+    temporal_indexing = build_bootstrap_temporal_indexing(
+        reference_sample.study,
+        reference_sample.reference_sample,
+        freq,
+        doy_window_width=threshold.doy_window_width,
+    )
+    array_inputs = build_bootstrap_array_inputs(reference_sample, dtype=np.float32)
+    result = _bootstrap_average_kernel(
+        array_inputs.flat_reference_raw,
+        array_inputs.flat_reference_filtered,
+        array_inputs.flat_study,
+        temporal_indexing.sample_indices_by_day_of_year,
+        temporal_indexing.reference_index_year,
+        temporal_indexing.reference_index_position,
+        temporal_indexing.substitute_alignment,
+        temporal_indexing.output_starts,
+        temporal_indexing.output_lengths,
+        temporal_indexing.year_group_starts,
+        temporal_indexing.year_group_stops,
+        temporal_indexing.year_max_day_of_years,
+        temporal_indexing.year_to_reference_index,
+        temporal_indexing.study_day_of_years,
+        float(threshold.percentile_coord().item()) / 100.0,
+        float(threshold.interpolation.alpha),
+        float(threshold.interpolation.beta),
+        _operator_code(threshold.operator),
+        (
+            np.nan
+            if reference_sample.threshold_floor_in_reference_units is None
+            else float(reference_sample.threshold_floor_in_reference_units)
+        ),
+    )
+    out = build_bootstrap_output(
+        flat_result=result,
+        reference_sample=reference_sample,
+        temporal_indexing=temporal_indexing,
+        spatial_shape=array_inputs.spatial_shape,
+        units=reference_sample.study.attrs.get("units", ""),
+    )
+    out = out.astype(reference_sample.study.dtype)
+    out.attrs[REFERENCE_PERIOD_ID] = reference_sample.climatology_bounds
+    del out.attrs["climatology_bounds"]
+    return out.assign_coords(percentiles=threshold.percentile_coord().item())
+
+
+def compute_doy_percentile_bootstrap_fraction_of_total(
+    study: DataArray,
+    threshold: PercentileThreshold,
+    freq: str,
+) -> DataArray | None:
+    """Compute bootstrap fractions of total with the optimized path."""
+    if not _can_compute_optimized_bootstrap(study, threshold, freq):
+        return None
+    reference_sample = build_bootstrap_reference_sample(study, threshold)
+    temporal_indexing = build_bootstrap_temporal_indexing(
+        reference_sample.study,
+        reference_sample.reference_sample,
+        freq,
+        doy_window_width=threshold.doy_window_width,
+    )
+    array_inputs = build_bootstrap_array_inputs(reference_sample, dtype=np.float32)
+    result = _bootstrap_fraction_kernel(
+        array_inputs.flat_reference_raw,
+        array_inputs.flat_reference_filtered,
+        array_inputs.flat_study,
+        temporal_indexing.sample_indices_by_day_of_year,
+        temporal_indexing.reference_index_year,
+        temporal_indexing.reference_index_position,
+        temporal_indexing.substitute_alignment,
+        temporal_indexing.output_starts,
+        temporal_indexing.output_lengths,
+        temporal_indexing.year_group_starts,
+        temporal_indexing.year_group_stops,
+        temporal_indexing.year_max_day_of_years,
+        temporal_indexing.year_to_reference_index,
+        temporal_indexing.study_day_of_years,
+        float(threshold.percentile_coord().item()) / 100.0,
+        float(threshold.interpolation.alpha),
+        float(threshold.interpolation.beta),
+        _operator_code(threshold.operator),
+        (
+            np.nan
+            if reference_sample.threshold_floor_in_reference_units is None
+            else float(reference_sample.threshold_floor_in_reference_units)
+        ),
+    )
+    out = build_bootstrap_output(
+        flat_result=result,
+        reference_sample=reference_sample,
+        temporal_indexing=temporal_indexing,
+        spatial_shape=array_inputs.spatial_shape,
+        units="1",
+    )
+    out = out.astype(reference_sample.study.dtype)
+    out.attrs[REFERENCE_PERIOD_ID] = reference_sample.climatology_bounds
+    del out.attrs["climatology_bounds"]
+    return out.assign_coords(percentiles=threshold.percentile_coord().item())
+
+
 def _can_compute_optimized_bootstrap(
     study: DataArray,
     threshold: PercentileThreshold,
@@ -535,6 +643,222 @@ if njit is not None:
                 )
         return out
 
+    @njit(parallel=True, cache=True)
+    def _bootstrap_average_kernel(
+        flat_ref_raw,
+        flat_ref_masked,
+        flat_study,
+        sample_indices,
+        index_year,
+        index_pos,
+        substitute_aligned,
+        study_starts,
+        study_lengths,
+        year_group_starts,
+        year_group_stops,
+        year_max_doys,
+        year_to_ref,
+        study_doys,
+        quantile,
+        alpha,
+        beta,
+        op_code,
+        min_threshold,
+    ):
+        """Compute yearly bootstrap exceedance averages from shared thresholds."""
+        n_years = len(year_to_ref)
+        n_groups = len(study_starts)
+        n_cells = flat_study.shape[1]
+        out = np.empty((n_groups, n_cells), dtype=np.float64)
+        n_ref_years = substitute_aligned.shape[1]
+        max_samples = sample_indices.shape[1]
+        for flat_i in prange(n_years * n_cells):
+            year_i = flat_i // n_cells
+            cell = flat_i % n_cells
+            target_ref_i = year_to_ref[year_i]
+            group_start = year_group_starts[year_i]
+            group_stop = year_group_stops[year_i]
+            if target_ref_i < 0:
+                thresholds = _build_float32_bootstrap_threshold_series_for_cell(
+                    _build_bootstrap_threshold_series_for_cell(
+                        flat_ref_masked,
+                        sample_indices,
+                        index_year,
+                        index_pos,
+                        substitute_aligned,
+                        -1,
+                        -1,
+                        cell,
+                        max_samples,
+                        quantile,
+                        alpha,
+                        beta,
+                        min_threshold,
+                    )
+                )
+                _write_average_groups_for_cell(
+                    out,
+                    flat_study,
+                    thresholds,
+                    study_doys,
+                    study_starts,
+                    study_lengths,
+                    group_start,
+                    group_stop,
+                    cell,
+                    year_max_doys[year_i],
+                    op_code,
+                )
+            else:
+                union_thresholds = _initialize_union_threshold_series(op_code)
+                for substitute_i in range(n_ref_years):
+                    if substitute_i == target_ref_i:
+                        continue
+                    thresholds = _build_float32_bootstrap_threshold_series_for_cell(
+                        _build_bootstrap_threshold_series_for_cell(
+                            flat_ref_raw,
+                            sample_indices,
+                            index_year,
+                            index_pos,
+                            substitute_aligned,
+                            target_ref_i,
+                            substitute_i,
+                            cell,
+                            max_samples,
+                            quantile,
+                            alpha,
+                            beta,
+                            min_threshold,
+                        )
+                    )
+                    _update_union_threshold_series(
+                        union_thresholds,
+                        thresholds,
+                        op_code,
+                    )
+                _write_average_groups_for_cell(
+                    out,
+                    flat_study,
+                    union_thresholds,
+                    study_doys,
+                    study_starts,
+                    study_lengths,
+                    group_start,
+                    group_stop,
+                    cell,
+                    year_max_doys[year_i],
+                    op_code,
+                )
+        return out
+
+    @njit(parallel=True, cache=True)
+    def _bootstrap_fraction_kernel(
+        flat_ref_raw,
+        flat_ref_masked,
+        flat_study,
+        sample_indices,
+        index_year,
+        index_pos,
+        substitute_aligned,
+        study_starts,
+        study_lengths,
+        year_group_starts,
+        year_group_stops,
+        year_max_doys,
+        year_to_ref,
+        study_doys,
+        quantile,
+        alpha,
+        beta,
+        op_code,
+        min_threshold,
+    ):
+        """Compute yearly bootstrap fractions of total from shared thresholds."""
+        n_years = len(year_to_ref)
+        n_groups = len(study_starts)
+        n_cells = flat_study.shape[1]
+        out = np.empty((n_groups, n_cells), dtype=np.float64)
+        n_ref_years = substitute_aligned.shape[1]
+        max_samples = sample_indices.shape[1]
+        for flat_i in prange(n_years * n_cells):
+            year_i = flat_i // n_cells
+            cell = flat_i % n_cells
+            target_ref_i = year_to_ref[year_i]
+            group_start = year_group_starts[year_i]
+            group_stop = year_group_stops[year_i]
+            if target_ref_i < 0:
+                thresholds = _build_float32_bootstrap_threshold_series_for_cell(
+                    _build_bootstrap_threshold_series_for_cell(
+                        flat_ref_masked,
+                        sample_indices,
+                        index_year,
+                        index_pos,
+                        substitute_aligned,
+                        -1,
+                        -1,
+                        cell,
+                        max_samples,
+                        quantile,
+                        alpha,
+                        beta,
+                        min_threshold,
+                    )
+                )
+                _write_fraction_groups_for_cell(
+                    out,
+                    flat_study,
+                    thresholds,
+                    study_doys,
+                    study_starts,
+                    study_lengths,
+                    group_start,
+                    group_stop,
+                    cell,
+                    year_max_doys[year_i],
+                    op_code,
+                )
+            else:
+                union_thresholds = _initialize_union_threshold_series(op_code)
+                for substitute_i in range(n_ref_years):
+                    if substitute_i == target_ref_i:
+                        continue
+                    thresholds = _build_float32_bootstrap_threshold_series_for_cell(
+                        _build_bootstrap_threshold_series_for_cell(
+                            flat_ref_raw,
+                            sample_indices,
+                            index_year,
+                            index_pos,
+                            substitute_aligned,
+                            target_ref_i,
+                            substitute_i,
+                            cell,
+                            max_samples,
+                            quantile,
+                            alpha,
+                            beta,
+                            min_threshold,
+                        )
+                    )
+                    _update_union_threshold_series(
+                        union_thresholds,
+                        thresholds,
+                        op_code,
+                    )
+                _write_fraction_groups_for_cell(
+                    out,
+                    flat_study,
+                    union_thresholds,
+                    study_doys,
+                    study_starts,
+                    study_lengths,
+                    group_start,
+                    group_stop,
+                    cell,
+                    year_max_doys[year_i],
+                    op_code,
+                )
+        return out
+
     @njit(cache=True)
     def _build_bootstrap_threshold_series_for_cell(
         flat_ref,
@@ -705,6 +1029,54 @@ if njit is not None:
         return float(total)
 
     @njit(cache=True)
+    def _average_exceedances(
+        flat_study,
+        thresholds,
+        study_doys,
+        start,
+        length,
+        cell,
+        max_target_doy,
+        op_code,
+    ):
+        total = np.float32(0.0)
+        count = 0.0
+        for offset in range(length):
+            doy = study_doys[start + offset]
+            threshold = _adjusted_threshold(thresholds, doy, max_target_doy)
+            value = flat_study[start + offset, cell]
+            if _compare(value, threshold, op_code):
+                total = np.float32(total + np.float32(value))
+                count += 1.0
+        if count == 0.0:
+            return np.nan
+        return float(np.float32(total / np.float32(count)))
+
+    @njit(cache=True)
+    def _fraction_of_total(
+        flat_study,
+        thresholds,
+        study_doys,
+        start,
+        length,
+        cell,
+        max_target_doy,
+        op_code,
+    ):
+        exceedance_total = np.float32(0.0)
+        total = np.float32(0.0)
+        for offset in range(length):
+            doy = study_doys[start + offset]
+            threshold = _adjusted_threshold(thresholds, doy, max_target_doy)
+            value = flat_study[start + offset, cell]
+            total = np.float32(total + np.float32(value))
+            if _compare(value, threshold, op_code):
+                exceedance_total = np.float32(exceedance_total + np.float32(value))
+        if total == np.float32(0.0):
+            return np.nan
+        return float(np.float32(exceedance_total / total))
+
+    @njit(cache=True)
     def _initialize_union_threshold_series(op_code):
         if op_code in (0, 1):
             return np.full(
@@ -815,6 +1187,58 @@ if njit is not None:
             )
 
     @njit(cache=True)
+    def _write_average_groups_for_cell(
+        out,
+        flat_study,
+        thresholds,
+        study_doys,
+        study_starts,
+        study_lengths,
+        group_start,
+        group_stop,
+        cell,
+        max_target_doy,
+        op_code,
+    ):
+        for group_i in range(group_start, group_stop):
+            out[group_i, cell] = _average_exceedances(
+                flat_study,
+                thresholds,
+                study_doys,
+                study_starts[group_i],
+                study_lengths[group_i],
+                cell,
+                max_target_doy,
+                op_code,
+            )
+
+    @njit(cache=True)
+    def _write_fraction_groups_for_cell(
+        out,
+        flat_study,
+        thresholds,
+        study_doys,
+        study_starts,
+        study_lengths,
+        group_start,
+        group_stop,
+        cell,
+        max_target_doy,
+        op_code,
+    ):
+        for group_i in range(group_start, group_stop):
+            out[group_i, cell] = _fraction_of_total(
+                flat_study,
+                thresholds,
+                study_doys,
+                study_starts[group_i],
+                study_lengths[group_i],
+                cell,
+                max_target_doy,
+                op_code,
+            )
+
+    @njit(cache=True)
     def _accumulate_sum_groups_for_cell(
         out,
         flat_study,
@@ -884,4 +1308,10 @@ else:
         return None
 
     def _bootstrap_union_count_kernel(*args, **kwargs):  # noqa: ARG001
+        return None
+
+    def _bootstrap_average_kernel(*args, **kwargs):  # noqa: ARG001
+        return None
+
+    def _bootstrap_fraction_kernel(*args, **kwargs):  # noqa: ARG001
         return None

--- a/src/icclim/_core/generic/bootstrap.py
+++ b/src/icclim/_core/generic/bootstrap.py
@@ -135,6 +135,59 @@ def compute_doy_percentile_bootstrap_exceedance_sum(
     return out.assign_coords(percentiles=threshold.percentile_coord().item())
 
 
+def compute_doy_percentile_bootstrap_union_exceedance_count(
+    study: DataArray,
+    threshold: PercentileThreshold,
+    freq: str,
+) -> DataArray | None:
+    """Count union exceedance days for thresholded bootstrap mean reducers."""
+    if not _can_compute_optimized_bootstrap(study, threshold, freq):
+        return None
+    reference_sample = build_bootstrap_reference_sample(study, threshold)
+    temporal_indexing = build_bootstrap_temporal_indexing(
+        reference_sample.study,
+        reference_sample.reference_sample,
+        freq,
+        doy_window_width=threshold.doy_window_width,
+    )
+    array_inputs = build_bootstrap_array_inputs(reference_sample, dtype=np.float32)
+    result = _bootstrap_union_count_kernel(
+        array_inputs.flat_reference_raw,
+        array_inputs.flat_reference_filtered,
+        array_inputs.flat_study,
+        temporal_indexing.sample_indices_by_day_of_year,
+        temporal_indexing.reference_index_year,
+        temporal_indexing.reference_index_position,
+        temporal_indexing.substitute_alignment,
+        temporal_indexing.output_starts,
+        temporal_indexing.output_lengths,
+        temporal_indexing.year_group_starts,
+        temporal_indexing.year_group_stops,
+        temporal_indexing.year_max_day_of_years,
+        temporal_indexing.year_to_reference_index,
+        temporal_indexing.study_day_of_years,
+        float(threshold.percentile_coord().item()) / 100.0,
+        float(threshold.interpolation.alpha),
+        float(threshold.interpolation.beta),
+        _operator_code(threshold.operator),
+        (
+            np.nan
+            if reference_sample.threshold_floor_in_reference_units is None
+            else float(reference_sample.threshold_floor_in_reference_units)
+        ),
+    )
+    out = build_bootstrap_output(
+        flat_result=result,
+        reference_sample=reference_sample,
+        temporal_indexing=temporal_indexing,
+        spatial_shape=array_inputs.spatial_shape,
+        units="d",
+    )
+    out.attrs[REFERENCE_PERIOD_ID] = reference_sample.climatology_bounds
+    del out.attrs["climatology_bounds"]
+    return out.assign_coords(percentiles=threshold.percentile_coord().item())
+
+
 def _can_compute_optimized_bootstrap(
     study: DataArray,
     threshold: PercentileThreshold,
@@ -360,6 +413,114 @@ if njit is not None:
                         op_code,
                     )
                 _write_sum_groups_for_cell(
+                    out,
+                    flat_study,
+                    union_thresholds,
+                    study_doys,
+                    study_starts,
+                    study_lengths,
+                    group_start,
+                    group_stop,
+                    cell,
+                    year_max_doys[year_i],
+                    op_code,
+                )
+        return out
+
+    @njit(parallel=True, cache=True)
+    def _bootstrap_union_count_kernel(
+        flat_ref_raw,
+        flat_ref_masked,
+        flat_study,
+        sample_indices,
+        index_year,
+        index_pos,
+        substitute_aligned,
+        study_starts,
+        study_lengths,
+        year_group_starts,
+        year_group_stops,
+        year_max_doys,
+        year_to_ref,
+        study_doys,
+        quantile,
+        alpha,
+        beta,
+        op_code,
+        min_threshold,
+    ):
+        """Count union exceedance days from shared bootstrap thresholds."""
+        n_years = len(year_to_ref)
+        n_groups = len(study_starts)
+        n_cells = flat_study.shape[1]
+        out = np.empty((n_groups, n_cells), dtype=np.float64)
+        n_ref_years = substitute_aligned.shape[1]
+        max_samples = sample_indices.shape[1]
+        for flat_i in prange(n_years * n_cells):
+            year_i = flat_i // n_cells
+            cell = flat_i % n_cells
+            target_ref_i = year_to_ref[year_i]
+            group_start = year_group_starts[year_i]
+            group_stop = year_group_stops[year_i]
+            if target_ref_i < 0:
+                thresholds = _build_float32_bootstrap_threshold_series_for_cell(
+                    _build_bootstrap_threshold_series_for_cell(
+                        flat_ref_masked,
+                        sample_indices,
+                        index_year,
+                        index_pos,
+                        substitute_aligned,
+                        -1,
+                        -1,
+                        cell,
+                        max_samples,
+                        quantile,
+                        alpha,
+                        beta,
+                        min_threshold,
+                    )
+                )
+                _write_count_groups_for_cell(
+                    out,
+                    flat_study,
+                    thresholds,
+                    study_doys,
+                    study_starts,
+                    study_lengths,
+                    group_start,
+                    group_stop,
+                    cell,
+                    year_max_doys[year_i],
+                    op_code,
+                )
+            else:
+                union_thresholds = _initialize_union_threshold_series(op_code)
+                for substitute_i in range(n_ref_years):
+                    if substitute_i == target_ref_i:
+                        continue
+                    thresholds = _build_float32_bootstrap_threshold_series_for_cell(
+                        _build_bootstrap_threshold_series_for_cell(
+                            flat_ref_raw,
+                            sample_indices,
+                            index_year,
+                            index_pos,
+                            substitute_aligned,
+                            target_ref_i,
+                            substitute_i,
+                            cell,
+                            max_samples,
+                            quantile,
+                            alpha,
+                            beta,
+                            min_threshold,
+                        )
+                    )
+                    _update_union_threshold_series(
+                        union_thresholds,
+                        thresholds,
+                        op_code,
+                    )
+                _write_count_groups_for_cell(
                     out,
                     flat_study,
                     union_thresholds,
@@ -720,4 +881,7 @@ else:
         return None
 
     def _bootstrap_sum_kernel(*args, **kwargs):  # noqa: ARG001
+        return None
+
+    def _bootstrap_union_count_kernel(*args, **kwargs):  # noqa: ARG001
         return None

--- a/src/icclim/_core/generic/bootstrap.py
+++ b/src/icclim/_core/generic/bootstrap.py
@@ -25,6 +25,9 @@ if TYPE_CHECKING:
     from icclim._core.generic.threshold.percentile import PercentileThreshold
 
 
+NON_LEAP_YEAR_DAY_COUNT = 365
+
+
 def compute_doy_percentile_bootstrap_count(
     study: DataArray,
     threshold: PercentileThreshold,
@@ -135,6 +138,7 @@ if njit is not None:
         op_code,
         min_threshold,
     ):
+        """Compute yearly bootstrap counts from threshold generation plus counting."""
         n_years = len(year_to_ref)
         n_groups = len(study_starts)
         n_cells = flat_study.shape[1]
@@ -145,11 +149,10 @@ if njit is not None:
             year_i = flat_i // n_cells
             cell = flat_i % n_cells
             target_ref_i = year_to_ref[year_i]
-            max_target_doy = year_max_doys[year_i]
             group_start = year_group_starts[year_i]
             group_stop = year_group_stops[year_i]
             if target_ref_i < 0:
-                q = _quantiles_for_cell(
+                thresholds = _build_bootstrap_threshold_series_for_cell(
                     flat_ref_masked,
                     sample_indices,
                     index_year,
@@ -164,17 +167,19 @@ if njit is not None:
                     beta,
                     min_threshold,
                 )
-                for group_i in range(group_start, group_stop):
-                    out[group_i, cell] = _count_exceedances(
-                        flat_study,
-                        q,
-                        study_doys,
-                        study_starts[group_i],
-                        study_lengths[group_i],
-                        cell,
-                        max_target_doy,
-                        op_code,
-                    )
+                _write_count_groups_for_cell(
+                    out,
+                    flat_study,
+                    thresholds,
+                    study_doys,
+                    study_starts,
+                    study_lengths,
+                    group_start,
+                    group_stop,
+                    cell,
+                    year_max_doys[year_i],
+                    op_code,
+                )
             else:
                 for group_i in range(group_start, group_stop):
                     out[group_i, cell] = 0.0
@@ -182,7 +187,7 @@ if njit is not None:
                 for substitute_i in range(n_ref_years):
                     if substitute_i == target_ref_i:
                         continue
-                    q = _quantiles_for_cell(
+                    thresholds = _build_bootstrap_threshold_series_for_cell(
                         flat_ref_raw,
                         sample_indices,
                         index_year,
@@ -197,24 +202,31 @@ if njit is not None:
                         beta,
                         min_threshold,
                     )
-                    for group_i in range(group_start, group_stop):
-                        out[group_i, cell] += _count_exceedances(
-                            flat_study,
-                            q,
-                            study_doys,
-                            study_starts[group_i],
-                            study_lengths[group_i],
-                            cell,
-                            max_target_doy,
-                            op_code,
-                        )
+                    _accumulate_count_groups_for_cell(
+                        out,
+                        flat_study,
+                        thresholds,
+                        study_doys,
+                        study_starts,
+                        study_lengths,
+                        group_start,
+                        group_stop,
+                        cell,
+                        year_max_doys[year_i],
+                        op_code,
+                    )
                     substitute_count += 1
-                for group_i in range(group_start, group_stop):
-                    out[group_i, cell] /= substitute_count
+                _average_count_groups_for_cell(
+                    out,
+                    group_start,
+                    group_stop,
+                    cell,
+                    substitute_count,
+                )
         return out
 
     @njit(cache=True)
-    def _quantiles_for_cell(
+    def _build_bootstrap_threshold_series_for_cell(
         flat_ref,
         sample_indices,
         index_year,
@@ -229,10 +241,10 @@ if njit is not None:
         beta,
         min_threshold,
     ):
-        q = np.empty(365, dtype=np.float64)
+        thresholds = np.empty(NON_LEAP_YEAR_DAY_COUNT, dtype=np.float64)
         buf = np.empty(max_samples, dtype=np.float64)
-        for doy_i in range(365):
-            q_value = _quantile_for_doy_cell(
+        for doy_i in range(NON_LEAP_YEAR_DAY_COUNT):
+            threshold_value = _quantile_for_doy_cell(
                 flat_ref,
                 sample_indices,
                 index_year,
@@ -248,11 +260,11 @@ if njit is not None:
                 beta,
             )
             if not np.isnan(min_threshold) and (
-                np.isnan(q_value) or q_value <= min_threshold
+                np.isnan(threshold_value) or threshold_value <= min_threshold
             ):
-                q_value = min_threshold
-            q[doy_i] = q_value
-        return q
+                threshold_value = min_threshold
+            thresholds[doy_i] = threshold_value
+        return thresholds
 
     @njit(cache=True)
     def _quantile_for_doy_cell(
@@ -345,7 +357,7 @@ if njit is not None:
     @njit(cache=True)
     def _count_exceedances(
         flat_study,
-        q,
+        thresholds,
         study_doys,
         start,
         length,
@@ -356,11 +368,74 @@ if njit is not None:
         count = 0.0
         for offset in range(length):
             doy = study_doys[start + offset]
-            threshold = _adjusted_threshold(q, doy, max_target_doy)
+            threshold = _adjusted_threshold(thresholds, doy, max_target_doy)
             value = flat_study[start + offset, cell]
             if _compare(value, threshold, op_code):
                 count += 1.0
         return count
+
+    @njit(cache=True)
+    def _write_count_groups_for_cell(
+        out,
+        flat_study,
+        thresholds,
+        study_doys,
+        study_starts,
+        study_lengths,
+        group_start,
+        group_stop,
+        cell,
+        max_target_doy,
+        op_code,
+    ):
+        for group_i in range(group_start, group_stop):
+            out[group_i, cell] = _count_exceedances(
+                flat_study,
+                thresholds,
+                study_doys,
+                study_starts[group_i],
+                study_lengths[group_i],
+                cell,
+                max_target_doy,
+                op_code,
+            )
+
+    @njit(cache=True)
+    def _accumulate_count_groups_for_cell(
+        out,
+        flat_study,
+        thresholds,
+        study_doys,
+        study_starts,
+        study_lengths,
+        group_start,
+        group_stop,
+        cell,
+        max_target_doy,
+        op_code,
+    ):
+        for group_i in range(group_start, group_stop):
+            out[group_i, cell] += _count_exceedances(
+                flat_study,
+                thresholds,
+                study_doys,
+                study_starts[group_i],
+                study_lengths[group_i],
+                cell,
+                max_target_doy,
+                op_code,
+            )
+
+    @njit(cache=True)
+    def _average_count_groups_for_cell(
+        out,
+        group_start,
+        group_stop,
+        cell,
+        substitute_count,
+    ):
+        for group_i in range(group_start, group_stop):
+            out[group_i, cell] /= substitute_count
 
     @njit(cache=True)
     def _compare(value, threshold, op_code):
@@ -373,18 +448,18 @@ if njit is not None:
         return value <= threshold
 
     @njit(cache=True)
-    def _adjusted_threshold(q, doy, max_target_doy):
-        if max_target_doy == 365:
-            return q[doy - 1]
+    def _adjusted_threshold(thresholds, doy, max_target_doy):
+        if max_target_doy == NON_LEAP_YEAR_DAY_COUNT:
+            return thresholds[doy - 1]
         position = (doy - 1.0) * 364.0 / 365.0
         lower = int(np.floor(position))
         if lower >= 364:
-            return q[364]
+            return thresholds[364]
         gamma = position - lower
-        diff = q[lower + 1] - q[lower]
+        diff = thresholds[lower + 1] - thresholds[lower]
         if gamma >= 0.5:
-            return q[lower + 1] - diff * (1.0 - gamma)
-        return q[lower] + diff * gamma
+            return thresholds[lower + 1] - diff * (1.0 - gamma)
+        return thresholds[lower] + diff * gamma
 
 else:
 

--- a/src/icclim/_core/generic/bootstrap_capability.py
+++ b/src/icclim/_core/generic/bootstrap_capability.py
@@ -137,7 +137,7 @@ def classify_doy_percentile_count_bootstrap(
         climate_var.bootstrap,
     ):
         return _not_required("bootstrap_not_needed_for_overlap")
-    return _classify_required_count_bootstrap(
+    return _classify_required_optimized_percentile_bootstrap(
         family=_classify_count_family(threshold_spec),
         study=climate_var.studied_data,
         threshold_spec=threshold_spec,
@@ -145,7 +145,35 @@ def classify_doy_percentile_count_bootstrap(
     )
 
 
-def _classify_required_count_bootstrap(
+def classify_doy_percentile_value_aggregate_bootstrap(
+    climate_var: ClimateVariable,
+    resample_frequency: Frequency,
+) -> BootstrapCapability:
+    """Classify bootstrap routing for optimized percentile value aggregates."""
+    threshold_spec = climate_var.threshold
+    threshold_kind = classify_threshold_kind(threshold_spec)
+    not_required_reason = _count_bootstrap_not_required_reason(threshold_kind)
+    if not_required_reason is not None:
+        return _not_required(not_required_reason)
+    if not isinstance(threshold_spec, PercentileThreshold):
+        return _not_required("threshold_is_not_day_of_year_percentile")
+    if climate_var.bootstrap is False:
+        return _not_required("bootstrap_disabled_by_user")
+    if not must_run_bootstrap(
+        climate_var.studied_data,
+        threshold_spec,
+        climate_var.bootstrap,
+    ):
+        return _not_required("bootstrap_not_needed_for_overlap")
+    return _classify_required_optimized_percentile_bootstrap(
+        family=_classify_value_aggregate_family(threshold_spec),
+        study=climate_var.studied_data,
+        threshold_spec=threshold_spec,
+        output_frequency=resample_frequency.pandas_freq,
+    )
+
+
+def _classify_required_optimized_percentile_bootstrap(
     *,
     family: BootstrapComputationFamily,
     study: DataArray,
@@ -213,6 +241,17 @@ def classify_generic_indicator_bootstrap(
             climate_var=climate_vars[0],
             resample_frequency=resample_frequency,
         )
+    if _uses_specialized_value_aggregate_routing(
+        indicator_name=indicator_name,
+        reducer_kind=reducer_kind,
+        climate_vars=climate_vars,
+        date_event=date_event,
+        inventory=inventory,
+    ):
+        return classify_doy_percentile_value_aggregate_bootstrap(
+            climate_var=climate_vars[0],
+            resample_frequency=resample_frequency,
+        )
     return _reference_bootstrap_path(
         family,
         _reference_bootstrap_reason_code(
@@ -256,6 +295,16 @@ def _classify_count_family(
     if threshold_spec.threshold_min_value is not None:
         return BootstrapComputationFamily.FILTERED_DAY_OF_YEAR_PERCENTILE_COUNT
     return BootstrapComputationFamily.DAY_OF_YEAR_PERCENTILE_COUNT
+
+
+def _classify_value_aggregate_family(
+    threshold_spec: PercentileThreshold,
+) -> BootstrapComputationFamily:
+    if threshold_spec.threshold_min_value is not None:
+        return (
+            BootstrapComputationFamily.FILTERED_DAY_OF_YEAR_PERCENTILE_VALUE_AGGREGATE
+        )
+    return BootstrapComputationFamily.DAY_OF_YEAR_PERCENTILE_VALUE_AGGREGATE
 
 
 def _classify_bootstrap_reducer_kind(
@@ -386,6 +435,31 @@ def _uses_specialized_count_routing(
     if reducer_kind != BootstrapReducerKind.COUNT:
         return False
     if date_event or len(climate_vars) != 1 or inventory.has_bounded_threshold:
+        return False
+    threshold_spec = climate_vars[0].threshold
+    return isinstance(threshold_spec, PercentileThreshold) and bool(
+        inventory.required_percentile_thresholds
+    )
+
+
+def _uses_specialized_value_aggregate_routing(
+    *,
+    indicator_name: str,
+    reducer_kind: BootstrapReducerKind,
+    climate_vars: list[ClimateVariable],
+    date_event: bool,
+    inventory: BootstrapThresholdInventory,
+) -> bool:
+    if indicator_name != "fraction_of_total":
+        return False
+    if reducer_kind != BootstrapReducerKind.VALUE_AGGREGATE:
+        return False
+    if (
+        date_event
+        or len(climate_vars) != 1
+        or inventory.has_bounded_threshold
+        or inventory.has_filtered_percentile
+    ):
         return False
     threshold_spec = climate_vars[0].threshold
     return isinstance(threshold_spec, PercentileThreshold) and bool(

--- a/src/icclim/_core/generic/bootstrap_capability.py
+++ b/src/icclim/_core/generic/bootstrap_capability.py
@@ -450,7 +450,7 @@ def _uses_specialized_value_aggregate_routing(
     date_event: bool,
     inventory: BootstrapThresholdInventory,
 ) -> bool:
-    if indicator_name != "fraction_of_total":
+    if indicator_name not in {"fraction_of_total", "sum"}:
         return False
     if reducer_kind != BootstrapReducerKind.VALUE_AGGREGATE:
         return False

--- a/src/icclim/_core/generic/bootstrap_capability.py
+++ b/src/icclim/_core/generic/bootstrap_capability.py
@@ -450,7 +450,7 @@ def _uses_specialized_value_aggregate_routing(
     date_event: bool,
     inventory: BootstrapThresholdInventory,
 ) -> bool:
-    if indicator_name not in {"fraction_of_total", "sum"}:
+    if indicator_name not in {"average", "fraction_of_total", "sum"}:
         return False
     if reducer_kind != BootstrapReducerKind.VALUE_AGGREGATE:
         return False

--- a/src/icclim/_core/generic/bootstrap_primitives.py
+++ b/src/icclim/_core/generic/bootstrap_primitives.py
@@ -136,6 +136,8 @@ def build_bootstrap_reference_sample(
 
 def build_bootstrap_array_inputs(
     reference_sample: BootstrapReferenceSample,
+    *,
+    dtype: np.dtype = np.float64,
 ) -> BootstrapArrayInputs:
     """Build flattened arrays consumed by optimized bootstrap kernels."""
     study = reference_sample.study.transpose("time", ...)
@@ -144,17 +146,17 @@ def build_bootstrap_array_inputs(
         "time", ...
     )
     return BootstrapArrayInputs(
-        flat_study=np.asarray(study.data, dtype=np.float64).reshape(
+        flat_study=np.asarray(study.data, dtype=dtype).reshape(
             study.sizes["time"],
             -1,
         ),
-        flat_reference_raw=np.asarray(reference_raw.data, dtype=np.float64).reshape(
+        flat_reference_raw=np.asarray(reference_raw.data, dtype=dtype).reshape(
             reference_raw.sizes["time"],
             -1,
         ),
         flat_reference_filtered=np.asarray(
             reference_filtered.data,
-            dtype=np.float64,
+            dtype=dtype,
         ).reshape(
             reference_filtered.sizes["time"],
             -1,

--- a/src/icclim/_core/generic/bootstrap_primitives.py
+++ b/src/icclim/_core/generic/bootstrap_primitives.py
@@ -1,0 +1,343 @@
+"""Reusable threshold and indexing helpers for percentile bootstrap.
+
+These helpers keep bootstrap workflow steps visible in domain language:
+
+1. build the reference sample used by bootstrap;
+2. build the temporal indexing needed by bootstrap kernels;
+3. let family-specific implementations focus on their own reducer logic.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    import pandas as pd
+    from xarray import DataArray
+
+    from icclim._core.generic.threshold.percentile import PercentileThreshold
+
+
+LEAP_YEAR_DAY_COUNT = 366
+
+
+@dataclass(frozen=True)
+class BootstrapReferenceSample:
+    """Reference-period data prepared for bootstrap threshold generation."""
+
+    study: DataArray
+    climatology_bounds: tuple[str, str]
+    reference_sample: DataArray
+    filtered_reference_sample: DataArray
+    threshold_floor_in_reference_units: float | None
+
+
+@dataclass(frozen=True)
+class BootstrapTemporalIndexing:
+    """Year and resampling indexes shared by bootstrap implementations."""
+
+    reference_year_indices: dict[int, np.ndarray]
+    study_year_indices: dict[int, np.ndarray]
+    output_group_indices: dict[np.datetime64, np.ndarray]
+    output_group_labels: list[np.datetime64]
+    output_starts: np.ndarray
+    output_lengths: np.ndarray
+    output_years: np.ndarray
+    bootstrap_years: np.ndarray
+    year_group_starts: np.ndarray
+    year_group_stops: np.ndarray
+    year_max_day_of_years: np.ndarray
+    year_to_reference_index: np.ndarray
+    study_day_of_years: np.ndarray
+    sample_indices_by_day_of_year: np.ndarray
+    reference_index_year: np.ndarray
+    reference_index_position: np.ndarray
+    substitute_alignment: np.ndarray
+
+
+@dataclass(frozen=True)
+class BootstrapArrayInputs:
+    """Flattened arrays shared by optimized bootstrap kernels."""
+
+    flat_study: np.ndarray
+    flat_reference_raw: np.ndarray
+    flat_reference_filtered: np.ndarray
+    spatial_shape: tuple[int, ...]
+
+
+def build_bootstrap_reference_sample(
+    study: DataArray,
+    threshold: PercentileThreshold,
+) -> BootstrapReferenceSample:
+    """Load and prepare the reference-period sample for bootstrap."""
+    loaded_study = study.load()
+    climatology_bounds = threshold.climatology_bounds(loaded_study)
+    reference_sample = loaded_study.sel(time=slice(*climatology_bounds))
+    threshold_floor = _threshold_min_value_in_reference_units(
+        threshold,
+        reference_sample,
+    )
+    filtered_reference_sample = reference_sample
+    if threshold_floor is not None:
+        filtered_reference_sample = reference_sample.where(
+            reference_sample >= threshold_floor,
+            np.nan,
+        )
+    return BootstrapReferenceSample(
+        study=loaded_study,
+        climatology_bounds=climatology_bounds,
+        reference_sample=reference_sample,
+        filtered_reference_sample=filtered_reference_sample,
+        threshold_floor_in_reference_units=threshold_floor,
+    )
+
+
+def build_bootstrap_array_inputs(
+    reference_sample: BootstrapReferenceSample,
+) -> BootstrapArrayInputs:
+    """Build flattened arrays consumed by optimized bootstrap kernels."""
+    study = reference_sample.study.transpose("time", ...)
+    reference_raw = reference_sample.reference_sample.transpose("time", ...)
+    reference_filtered = reference_sample.filtered_reference_sample.transpose(
+        "time", ...
+    )
+    return BootstrapArrayInputs(
+        flat_study=np.asarray(study.data, dtype=np.float64).reshape(
+            study.sizes["time"],
+            -1,
+        ),
+        flat_reference_raw=np.asarray(reference_raw.data, dtype=np.float64).reshape(
+            reference_raw.sizes["time"],
+            -1,
+        ),
+        flat_reference_filtered=np.asarray(
+            reference_filtered.data,
+            dtype=np.float64,
+        ).reshape(
+            reference_filtered.sizes["time"],
+            -1,
+        ),
+        spatial_shape=study.shape[1:],
+    )
+
+
+def build_bootstrap_temporal_indexing(
+    study: DataArray,
+    reference_sample: DataArray,
+    freq: str,
+    *,
+    doy_window_width: int,
+) -> BootstrapTemporalIndexing:
+    """Build year and grouping indexes shared by bootstrap kernels."""
+    study_time = study.indexes["time"]
+    reference_time = reference_sample.indexes["time"]
+    reference_year_indices = indices_by_year(reference_time)
+    study_year_indices = indices_by_year(study_time)
+    reference_years = np.asarray(list(reference_year_indices), dtype=np.int64)
+    output_group_indices = indices_by_resample_group(study, freq)
+    output_group_labels = list(output_group_indices)
+    output_starts = np.asarray(
+        [indices[0] for indices in output_group_indices.values()],
+        dtype=np.int64,
+    )
+    output_lengths = np.asarray(
+        [len(indices) for indices in output_group_indices.values()],
+        dtype=np.int64,
+    )
+    source_max_day_of_year = int(reference_time.dayofyear.max())
+    study_year_max_day_of_year = {
+        year: source_max_day_of_year
+        if source_max_day_of_year == LEAP_YEAR_DAY_COUNT
+        else int(study_time[indices].dayofyear.max())
+        for year, indices in study_year_indices.items()
+    }
+    output_years = np.asarray(
+        [int(study_time[indices[0]].year) for indices in output_group_indices.values()],
+        dtype=np.int64,
+    )
+    bootstrap_years = np.asarray(list(dict.fromkeys(output_years)), dtype=np.int64)
+    year_group_starts, year_group_stops = group_bounds_by_year(
+        output_years,
+        bootstrap_years,
+    )
+    year_max_day_of_years = np.asarray(
+        [study_year_max_day_of_year[year] for year in bootstrap_years],
+        dtype=np.int64,
+    )
+    year_to_reference_index = np.asarray(
+        [
+            int(np.where(reference_years == year)[0][0])
+            if year in reference_year_indices
+            else -1
+            for year in bootstrap_years
+        ],
+        dtype=np.int64,
+    )
+    sample_indices_by_day_of_year = rolling_sample_index_matrix(
+        reference_time,
+        window=doy_window_width,
+    )
+    reference_index_year, reference_index_position = ref_index_year_and_position(
+        reference_year_indices,
+        len(reference_time),
+    )
+    substitute_alignment = substitute_alignment_matrix(
+        reference_time,
+        reference_year_indices,
+    )
+    return BootstrapTemporalIndexing(
+        reference_year_indices=reference_year_indices,
+        study_year_indices=study_year_indices,
+        output_group_indices=output_group_indices,
+        output_group_labels=output_group_labels,
+        output_starts=output_starts,
+        output_lengths=output_lengths,
+        output_years=output_years,
+        bootstrap_years=bootstrap_years,
+        year_group_starts=year_group_starts,
+        year_group_stops=year_group_stops,
+        year_max_day_of_years=year_max_day_of_years,
+        year_to_reference_index=year_to_reference_index,
+        study_day_of_years=study_time.dayofyear.to_numpy(dtype=np.int64),
+        sample_indices_by_day_of_year=sample_indices_by_day_of_year,
+        reference_index_year=reference_index_year,
+        reference_index_position=reference_index_position,
+        substitute_alignment=substitute_alignment,
+    )
+
+
+def indices_by_year(time: pd.DatetimeIndex) -> dict[int, np.ndarray]:
+    return {int(year): np.where(time.year == year)[0] for year in np.unique(time.year)}
+
+
+def indices_by_resample_group(
+    da: DataArray,
+    freq: str,
+) -> dict[np.datetime64, np.ndarray]:
+    groups = da.resample(time=freq).groups
+    out: dict[np.datetime64, np.ndarray] = {}
+    for label, indexer in groups.items():
+        if isinstance(indexer, slice):
+            start = 0 if indexer.start is None else indexer.start
+            stop = da.sizes["time"] if indexer.stop is None else indexer.stop
+            step = 1 if indexer.step is None else indexer.step
+            indices = np.arange(start, stop, step, dtype=np.int64)
+        else:
+            indices = np.asarray(indexer, dtype=np.int64)
+        out[np.datetime64(label)] = indices
+    return out
+
+
+def group_bounds_by_year(
+    output_years: np.ndarray,
+    bootstrap_years: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    starts = np.empty(len(bootstrap_years), dtype=np.int64)
+    stops = np.empty(len(bootstrap_years), dtype=np.int64)
+    for i, year in enumerate(bootstrap_years):
+        group_indices = np.where(output_years == year)[0]
+        starts[i] = int(group_indices[0])
+        stops[i] = int(group_indices[-1]) + 1
+    return starts, stops
+
+
+def rolling_sample_index_matrix(
+    time: pd.DatetimeIndex,
+    *,
+    window: int,
+) -> np.ndarray:
+    half_window = window // 2
+    sample_indices: dict[int, list[int]] = {doy: [] for doy in range(1, 366)}
+    day_of_years = time.dayofyear.to_numpy()
+    for center, day_of_year in enumerate(day_of_years):
+        if day_of_year == LEAP_YEAR_DAY_COUNT:
+            continue
+        start = max(0, center - half_window)
+        stop = min(len(time), center + half_window + 1)
+        sample_indices[int(day_of_year)].extend(range(start, stop))
+    max_samples = max(len(indices) for indices in sample_indices.values())
+    matrix = np.full((365, max_samples), -1, dtype=np.int64)
+    for day_of_year, indices in sample_indices.items():
+        matrix[day_of_year - 1, : len(indices)] = indices
+    return matrix
+
+
+def ref_index_year_and_position(
+    reference_year_indices: dict[int, np.ndarray],
+    n_reference_time: int,
+) -> tuple[np.ndarray, np.ndarray]:
+    index_year = np.full(n_reference_time, -1, dtype=np.int64)
+    index_position = np.full(n_reference_time, -1, dtype=np.int64)
+    for year_index, indices in enumerate(reference_year_indices.values()):
+        index_year[indices] = year_index
+        index_position[indices] = np.arange(len(indices), dtype=np.int64)
+    return index_year, index_position
+
+
+def substitute_alignment_matrix(
+    reference_time: pd.DatetimeIndex,
+    reference_year_indices: dict[int, np.ndarray],
+) -> np.ndarray:
+    max_year_length = max(len(indices) for indices in reference_year_indices.values())
+    n_years = len(reference_year_indices)
+    aligned = np.full((n_years, n_years, max_year_length), -1, dtype=np.int64)
+    years = list(reference_year_indices)
+    for target_index, target_year in enumerate(years):
+        target_indices = reference_year_indices[target_year]
+        target_time = reference_time[target_indices]
+        for substitute_index, substitute_year in enumerate(years):
+            substitute_indices = reference_year_indices[substitute_year]
+            aligned[target_index, substitute_index, : len(target_indices)] = (
+                substitute_indices_aligned_to_target(
+                    target_time,
+                    reference_time[substitute_indices],
+                    substitute_indices,
+                )
+            )
+    return aligned
+
+
+def substitute_indices_aligned_to_target(
+    target_time: pd.DatetimeIndex,
+    substitute_time: pd.DatetimeIndex,
+    substitute_indices: np.ndarray,
+) -> np.ndarray:
+    if len(target_time) == len(substitute_time):
+        return substitute_indices
+    substitute_by_month_day = {
+        (int(month), int(day)): int(index)
+        for month, day, index in zip(
+            substitute_time.month,
+            substitute_time.day,
+            substitute_indices,
+            strict=True,
+        )
+    }
+    return np.asarray(
+        [
+            substitute_by_month_day.get((int(month), int(day)), -1)
+            for month, day in zip(target_time.month, target_time.day, strict=True)
+        ],
+        dtype=np.int64,
+    )
+
+
+def _threshold_min_value_in_reference_units(
+    threshold: PercentileThreshold,
+    reference_sample: DataArray,
+) -> float | None:
+    if threshold.threshold_min_value is None:
+        return None
+    from xclim.core.units import convert_units_to  # noqa: PLC0415
+
+    converted = convert_units_to(
+        threshold.threshold_min_value,
+        reference_sample,
+        context="hydro",
+    )
+    if hasattr(converted, "magnitude"):
+        return float(converted.magnitude)
+    return float(converted)

--- a/src/icclim/_core/generic/bootstrap_primitives.py
+++ b/src/icclim/_core/generic/bootstrap_primitives.py
@@ -68,6 +68,45 @@ class BootstrapArrayInputs:
     spatial_shape: tuple[int, ...]
 
 
+def build_bootstrap_output(
+    *,
+    flat_result: np.ndarray,
+    reference_sample: BootstrapReferenceSample,
+    temporal_indexing: BootstrapTemporalIndexing,
+    spatial_shape: tuple[int, ...],
+    units: str,
+) -> DataArray:
+    """Rebuild an xarray result from bootstrap kernel output."""
+    import xarray as xr  # noqa: PLC0415
+
+    data = flat_result.reshape(
+        (len(temporal_indexing.output_group_labels), *spatial_shape)
+    )
+    output = xr.DataArray(
+        data,
+        dims=reference_sample.study.dims,
+        coords={
+            "time": temporal_indexing.output_group_labels,
+            **{
+                coord: reference_sample.study.coords[coord]
+                for coord in reference_sample.study.dims
+                if coord != "time"
+            },
+        },
+        attrs={
+            "units": units,
+            "climatology_bounds": reference_sample.climatology_bounds,
+        },
+    )
+    for coord in reference_sample.study.coords:
+        if (
+            coord not in output.coords
+            and "time" not in reference_sample.study[coord].dims
+        ):
+            output = output.assign_coords({coord: reference_sample.study[coord]})
+    return output
+
+
 def build_bootstrap_reference_sample(
     study: DataArray,
     threshold: PercentileThreshold,

--- a/src/icclim/_core/generic/functions.py
+++ b/src/icclim/_core/generic/functions.py
@@ -48,6 +48,7 @@ from icclim._core.constants import (
     UNITS_KEY,
 )
 from icclim._core.generic.bootstrap_capability import (
+    BootstrapCapability,
     BootstrapExecutionKind,
     classify_doy_percentile_count_bootstrap,
     classify_generic_indicator_bootstrap,
@@ -465,7 +466,7 @@ def fraction_of_total(
     the units will be set to "%". Otherwise, the units will be set to the value of
     PART_OF_A_WHOLE_UNIT, which is 1.
     """
-    _note_generic_bootstrap_capability(
+    bootstrap_capability = _note_generic_bootstrap_capability(
         indicator_name="fraction_of_total",
         climate_vars=climate_vars,
         resample_freq=resample_freq,
@@ -474,6 +475,31 @@ def fraction_of_total(
     if threshold is None:
         msg = "No threshold found"
         raise InvalidIcclimArgumentError(msg)
+    if (
+        bootstrap_capability.uses_optimized_bootstrap
+        and threshold.threshold_min_value is None
+    ):
+        optimized_over = _compute_fast_tiled_bootstrap_exceedance_sum(
+            climate_vars[0],
+            threshold,
+            resample_freq,
+            _get_fast_bootstrap_max_cells(study),
+        )
+        if optimized_over is not None:
+            total = (
+                study.resample(time=resample_freq.pandas_freq).sum(dim="time").load()
+            )
+            res = optimized_over / total
+            if REFERENCE_PERIOD_ID in optimized_over.attrs:
+                res.attrs[REFERENCE_PERIOD_ID] = optimized_over.attrs[
+                    REFERENCE_PERIOD_ID
+                ]
+            if to_percent:
+                res = res * 100
+                res.attrs[UNITS_KEY] = "%"
+            else:
+                res.attrs[UNITS_KEY] = PART_OF_A_WHOLE_UNIT
+            return res
     if threshold.threshold_min_value is not None:
         min_val = threshold.threshold_min_value
         from xclim.core.units import convert_units_to  # noqa: PLC0415
@@ -1299,7 +1325,7 @@ def _note_generic_bootstrap_capability(
     climate_vars: list[ClimateVariable],
     resample_freq: Frequency,
     date_event: bool = False,
-) -> None:
+) -> BootstrapCapability:
     capability = classify_generic_indicator_bootstrap(
         indicator_name=indicator_name,
         climate_vars=climate_vars,
@@ -1318,6 +1344,7 @@ def _note_generic_bootstrap_capability(
         "bootstrap_family",
         capability.family.value,
     )
+    return capability
 
 
 def _compute_safe_tiled_count_occurrences(  # noqa: C901
@@ -1481,6 +1508,45 @@ def _compute_fast_tiled_count_occurrences(
     _profile_bootstrap_add(
         "bootstrap_optimized_total_seconds",
         perf_counter() - fast_start,
+    )
+    return result
+
+
+def _compute_fast_tiled_bootstrap_exceedance_sum(
+    climate_var: ClimateVariable,
+    threshold: PercentileThreshold,
+    resample_freq: Frequency,
+    max_cells: int,
+) -> DataArray | None:
+    from icclim._core.generic.bootstrap import (  # noqa: PLC0415
+        compute_doy_percentile_bootstrap_exceedance_sum,
+    )
+
+    optimized_start = perf_counter()
+    tile_results: list[DataArray] = []
+    for tile_indexers in _iter_spatial_tiles(climate_var.studied_data, max_cells):
+        tile_study = climate_var.studied_data.isel(tile_indexers)
+        tile_threshold = _slice_threshold_for_tile(threshold, tile_indexers)
+        tile_result = compute_doy_percentile_bootstrap_exceedance_sum(
+            tile_study,
+            tile_threshold,
+            resample_freq.pandas_freq,
+        )
+        if tile_result is None:
+            return None
+        tile_results.append(tile_result)
+        _profile_bootstrap_inc("bootstrap_optimized_tile_count")
+    if len(tile_results) == 1:
+        result = tile_results[0]
+    else:
+        result = xr.combine_by_coords(
+            [tile.to_dataset(name="__icclim_bootstrap_tile") for tile in tile_results],
+            combine_attrs="override",
+        )["__icclim_bootstrap_tile"]
+    result.attrs.update(tile_results[-1].attrs)
+    _profile_bootstrap_add(
+        "bootstrap_optimized_total_seconds",
+        perf_counter() - optimized_start,
     )
     return result
 

--- a/src/icclim/_core/generic/functions.py
+++ b/src/icclim/_core/generic/functions.py
@@ -731,6 +731,26 @@ def generic_sum(
     >>> int(result["sum"].isel(time=0).values)
     730
     """
+    bootstrap_capability = _note_generic_bootstrap_capability(
+        indicator_name="sum",
+        climate_vars=climate_vars,
+        resample_freq=resample_freq,
+    )
+    study, threshold = get_single_var(climate_vars)
+    if (
+        threshold is not None
+        and bootstrap_capability.uses_optimized_bootstrap
+        and threshold.threshold_min_value is None
+        and not _is_rate(study)
+    ):
+        optimized_sum = _compute_fast_tiled_bootstrap_exceedance_sum(
+            climate_vars[0],
+            threshold,
+            resample_freq,
+            _get_fast_bootstrap_max_cells(study),
+        )
+        if optimized_sum is not None:
+            return optimized_sum
     return _run_simple_reducer(
         climate_vars=climate_vars,
         resample_freq=resample_freq,

--- a/src/icclim/_core/generic/functions.py
+++ b/src/icclim/_core/generic/functions.py
@@ -479,21 +479,14 @@ def fraction_of_total(
         bootstrap_capability.uses_optimized_bootstrap
         and threshold.threshold_min_value is None
     ):
-        optimized_over = _compute_fast_tiled_bootstrap_exceedance_sum(
+        optimized_fraction = _compute_fast_tiled_bootstrap_fraction_of_total(
             climate_vars[0],
             threshold,
             resample_freq,
             _get_fast_bootstrap_max_cells(study),
         )
-        if optimized_over is not None:
-            total = (
-                study.resample(time=resample_freq.pandas_freq).sum(dim="time").load()
-            )
-            res = optimized_over / total
-            if REFERENCE_PERIOD_ID in optimized_over.attrs:
-                res.attrs[REFERENCE_PERIOD_ID] = optimized_over.attrs[
-                    REFERENCE_PERIOD_ID
-                ]
+        if optimized_fraction is not None:
+            res = optimized_fraction
             if to_percent:
                 res = res * 100
                 res.attrs[UNITS_KEY] = "%"
@@ -693,22 +686,14 @@ def average(
         and bootstrap_capability.uses_optimized_bootstrap
         and threshold.threshold_min_value is None
     ):
-        optimized_sum = _compute_fast_tiled_bootstrap_exceedance_sum(
+        optimized_average = _compute_fast_tiled_bootstrap_exceedance_average(
             climate_vars[0],
             threshold,
             resample_freq,
             _get_fast_bootstrap_max_cells(study),
         )
-        optimized_count = _compute_fast_tiled_bootstrap_union_exceedance_count(
-            climate_vars[0],
-            threshold,
-            resample_freq,
-            _get_fast_bootstrap_max_cells(study),
-        )
-        if optimized_sum is not None and optimized_count is not None:
-            return (optimized_sum / optimized_count.where(optimized_count != 0)).astype(
-                study.dtype,
-            )
+        if optimized_average is not None:
+            return optimized_average
     return _run_simple_reducer(
         climate_vars=climate_vars,
         resample_freq=resample_freq,
@@ -1578,19 +1563,38 @@ def _compute_fast_tiled_bootstrap_exceedance_sum(
     )
 
 
-def _compute_fast_tiled_bootstrap_union_exceedance_count(
+def _compute_fast_tiled_bootstrap_exceedance_average(
     climate_var: ClimateVariable,
     threshold: PercentileThreshold,
     resample_freq: Frequency,
     max_cells: int,
 ) -> DataArray | None:
     from icclim._core.generic.bootstrap import (  # noqa: PLC0415
-        compute_doy_percentile_bootstrap_union_exceedance_count,
+        compute_doy_percentile_bootstrap_exceedance_average,
     )
 
     return _compute_fast_tiled_bootstrap_reducer(
         climate_var,
-        reducer=compute_doy_percentile_bootstrap_union_exceedance_count,
+        reducer=compute_doy_percentile_bootstrap_exceedance_average,
+        threshold=threshold,
+        resample_freq=resample_freq,
+        max_cells=max_cells,
+    )
+
+
+def _compute_fast_tiled_bootstrap_fraction_of_total(
+    climate_var: ClimateVariable,
+    threshold: PercentileThreshold,
+    resample_freq: Frequency,
+    max_cells: int,
+) -> DataArray | None:
+    from icclim._core.generic.bootstrap import (  # noqa: PLC0415
+        compute_doy_percentile_bootstrap_fraction_of_total,
+    )
+
+    return _compute_fast_tiled_bootstrap_reducer(
+        climate_var,
+        reducer=compute_doy_percentile_bootstrap_fraction_of_total,
         threshold=threshold,
         resample_freq=resample_freq,
         max_cells=max_cells,

--- a/src/icclim/_core/generic/functions.py
+++ b/src/icclim/_core/generic/functions.py
@@ -682,6 +682,33 @@ def average(
     >>> round(float(result.average.isel(time=0).values), 2)
     20.0
     """
+    bootstrap_capability = _note_generic_bootstrap_capability(
+        indicator_name="average",
+        climate_vars=climate_vars,
+        resample_freq=resample_freq,
+    )
+    study, threshold = get_single_var(climate_vars)
+    if (
+        threshold is not None
+        and bootstrap_capability.uses_optimized_bootstrap
+        and threshold.threshold_min_value is None
+    ):
+        optimized_sum = _compute_fast_tiled_bootstrap_exceedance_sum(
+            climate_vars[0],
+            threshold,
+            resample_freq,
+            _get_fast_bootstrap_max_cells(study),
+        )
+        optimized_count = _compute_fast_tiled_bootstrap_union_exceedance_count(
+            climate_vars[0],
+            threshold,
+            resample_freq,
+            _get_fast_bootstrap_max_cells(study),
+        )
+        if optimized_sum is not None and optimized_count is not None:
+            return (optimized_sum / optimized_count.where(optimized_count != 0)).astype(
+                study.dtype,
+            )
     return _run_simple_reducer(
         climate_vars=climate_vars,
         resample_freq=resample_freq,
@@ -1545,6 +1572,25 @@ def _compute_fast_tiled_bootstrap_exceedance_sum(
     return _compute_fast_tiled_bootstrap_reducer(
         climate_var,
         reducer=compute_doy_percentile_bootstrap_exceedance_sum,
+        threshold=threshold,
+        resample_freq=resample_freq,
+        max_cells=max_cells,
+    )
+
+
+def _compute_fast_tiled_bootstrap_union_exceedance_count(
+    climate_var: ClimateVariable,
+    threshold: PercentileThreshold,
+    resample_freq: Frequency,
+    max_cells: int,
+) -> DataArray | None:
+    from icclim._core.generic.bootstrap import (  # noqa: PLC0415
+        compute_doy_percentile_bootstrap_union_exceedance_count,
+    )
+
+    return _compute_fast_tiled_bootstrap_reducer(
+        climate_var,
+        reducer=compute_doy_percentile_bootstrap_union_exceedance_count,
         threshold=threshold,
         resample_freq=resample_freq,
         max_cells=max_cells,

--- a/src/icclim/_core/generic/functions.py
+++ b/src/icclim/_core/generic/functions.py
@@ -1542,12 +1542,28 @@ def _compute_fast_tiled_bootstrap_exceedance_sum(
         compute_doy_percentile_bootstrap_exceedance_sum,
     )
 
+    return _compute_fast_tiled_bootstrap_reducer(
+        climate_var,
+        reducer=compute_doy_percentile_bootstrap_exceedance_sum,
+        threshold=threshold,
+        resample_freq=resample_freq,
+        max_cells=max_cells,
+    )
+
+
+def _compute_fast_tiled_bootstrap_reducer(
+    climate_var: ClimateVariable,
+    reducer: Callable[[DataArray, PercentileThreshold, str], DataArray | None],
+    threshold: PercentileThreshold,
+    resample_freq: Frequency,
+    max_cells: int,
+) -> DataArray | None:
     optimized_start = perf_counter()
     tile_results: list[DataArray] = []
     for tile_indexers in _iter_spatial_tiles(climate_var.studied_data, max_cells):
         tile_study = climate_var.studied_data.isel(tile_indexers)
         tile_threshold = _slice_threshold_for_tile(threshold, tile_indexers)
-        tile_result = compute_doy_percentile_bootstrap_exceedance_sum(
+        tile_result = reducer(
             tile_study,
             tile_threshold,
             resample_freq.pandas_freq,

--- a/tests/test_bootstrap_capability.py
+++ b/tests/test_bootstrap_capability.py
@@ -196,7 +196,7 @@ def test_bounded_threshold_is_not_routed_through_count_fast_path() -> None:
     assert decision.reason_code == "threshold_is_compound"
 
 
-def test_generic_fraction_of_total_routes_to_reference_bootstrap() -> None:
+def test_generic_filtered_fraction_of_total_routes_to_reference_bootstrap() -> None:
     pr = stub_tas(5.0).rename("pr")
     pr.attrs["units"] = "mm/day"
     pr = pr.chunk({"time": 365, "lat": 1, "lon": 1})
@@ -221,6 +221,31 @@ def test_generic_fraction_of_total_routes_to_reference_bootstrap() -> None:
     )
     assert decision.execution_kind == BootstrapExecutionKind.REFERENCE_BOOTSTRAP
     assert decision.reason_code == "value_aggregate_uses_reference_bootstrap_path"
+
+
+def test_generic_fraction_of_total_routes_to_optimized_bootstrap() -> None:
+    tas = stub_tas(27 + K2C).chunk({"time": 365, "lat": 1, "lon": 1})
+    climate_var = _build_climate_variable(
+        tas,
+        {
+            "query": "> 90 doy_per",
+            "doy_window_width": 1,
+            "reference_period": ("2042-01-01", "2043-12-31"),
+        },
+    )
+
+    decision = classify_generic_indicator_bootstrap(
+        indicator_name="fraction_of_total",
+        climate_vars=[climate_var],
+        resample_frequency=FrequencyRegistry.YEAR,
+    )
+
+    assert (
+        decision.family
+        == BootstrapComputationFamily.DAY_OF_YEAR_PERCENTILE_VALUE_AGGREGATE
+    )
+    assert decision.execution_kind == BootstrapExecutionKind.OPTIMIZED_BOOTSTRAP
+    assert decision.reason_code == "optimized_bootstrap_supported"
 
 
 def test_generic_spell_routes_to_reference_bootstrap() -> None:

--- a/tests/test_bootstrap_primitives.py
+++ b/tests/test_bootstrap_primitives.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+from icclim._core.generic.bootstrap_primitives import (
+    build_bootstrap_array_inputs,
+    build_bootstrap_reference_sample,
+    build_bootstrap_temporal_indexing,
+    substitute_indices_aligned_to_target,
+)
+from icclim.threshold.factory import build_threshold
+from tests.testing_utils import stub_pr, stub_tas
+
+
+def test_build_bootstrap_reference_sample_applies_threshold_floor() -> None:
+    pr = stub_pr(0.0)
+    pr[1:] = 2.0e-5
+    threshold = build_threshold("> 90 doy_per", threshold_min_value="1 mm/day")
+
+    reference_sample = build_bootstrap_reference_sample(pr, threshold)
+
+    assert reference_sample.climatology_bounds == ["2042-01-01", "2046-12-31"]
+    assert reference_sample.threshold_floor_in_reference_units is not None
+    assert np.isnan(reference_sample.filtered_reference_sample.isel(time=0).item())
+    assert not np.isnan(reference_sample.filtered_reference_sample.isel(time=1).item())
+    xr.testing.assert_identical(
+        reference_sample.reference_sample, reference_sample.study
+    )
+
+
+def test_build_bootstrap_temporal_indexing_tracks_years_and_groups() -> None:
+    tas = stub_tas()
+    threshold = build_threshold("> 90 doy_per")
+    reference_sample = build_bootstrap_reference_sample(tas, threshold)
+
+    temporal_indexing = build_bootstrap_temporal_indexing(
+        reference_sample.study,
+        reference_sample.reference_sample,
+        "MS",
+        doy_window_width=threshold.doy_window_width,
+    )
+
+    np.testing.assert_array_equal(
+        temporal_indexing.bootstrap_years,
+        np.asarray([2042, 2043, 2044, 2045, 2046]),
+    )
+    assert len(temporal_indexing.output_group_labels) == 60
+    assert int(temporal_indexing.output_lengths.sum()) == tas.sizes["time"]
+    np.testing.assert_array_equal(
+        temporal_indexing.year_to_reference_index,
+        np.asarray([0, 1, 2, 3, 4]),
+    )
+    assert temporal_indexing.sample_indices_by_day_of_year.shape[0] == 365
+    assert temporal_indexing.reference_index_year.shape == (tas.sizes["time"],)
+    assert temporal_indexing.reference_index_position.shape == (tas.sizes["time"],)
+    assert temporal_indexing.substitute_alignment.shape[:2] == (5, 5)
+
+
+def test_build_bootstrap_array_inputs_flattens_study_and_reference() -> None:
+    tas = stub_tas(lat_length=2, lon_length=3)
+    threshold = build_threshold("> 90 doy_per")
+    reference_sample = build_bootstrap_reference_sample(tas, threshold)
+
+    array_inputs = build_bootstrap_array_inputs(reference_sample)
+
+    assert array_inputs.flat_study.shape == (tas.sizes["time"], 6)
+    assert array_inputs.flat_reference_raw.shape == (tas.sizes["time"], 6)
+    assert array_inputs.flat_reference_filtered.shape == (tas.sizes["time"], 6)
+    assert array_inputs.spatial_shape == (2, 3)
+
+
+def test_substitute_indices_aligned_to_target_marks_missing_february_29() -> None:
+    target_time = pd.DatetimeIndex(
+        ["2044-02-28", "2044-02-29", "2044-03-01"],
+    )
+    substitute_time = pd.DatetimeIndex(
+        ["2043-02-28", "2043-03-01"],
+    )
+    substitute_indices = np.asarray([10, 11], dtype=np.int64)
+
+    aligned = substitute_indices_aligned_to_target(
+        target_time,
+        substitute_time,
+        substitute_indices,
+    )
+
+    np.testing.assert_array_equal(
+        aligned,
+        np.asarray([10, -1, 11], dtype=np.int64),
+    )

--- a/tests/test_bootstrap_primitives.py
+++ b/tests/test_bootstrap_primitives.py
@@ -6,6 +6,7 @@ import xarray as xr
 
 from icclim._core.generic.bootstrap_primitives import (
     build_bootstrap_array_inputs,
+    build_bootstrap_output,
     build_bootstrap_reference_sample,
     build_bootstrap_temporal_indexing,
     substitute_indices_aligned_to_target,
@@ -90,3 +91,29 @@ def test_substitute_indices_aligned_to_target_marks_missing_february_29() -> Non
         aligned,
         np.asarray([10, -1, 11], dtype=np.int64),
     )
+
+
+def test_build_bootstrap_output_rebuilds_coordinates_and_attrs() -> None:
+    tas = stub_tas(lat_length=2, lon_length=1)
+    threshold = build_threshold("> 90 doy_per")
+    reference_sample = build_bootstrap_reference_sample(tas, threshold)
+    temporal_indexing = build_bootstrap_temporal_indexing(
+        reference_sample.study,
+        reference_sample.reference_sample,
+        "YS",
+        doy_window_width=threshold.doy_window_width,
+    )
+    flat_result = np.zeros((len(temporal_indexing.output_group_labels), 2), dtype=float)
+
+    output = build_bootstrap_output(
+        flat_result=flat_result,
+        reference_sample=reference_sample,
+        temporal_indexing=temporal_indexing,
+        spatial_shape=(2, 1),
+        units="d",
+    )
+
+    assert output.dims == ("time", "lat", "lon")
+    assert output.shape == (5, 2, 1)
+    assert output.attrs["units"] == "d"
+    assert output.attrs["climatology_bounds"] == ["2042-01-01", "2046-12-31"]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1541,6 +1541,70 @@ class TestIntegration:
             reference["sum"],
         )
 
+    def test_average__dask_percentile_bootstrap_uses_optimized_path(
+        self,
+        monkeypatch,
+    ) -> None:
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS", "1")
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_FAST_TILE_CELLS", "1")
+        tas = stub_tas(tas_value=27 + K2C).rename("tas")
+        tas = tas.chunk({"time": 365, "lat": 1, "lon": 1})
+
+        icclim.index(
+            in_files=tas,
+            var_name="tas",
+            index_name="average",
+            threshold=build_threshold(
+                "> 90 doy_per",
+                reference_period=("2042-01-01", "2043-12-31"),
+            ),
+            time_range=("2042-01-01", "2045-12-31"),
+            out_file=self.OUTPUT_FILE,
+            slice_mode="year",
+        ).compute()
+
+        profile = generic_functions.get_bootstrap_profile()
+        assert profile["bootstrap_execution_kind"] == "optimized_bootstrap"
+        assert profile["bootstrap_reason_code"] == "optimized_bootstrap_supported"
+        assert profile["bootstrap_family"] == "day_of_year_percentile_value_aggregate"
+
+    def test_average__optimized_bootstrap_matches_reference_on_overlap_years(
+        self,
+        monkeypatch,
+    ) -> None:
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS", "1")
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_FAST_TILE_CELLS", "1")
+        tas = stub_tas(tas_value=27 + K2C, lat_length=1, lon_length=1).rename("tas")
+        tas.loc[{"time": slice("2042-01-01", "2042-12-31")}] = 26 + K2C
+        tas.loc[{"time": slice("2043-01-01", "2043-12-31")}] = 30 + K2C
+        tas.loc[{"time": "2042-07-15"}] = 28 + K2C
+        tas.loc[{"time": "2043-07-15"}] = 28 + K2C
+        tas = tas.chunk({"time": 365, "lat": 1, "lon": 1})
+        common_kwargs = {
+            "in_files": tas,
+            "var_name": "tas",
+            "index_name": "average",
+            "threshold": build_threshold(
+                "> 90 doy_per",
+                doy_window_width=1,
+                reference_period=("2042-01-01", "2043-12-31"),
+            ),
+            "time_range": ("2042-01-01", "2045-12-31"),
+            "out_file": self.OUTPUT_FILE,
+            "slice_mode": "year",
+        }
+
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_MODE", "default")
+        reference = icclim.index(**common_kwargs).compute()
+        monkeypatch.delenv("ICCLIM_BOOTSTRAP_MODE")
+
+        optimized = icclim.index(**common_kwargs).compute()
+
+        xr.testing.assert_allclose(
+            optimized.average,
+            reference.average,
+        )
+
     def test_std(self) -> None:
         tas = stub_tas(tas_value=25 + K2C).rename("tas")
         res = icclim.index(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1440,6 +1440,43 @@ class TestIntegration:
             reference.fraction_of_total,
         )
 
+    def test_fraction_of_total__optimized_bootstrap_matches_reference_on_overlap_years(
+        self,
+        monkeypatch,
+    ) -> None:
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS", "1")
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_FAST_TILE_CELLS", "1")
+        tas = stub_tas(tas_value=27 + K2C, lat_length=1, lon_length=1).rename("tas")
+        tas.loc[{"time": slice("2042-01-01", "2042-12-31")}] = 26 + K2C
+        tas.loc[{"time": slice("2043-01-01", "2043-12-31")}] = 30 + K2C
+        tas.loc[{"time": "2042-07-15"}] = 28 + K2C
+        tas.loc[{"time": "2043-07-15"}] = 28 + K2C
+        tas = tas.chunk({"time": 365, "lat": 1, "lon": 1})
+        common_kwargs = {
+            "in_files": tas,
+            "var_name": "tas",
+            "index_name": "fraction_of_total",
+            "threshold": build_threshold(
+                "> 90 doy_per",
+                doy_window_width=1,
+                reference_period=("2042-01-01", "2043-12-31"),
+            ),
+            "time_range": ("2042-01-01", "2045-12-31"),
+            "out_file": self.OUTPUT_FILE,
+            "slice_mode": "year",
+        }
+
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_MODE", "default")
+        reference = icclim.index(**common_kwargs).compute()
+        monkeypatch.delenv("ICCLIM_BOOTSTRAP_MODE")
+
+        optimized = icclim.index(**common_kwargs).compute()
+
+        xr.testing.assert_allclose(
+            optimized.fraction_of_total,
+            reference.fraction_of_total,
+        )
+
     def test_std(self) -> None:
         tas = stub_tas(tas_value=25 + K2C).rename("tas")
         res = icclim.index(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1399,6 +1399,47 @@ class TestIntegration:
         assert res.fraction_of_total.isel(time=1) == 100
         assert res.fraction_of_total.attrs[UNITS_KEY] == "%"
 
+    def test_fraction_of_total__dask_percentile_bootstrap_uses_optimized_path(
+        self,
+        monkeypatch,
+    ) -> None:
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS", "1")
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_FAST_TILE_CELLS", "1")
+        tas = stub_tas(tas_value=27 + K2C, lat_length=2, lon_length=2).rename("tas")
+        tas[5:10] = 0
+        tas = tas.chunk({"time": 365, "lat": 1, "lon": 1})
+        common_kwargs = {
+            "in_files": tas,
+            "var_name": "tas",
+            "index_name": "fraction_of_total",
+            "threshold": build_threshold(
+                "> 90 doy_per",
+                doy_window_width=1,
+                reference_period=("2042-01-01", "2043-12-31"),
+            ),
+            "time_range": ("2042-01-01", "2045-12-31"),
+            "out_file": self.OUTPUT_FILE,
+            "slice_mode": "year",
+        }
+
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_MODE", "default")
+        reference = icclim.index(**common_kwargs).compute()
+        monkeypatch.delenv("ICCLIM_BOOTSTRAP_MODE")
+        generic_functions.reset_bootstrap_profile()
+
+        optimized = icclim.index(**common_kwargs)
+        profile = generic_functions.get_bootstrap_profile()
+
+        assert not hasattr(optimized.fraction_of_total.data, "__dask_graph__")
+        assert profile["bootstrap_execution_kind"] == "optimized_bootstrap"
+        assert profile["bootstrap_reason_code"] == "optimized_bootstrap_supported"
+        assert profile["bootstrap_family"] == "day_of_year_percentile_value_aggregate"
+        assert profile["bootstrap_optimized_tile_count"] == 4
+        xr.testing.assert_allclose(
+            optimized.fraction_of_total,
+            reference.fraction_of_total,
+        )
+
     def test_std(self) -> None:
         tas = stub_tas(tas_value=25 + K2C).rename("tas")
         res = icclim.index(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1477,6 +1477,70 @@ class TestIntegration:
             reference.fraction_of_total,
         )
 
+    def test_sum__dask_percentile_bootstrap_uses_optimized_path(
+        self,
+        monkeypatch,
+    ) -> None:
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS", "1")
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_FAST_TILE_CELLS", "1")
+        tas = stub_tas(tas_value=27 + K2C).rename("tas")
+        tas = tas.chunk({"time": 365, "lat": 1, "lon": 1})
+
+        icclim.index(
+            in_files=tas,
+            var_name="tas",
+            index_name="sum",
+            threshold=build_threshold(
+                "> 90 doy_per",
+                reference_period=("2042-01-01", "2043-12-31"),
+            ),
+            time_range=("2042-01-01", "2045-12-31"),
+            out_file=self.OUTPUT_FILE,
+            slice_mode="year",
+        ).compute()
+
+        profile = generic_functions.get_bootstrap_profile()
+        assert profile["bootstrap_execution_kind"] == "optimized_bootstrap"
+        assert profile["bootstrap_reason_code"] == "optimized_bootstrap_supported"
+        assert profile["bootstrap_family"] == "day_of_year_percentile_value_aggregate"
+
+    def test_sum__optimized_bootstrap_matches_reference_on_overlap_years(
+        self,
+        monkeypatch,
+    ) -> None:
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS", "1")
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_FAST_TILE_CELLS", "1")
+        tas = stub_tas(tas_value=27 + K2C, lat_length=1, lon_length=1).rename("tas")
+        tas.loc[{"time": slice("2042-01-01", "2042-12-31")}] = 26 + K2C
+        tas.loc[{"time": slice("2043-01-01", "2043-12-31")}] = 30 + K2C
+        tas.loc[{"time": "2042-07-15"}] = 28 + K2C
+        tas.loc[{"time": "2043-07-15"}] = 28 + K2C
+        tas = tas.chunk({"time": 365, "lat": 1, "lon": 1})
+        common_kwargs = {
+            "in_files": tas,
+            "var_name": "tas",
+            "index_name": "sum",
+            "threshold": build_threshold(
+                "> 90 doy_per",
+                doy_window_width=1,
+                reference_period=("2042-01-01", "2043-12-31"),
+            ),
+            "time_range": ("2042-01-01", "2045-12-31"),
+            "out_file": self.OUTPUT_FILE,
+            "slice_mode": "year",
+        }
+
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_MODE", "default")
+        reference = icclim.index(**common_kwargs).compute()
+        monkeypatch.delenv("ICCLIM_BOOTSTRAP_MODE")
+
+        optimized = icclim.index(**common_kwargs).compute()
+
+        xr.testing.assert_allclose(
+            optimized["sum"],
+            reference["sum"],
+        )
+
     def test_std(self) -> None:
         tas = stub_tas(tas_value=25 + K2C).rename("tas")
         res = icclim.index(

--- a/tools/run_real_data_validation.py
+++ b/tools/run_real_data_validation.py
@@ -183,6 +183,18 @@ def _build_workload(icclim, workload: str) -> xr.Dataset:
             time_range=TIME_RANGE,
             slice_mode="year",
         )
+    if workload == "generic_tas_sum_bootstrap_yearly":
+        tas = _open_var(TAS_GLOB, "tas")
+        return icclim.sum(
+            in_files=tas,
+            var_name="tas",
+            threshold=icclim.build_threshold(
+                "> 90 doy_per",
+                reference_period=BASE_PERIOD,
+            ),
+            time_range=TIME_RANGE,
+            slice_mode="year",
+        )
     if workload == "generic_tas_spell_bootstrap_yearly":
         tas = _open_var(TAS_GLOB, "tas")
         return icclim.sum_of_spell_lengths(

--- a/tools/run_real_data_validation.py
+++ b/tools/run_real_data_validation.py
@@ -171,6 +171,18 @@ def _build_workload(icclim, workload: str) -> xr.Dataset:
             time_range=TIME_RANGE,
             slice_mode="year",
         )
+    if workload == "generic_tas_fraction_bootstrap_yearly":
+        tas = _open_var(TAS_GLOB, "tas")
+        return icclim.fraction_of_total(
+            in_files=tas,
+            var_name="tas",
+            threshold=icclim.build_threshold(
+                "> 90 doy_per",
+                reference_period=BASE_PERIOD,
+            ),
+            time_range=TIME_RANGE,
+            slice_mode="year",
+        )
     if workload == "generic_tas_spell_bootstrap_yearly":
         tas = _open_var(TAS_GLOB, "tas")
         return icclim.sum_of_spell_lengths(

--- a/tools/run_real_data_validation.py
+++ b/tools/run_real_data_validation.py
@@ -195,6 +195,18 @@ def _build_workload(icclim, workload: str) -> xr.Dataset:
             time_range=TIME_RANGE,
             slice_mode="year",
         )
+    if workload == "generic_tas_average_bootstrap_yearly":
+        tas = _open_var(TAS_GLOB, "tas")
+        return icclim.average(
+            in_files=tas,
+            var_name="tas",
+            threshold=icclim.build_threshold(
+                "> 90 doy_per",
+                reference_period=BASE_PERIOD,
+            ),
+            time_range=TIME_RANGE,
+            slice_mode="year",
+        )
     if workload == "generic_tas_spell_bootstrap_yearly":
         tas = _open_var(TAS_GLOB, "tas")
         return icclim.sum_of_spell_lengths(

--- a/tools/summarize_real_data_validation.py
+++ b/tools/summarize_real_data_validation.py
@@ -151,6 +151,9 @@ def _workload_notes(workload: str) -> str:
         "generic_tas_fraction_bootstrap_yearly": (
             "unfiltered value aggregate; optimized fraction_of_total candidate"
         ),
+        "generic_tas_sum_bootstrap_yearly": (
+            "unfiltered value aggregate; optimized sum candidate"
+        ),
         "generic_tas_spell_bootstrap_yearly": (
             "spell reducer; raw v7.1.7 differs from current and master"
         ),

--- a/tools/summarize_real_data_validation.py
+++ b/tools/summarize_real_data_validation.py
@@ -148,6 +148,9 @@ def _workload_notes(workload: str) -> str:
         "generic_pr_fraction_bootstrap_yearly": (
             "filtered value aggregate; wet-day style threshold_min_value"
         ),
+        "generic_tas_fraction_bootstrap_yearly": (
+            "unfiltered value aggregate; optimized fraction_of_total candidate"
+        ),
         "generic_tas_spell_bootstrap_yearly": (
             "spell reducer; raw v7.1.7 differs from current and master"
         ),

--- a/tools/summarize_real_data_validation.py
+++ b/tools/summarize_real_data_validation.py
@@ -154,6 +154,9 @@ def _workload_notes(workload: str) -> str:
         "generic_tas_sum_bootstrap_yearly": (
             "unfiltered value aggregate; optimized sum candidate"
         ),
+        "generic_tas_average_bootstrap_yearly": (
+            "unfiltered value aggregate; optimized average candidate"
+        ),
         "generic_tas_spell_bootstrap_yearly": (
             "spell reducer; raw v7.1.7 differs from current and master"
         ),


### PR DESCRIPTION
## Summary
- extend optimized bootstrap value-aggregate routing to exact `average` for unfiltered day-of-year percentile thresholds
- replace the two-pass optimized `average` path with a single compiled reducer that reuses one threshold-generation pass
- replace the mixed optimized/xarray `fraction_of_total` path with a single compiled reducer for numerator and total
- keep the validated bootstrap architecture note aligned with the current exact optimized boundary

## Validation
Local:
- `pytest -q tests/test_bootstrap_capability.py tests/test_generic_functions.py tests/test_main.py -k 'average or sum or fraction_of_total or bootstrap'`
- `pre-commit run --files src/icclim/_core/generic/bootstrap.py src/icclim/_core/generic/bootstrap_capability.py src/icclim/_core/generic/functions.py tests/test_main.py tools/run_real_data_validation.py tools/summarize_real_data_validation.py doc/source/dev/bootstrap_architecture.rst`

Kraken real data on Friday, July 31, 2026:
- `generic_pr_fraction_bootstrap_yearly`: exact vs `master`, exact vs `v7.1.7`
- `generic_tas_fraction_bootstrap_yearly`: exact vs `master`, exact vs `v7.1.7`
- `generic_tas_sum_bootstrap_yearly`: exact vs `master`, exact vs `v7.1.7`
- `generic_tas_average_bootstrap_yearly`: exact vs `master`, exact vs `v7.1.7`

## Performance summary
Kraken real-data durations:
- `generic_pr_fraction_bootstrap_yearly`: `91.13s` current vs `90.87s` master
- `generic_tas_fraction_bootstrap_yearly`: `84.18s` current vs `110.98s` master
- `generic_tas_sum_bootstrap_yearly`: `83.78s` current vs `109.00s` master
- `generic_tas_average_bootstrap_yearly`: `84.22s` current vs `109.02s` master

So the three unfiltered optimized value-aggregate cases are now all about `1.3x` faster than the trusted baselines, while staying field-identical on real data.
