### PR TITLE
Extend validated wet-day bootstrap routing

### DIFF
--- a/doc/source/dev/bootstrap_architecture.rst
+++ b/doc/source/dev/bootstrap_architecture.rst
@@ -271,7 +271,7 @@ useful intermediate step because it makes the scientific boundary
 visible in code before more bootstrap families reuse the same threshold
 generation semantics.
 
-As of Friday, July 31, 2026, three non-count consumers of this shared
+As of Friday, July 31, 2026, three unfiltered non-count consumers of this shared
 threshold generation layer are validated on Kraken real data:
 
 - ``fraction_of_total`` for unfiltered day-of-year percentile bootstrap;
@@ -280,6 +280,20 @@ threshold generation layer are validated on Kraken real data:
 
 Those reducers are exact against the trusted baselines on real data.
 They currently define the validated optimized value-aggregate boundary.
+
+The same validation round also established the current filtered
+``threshold_min_value`` boundary on Kraken real data:
+
+- filtered day-of-year percentile ``count_occurrences`` is exact through
+  the exact tiled bootstrap path;
+- filtered day-of-year percentile ``average`` is exact through the exact
+  tiled bootstrap path;
+- filtered day-of-year percentile ``sum`` is exact through the optimized
+  path;
+- filtered ``fraction_of_total`` is exact through the optimized path.
+
+So filtered precipitation-style bootstrap support is no longer all-or-nothing.
+The validated boundary is now reducer-specific.
 
 The same validation round also showed that ``average`` cannot be
 derived naively from ``optimized_sum / optimized_count``. A first

--- a/doc/source/dev/percentile_bootstrap.rst
+++ b/doc/source/dev/percentile_bootstrap.rst
@@ -50,11 +50,12 @@ Unsupported cases
 Unsupported cases intentionally fall back to the safe tiled path. The
 most useful future extensions are likely:
 
-- percentile thresholds using ``threshold_min_value`` such as wet-day
-  precipitation counts; Kraken validation on July 29, 2026 showed that
-  the experimental fast-path implementation was materially faster but
-  not field-identical to the safe tiled reference, so support remains
-  disabled until substitute-year bootstrap semantics are matched exactly;
+- additional ``threshold_min_value`` reducers. As of Friday, July 31, 2026,
+  wet-day style support is now split by reducer after Kraken validation:
+
+  ``count_occurrences`` and ``average`` stay on the exact tiled bootstrap path,
+  while ``sum`` and ``fraction_of_total`` are field-identical on the optimized
+  path;
 - ``cftime`` calendars; Kraken validation on July 29, 2026 found a
   remaining one-cell mismatch on a Gregorian-like ``cftime`` case, so
   the release path keeps ``cftime`` on the exact safe tiled fallback

--- a/src/icclim/_core/generic/bootstrap.py
+++ b/src/icclim/_core/generic/bootstrap.py
@@ -353,6 +353,9 @@ if njit is not None:
             target_ref_i = year_to_ref[year_i]
             group_start = year_group_starts[year_i]
             group_stop = year_group_stops[year_i]
+            overlap_reference = (
+                flat_ref_masked if not np.isnan(min_threshold) else flat_ref_raw
+            )
             if target_ref_i < 0:
                 thresholds = _build_bootstrap_threshold_series_for_cell(
                     flat_ref_masked,
@@ -390,7 +393,7 @@ if njit is not None:
                     if substitute_i == target_ref_i:
                         continue
                     thresholds = _build_bootstrap_threshold_series_for_cell(
-                        flat_ref_raw,
+                        overlap_reference,
                         sample_indices,
                         index_year,
                         index_pos,
@@ -462,6 +465,9 @@ if njit is not None:
             target_ref_i = year_to_ref[year_i]
             group_start = year_group_starts[year_i]
             group_stop = year_group_stops[year_i]
+            overlap_reference = (
+                flat_ref_masked if not np.isnan(min_threshold) else flat_ref_raw
+            )
             if target_ref_i < 0:
                 thresholds = _build_float32_bootstrap_threshold_series_for_cell(
                     _build_bootstrap_threshold_series_for_cell(
@@ -500,7 +506,7 @@ if njit is not None:
                         continue
                     thresholds = _build_float32_bootstrap_threshold_series_for_cell(
                         _build_bootstrap_threshold_series_for_cell(
-                            flat_ref_raw,
+                            overlap_reference,
                             sample_indices,
                             index_year,
                             index_pos,
@@ -570,6 +576,9 @@ if njit is not None:
             target_ref_i = year_to_ref[year_i]
             group_start = year_group_starts[year_i]
             group_stop = year_group_stops[year_i]
+            overlap_reference = (
+                flat_ref_masked if not np.isnan(min_threshold) else flat_ref_raw
+            )
             if target_ref_i < 0:
                 thresholds = _build_float32_bootstrap_threshold_series_for_cell(
                     _build_bootstrap_threshold_series_for_cell(
@@ -608,7 +617,7 @@ if njit is not None:
                         continue
                     thresholds = _build_float32_bootstrap_threshold_series_for_cell(
                         _build_bootstrap_threshold_series_for_cell(
-                            flat_ref_raw,
+                            overlap_reference,
                             sample_indices,
                             index_year,
                             index_pos,
@@ -678,6 +687,9 @@ if njit is not None:
             target_ref_i = year_to_ref[year_i]
             group_start = year_group_starts[year_i]
             group_stop = year_group_stops[year_i]
+            overlap_reference = (
+                flat_ref_masked if not np.isnan(min_threshold) else flat_ref_raw
+            )
             if target_ref_i < 0:
                 thresholds = _build_float32_bootstrap_threshold_series_for_cell(
                     _build_bootstrap_threshold_series_for_cell(
@@ -716,7 +728,7 @@ if njit is not None:
                         continue
                     thresholds = _build_float32_bootstrap_threshold_series_for_cell(
                         _build_bootstrap_threshold_series_for_cell(
-                            flat_ref_raw,
+                            overlap_reference,
                             sample_indices,
                             index_year,
                             index_pos,
@@ -786,6 +798,9 @@ if njit is not None:
             target_ref_i = year_to_ref[year_i]
             group_start = year_group_starts[year_i]
             group_stop = year_group_stops[year_i]
+            overlap_reference = (
+                flat_ref_masked if not np.isnan(min_threshold) else flat_ref_raw
+            )
             if target_ref_i < 0:
                 thresholds = _build_float32_bootstrap_threshold_series_for_cell(
                     _build_bootstrap_threshold_series_for_cell(
@@ -816,6 +831,7 @@ if njit is not None:
                     cell,
                     year_max_doys[year_i],
                     op_code,
+                    min_threshold,
                 )
             else:
                 union_thresholds = _initialize_union_threshold_series(op_code)
@@ -824,7 +840,7 @@ if njit is not None:
                         continue
                     thresholds = _build_float32_bootstrap_threshold_series_for_cell(
                         _build_bootstrap_threshold_series_for_cell(
-                            flat_ref_raw,
+                            overlap_reference,
                             sample_indices,
                             index_year,
                             index_pos,
@@ -856,6 +872,7 @@ if njit is not None:
                     cell,
                     year_max_doys[year_i],
                     op_code,
+                    min_threshold,
                 )
         return out
 
@@ -1062,6 +1079,7 @@ if njit is not None:
         cell,
         max_target_doy,
         op_code,
+        min_threshold,
     ):
         exceedance_total = np.float32(0.0)
         total = np.float32(0.0)
@@ -1069,7 +1087,8 @@ if njit is not None:
             doy = study_doys[start + offset]
             threshold = _adjusted_threshold(thresholds, doy, max_target_doy)
             value = flat_study[start + offset, cell]
-            total = np.float32(total + np.float32(value))
+            if np.isnan(min_threshold) or _compare(value, min_threshold, op_code):
+                total = np.float32(total + np.float32(value))
             if _compare(value, threshold, op_code):
                 exceedance_total = np.float32(exceedance_total + np.float32(value))
         if total == np.float32(0.0):
@@ -1225,6 +1244,7 @@ if njit is not None:
         cell,
         max_target_doy,
         op_code,
+        min_threshold,
     ):
         for group_i in range(group_start, group_stop):
             out[group_i, cell] = _fraction_of_total(
@@ -1236,6 +1256,7 @@ if njit is not None:
                 cell,
                 max_target_doy,
                 op_code,
+                min_threshold,
             )
 
     @njit(cache=True)

--- a/src/icclim/_core/generic/bootstrap_capability.py
+++ b/src/icclim/_core/generic/bootstrap_capability.py
@@ -172,10 +172,7 @@ def classify_doy_percentile_value_aggregate_bootstrap(
         climate_var.bootstrap,
     ):
         return _not_required("bootstrap_not_needed_for_overlap")
-    if (
-        threshold_spec.threshold_min_value is not None
-        and indicator_name == "average"
-    ):
+    if threshold_spec.threshold_min_value is not None and indicator_name == "average":
         return _exact_tiled_bootstrap(
             family=_classify_value_aggregate_family(threshold_spec),
             reason_code="filtered_average_requires_exact_tiled_bootstrap",

--- a/src/icclim/_core/generic/bootstrap_capability.py
+++ b/src/icclim/_core/generic/bootstrap_capability.py
@@ -137,6 +137,11 @@ def classify_doy_percentile_count_bootstrap(
         climate_var.bootstrap,
     ):
         return _not_required("bootstrap_not_needed_for_overlap")
+    if threshold_spec.threshold_min_value is not None:
+        return _exact_tiled_bootstrap(
+            family=_classify_count_family(threshold_spec),
+            reason_code="threshold_min_value_requires_exact_tiled_bootstrap",
+        )
     return _classify_required_optimized_percentile_bootstrap(
         family=_classify_count_family(threshold_spec),
         study=climate_var.studied_data,
@@ -146,6 +151,8 @@ def classify_doy_percentile_count_bootstrap(
 
 
 def classify_doy_percentile_value_aggregate_bootstrap(
+    *,
+    indicator_name: str,
     climate_var: ClimateVariable,
     resample_frequency: Frequency,
 ) -> BootstrapCapability:
@@ -165,6 +172,14 @@ def classify_doy_percentile_value_aggregate_bootstrap(
         climate_var.bootstrap,
     ):
         return _not_required("bootstrap_not_needed_for_overlap")
+    if (
+        threshold_spec.threshold_min_value is not None
+        and indicator_name == "average"
+    ):
+        return _exact_tiled_bootstrap(
+            family=_classify_value_aggregate_family(threshold_spec),
+            reason_code="filtered_average_requires_exact_tiled_bootstrap",
+        )
     return _classify_required_optimized_percentile_bootstrap(
         family=_classify_value_aggregate_family(threshold_spec),
         study=climate_var.studied_data,
@@ -249,6 +264,7 @@ def classify_generic_indicator_bootstrap(
         inventory=inventory,
     ):
         return classify_doy_percentile_value_aggregate_bootstrap(
+            indicator_name=indicator_name,
             climate_var=climate_vars[0],
             resample_frequency=resample_frequency,
         )
@@ -454,12 +470,7 @@ def _uses_specialized_value_aggregate_routing(
         return False
     if reducer_kind != BootstrapReducerKind.VALUE_AGGREGATE:
         return False
-    if (
-        date_event
-        or len(climate_vars) != 1
-        or inventory.has_bounded_threshold
-        or inventory.has_filtered_percentile
-    ):
+    if date_event or len(climate_vars) != 1 or inventory.has_bounded_threshold:
         return False
     threshold_spec = climate_vars[0].threshold
     return isinstance(threshold_spec, PercentileThreshold) and bool(
@@ -543,10 +554,6 @@ def _optimized_count_path_blocker(
 ) -> str | None:
     """Return the optimized-path blocker reason, or ``None`` when it is supported."""
     blockers = [
-        (
-            threshold_spec.threshold_min_value is not None,
-            "threshold_min_value_requires_exact_tiled_bootstrap",
-        ),
         (
             not isinstance(study.indexes.get("time"), pd.DatetimeIndex),
             "calendar_requires_exact_tiled_bootstrap",

--- a/src/icclim/_core/generic/functions.py
+++ b/src/icclim/_core/generic/functions.py
@@ -475,10 +475,7 @@ def fraction_of_total(
     if threshold is None:
         msg = "No threshold found"
         raise InvalidIcclimArgumentError(msg)
-    if (
-        bootstrap_capability.uses_optimized_bootstrap
-        and threshold.threshold_min_value is None
-    ):
+    if bootstrap_capability.uses_optimized_bootstrap:
         optimized_fraction = _compute_fast_tiled_bootstrap_fraction_of_total(
             climate_vars[0],
             threshold,
@@ -681,11 +678,7 @@ def average(
         resample_freq=resample_freq,
     )
     study, threshold = get_single_var(climate_vars)
-    if (
-        threshold is not None
-        and bootstrap_capability.uses_optimized_bootstrap
-        and threshold.threshold_min_value is None
-    ):
+    if threshold is not None and bootstrap_capability.uses_optimized_bootstrap:
         optimized_average = _compute_fast_tiled_bootstrap_exceedance_average(
             climate_vars[0],
             threshold,
@@ -752,7 +745,6 @@ def generic_sum(
     if (
         threshold is not None
         and bootstrap_capability.uses_optimized_bootstrap
-        and threshold.threshold_min_value is None
         and not _is_rate(study)
     ):
         optimized_sum = _compute_fast_tiled_bootstrap_exceedance_sum(

--- a/tests/test_bootstrap_capability.py
+++ b/tests/test_bootstrap_capability.py
@@ -113,9 +113,7 @@ def test_threshold_min_value_routes_to_exact_tiled_bootstrap() -> None:
         == BootstrapComputationFamily.FILTERED_DAY_OF_YEAR_PERCENTILE_COUNT
     )
     assert decision.execution_kind == BootstrapExecutionKind.EXACT_TILED_BOOTSTRAP
-    assert (
-        decision.reason_code == "threshold_min_value_requires_exact_tiled_bootstrap"
-    )
+    assert decision.reason_code == "threshold_min_value_requires_exact_tiled_bootstrap"
 
 
 def test_cftime_routes_to_exact_tiled_bootstrap() -> None:

--- a/tests/test_bootstrap_capability.py
+++ b/tests/test_bootstrap_capability.py
@@ -113,7 +113,9 @@ def test_threshold_min_value_routes_to_exact_tiled_bootstrap() -> None:
         == BootstrapComputationFamily.FILTERED_DAY_OF_YEAR_PERCENTILE_COUNT
     )
     assert decision.execution_kind == BootstrapExecutionKind.EXACT_TILED_BOOTSTRAP
-    assert decision.reason_code == "threshold_min_value_requires_exact_tiled_bootstrap"
+    assert (
+        decision.reason_code == "threshold_min_value_requires_exact_tiled_bootstrap"
+    )
 
 
 def test_cftime_routes_to_exact_tiled_bootstrap() -> None:
@@ -196,7 +198,7 @@ def test_bounded_threshold_is_not_routed_through_count_fast_path() -> None:
     assert decision.reason_code == "threshold_is_compound"
 
 
-def test_generic_filtered_fraction_of_total_routes_to_reference_bootstrap() -> None:
+def test_generic_filtered_fraction_of_total_routes_to_optimized_bootstrap() -> None:
     pr = stub_tas(5.0).rename("pr")
     pr.attrs["units"] = "mm/day"
     pr = pr.chunk({"time": 365, "lat": 1, "lon": 1})
@@ -219,8 +221,8 @@ def test_generic_filtered_fraction_of_total_routes_to_reference_bootstrap() -> N
         decision.family
         == BootstrapComputationFamily.FILTERED_DAY_OF_YEAR_PERCENTILE_VALUE_AGGREGATE
     )
-    assert decision.execution_kind == BootstrapExecutionKind.REFERENCE_BOOTSTRAP
-    assert decision.reason_code == "value_aggregate_uses_reference_bootstrap_path"
+    assert decision.execution_kind == BootstrapExecutionKind.OPTIMIZED_BOOTSTRAP
+    assert decision.reason_code == "optimized_bootstrap_supported"
 
 
 def test_generic_fraction_of_total_routes_to_optimized_bootstrap() -> None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -889,7 +889,7 @@ class TestIntegration:
         assert profile["bootstrap_optimized_tile_count"] == 4
         xr.testing.assert_allclose(default.TX90p, legacy.TX90p)
 
-    def test_count_occurrences__dask_wet_day_bootstrap_falls_back_to_safe_tiled_path(
+    def test_count_occurrences__dask_wet_day_bootstrap_uses_exact_tiled_path(
         self,
         monkeypatch,
     ) -> None:
@@ -935,9 +935,160 @@ class TestIntegration:
             profile["bootstrap_count_reason_code"]
             == "threshold_min_value_requires_exact_tiled_bootstrap"
         )
-        assert "bootstrap_optimized_tile_count" not in profile
-        assert profile["bootstrap_safe_tile_count"] == 4
+        assert (
+            profile["bootstrap_count_family"] == "filtered_day_of_year_percentile_count"
+        )
         xr.testing.assert_allclose(default.count_occurrences, legacy.count_occurrences)
+
+    def test_fraction_of_total__filtered_optimized_bootstrap_matches_reference_on_overlap_years(
+        self,
+        monkeypatch,
+    ) -> None:
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS", "1")
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_FAST_TILE_CELLS", "1")
+        time = pd.date_range("2042-01-01", periods=365 * 5 + 1, freq="D")
+        pr = xr.DataArray(
+            np.full((len(time), 1, 1), 0.2, dtype=float),
+            dims=["time", "lat", "lon"],
+            coords={"time": time, "lat": [0], "lon": [0]},
+            attrs={UNITS_KEY: "mm/day"},
+            name="pr",
+        )
+        pr.loc[{"time": slice("2042-01-01", "2042-12-31")}] = 0.5
+        pr.loc[{"time": slice("2043-01-01", "2043-12-31")}] = 3.0
+        pr.loc[{"time": "2042-07-15"}] = 6.0
+        pr.loc[{"time": "2043-07-15"}] = 6.0
+        pr = pr.chunk({"time": 365, "lat": 1, "lon": 1})
+        common_kwargs = {
+            "in_files": pr,
+            "var_name": "pr",
+            "index_name": "fraction_of_total",
+            "threshold": build_threshold(
+                "> 90 doy_per",
+                threshold_min_value="1 mm/day",
+                doy_window_width=1,
+                reference_period=("2042-01-01", "2043-12-31"),
+            ),
+            "time_range": ("2042-01-01", "2045-12-31"),
+            "out_file": self.OUTPUT_FILE,
+            "slice_mode": "year",
+        }
+
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_MODE", "default")
+        reference = icclim.index(**common_kwargs).compute()
+        monkeypatch.delenv("ICCLIM_BOOTSTRAP_MODE")
+        generic_functions.reset_bootstrap_profile()
+
+        optimized = icclim.index(**common_kwargs).compute()
+        profile = generic_functions.get_bootstrap_profile()
+
+        assert profile["bootstrap_execution_kind"] == "optimized_bootstrap"
+        assert profile["bootstrap_reason_code"] == "optimized_bootstrap_supported"
+        assert (
+            profile["bootstrap_family"]
+            == "filtered_day_of_year_percentile_value_aggregate"
+        )
+        xr.testing.assert_allclose(
+            optimized.fraction_of_total,
+            reference.fraction_of_total,
+        )
+
+    def test_sum__filtered_optimized_bootstrap_matches_reference_on_overlap_years(
+        self,
+        monkeypatch,
+    ) -> None:
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS", "1")
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_FAST_TILE_CELLS", "1")
+        time = pd.date_range("2042-01-01", periods=365 * 5 + 1, freq="D")
+        pr = xr.DataArray(
+            np.full((len(time), 1, 1), 0.2, dtype=float),
+            dims=["time", "lat", "lon"],
+            coords={"time": time, "lat": [0], "lon": [0]},
+            attrs={UNITS_KEY: "mm/day"},
+            name="pr",
+        )
+        pr.loc[{"time": slice("2042-01-01", "2042-12-31")}] = 0.5
+        pr.loc[{"time": slice("2043-01-01", "2043-12-31")}] = 3.0
+        pr.loc[{"time": "2042-07-15"}] = 6.0
+        pr.loc[{"time": "2043-07-15"}] = 6.0
+        pr = pr.chunk({"time": 365, "lat": 1, "lon": 1})
+        common_kwargs = {
+            "in_files": pr,
+            "var_name": "pr",
+            "index_name": "sum",
+            "threshold": build_threshold(
+                "> 90 doy_per",
+                threshold_min_value="1 mm/day",
+                doy_window_width=1,
+                reference_period=("2042-01-01", "2043-12-31"),
+            ),
+            "time_range": ("2042-01-01", "2045-12-31"),
+            "out_file": self.OUTPUT_FILE,
+            "slice_mode": "year",
+        }
+
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_MODE", "default")
+        reference = icclim.index(**common_kwargs).compute()
+        monkeypatch.delenv("ICCLIM_BOOTSTRAP_MODE")
+
+        optimized = icclim.index(**common_kwargs).compute()
+
+        xr.testing.assert_allclose(
+            optimized["sum"],
+            reference["sum"],
+        )
+
+    def test_average__filtered_exact_tiled_bootstrap_matches_reference_on_overlap_years(
+        self,
+        monkeypatch,
+    ) -> None:
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS", "1")
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_FAST_TILE_CELLS", "1")
+        time = pd.date_range("2042-01-01", periods=365 * 5 + 1, freq="D")
+        pr = xr.DataArray(
+            np.full((len(time), 1, 1), 0.2, dtype=float),
+            dims=["time", "lat", "lon"],
+            coords={"time": time, "lat": [0], "lon": [0]},
+            attrs={UNITS_KEY: "mm/day"},
+            name="pr",
+        )
+        pr.loc[{"time": slice("2042-01-01", "2042-12-31")}] = 0.5
+        pr.loc[{"time": slice("2043-01-01", "2043-12-31")}] = 3.0
+        pr.loc[{"time": "2042-07-15"}] = 6.0
+        pr.loc[{"time": "2043-07-15"}] = 6.0
+        pr = pr.chunk({"time": 365, "lat": 1, "lon": 1})
+        common_kwargs = {
+            "in_files": pr,
+            "var_name": "pr",
+            "index_name": "average",
+            "threshold": build_threshold(
+                "> 90 doy_per",
+                threshold_min_value="1 mm/day",
+                doy_window_width=1,
+                reference_period=("2042-01-01", "2043-12-31"),
+            ),
+            "time_range": ("2042-01-01", "2045-12-31"),
+            "out_file": self.OUTPUT_FILE,
+            "slice_mode": "year",
+        }
+
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_MODE", "default")
+        reference = icclim.index(**common_kwargs).compute()
+        monkeypatch.delenv("ICCLIM_BOOTSTRAP_MODE")
+
+        generic_functions.reset_bootstrap_profile()
+        exact = icclim.index(**common_kwargs).compute()
+        profile = generic_functions.get_bootstrap_profile()
+
+        assert profile["bootstrap_execution_kind"] == "exact_tiled_bootstrap"
+        assert (
+            profile["bootstrap_reason_code"]
+            == "filtered_average_requires_exact_tiled_bootstrap"
+        )
+        xr.testing.assert_allclose(
+            exact.average,
+            reference.average,
+        )
 
     def test_count_occurrences__bounded_percentile_bootstrap_uses_reference_path(
         self,

--- a/tools/run_real_data_validation.py
+++ b/tools/run_real_data_validation.py
@@ -171,6 +171,45 @@ def _build_workload(icclim, workload: str) -> xr.Dataset:
             time_range=TIME_RANGE,
             slice_mode="year",
         )
+    if workload == "generic_pr_count_bootstrap_yearly":
+        pr = _open_var(PR_GLOB, "pr")
+        return icclim.count_occurrences(
+            in_files=pr,
+            var_name="pr",
+            threshold=icclim.build_threshold(
+                "> 95 doy_per",
+                threshold_min_value="1 mm/day",
+                reference_period=BASE_PERIOD,
+            ),
+            time_range=TIME_RANGE,
+            slice_mode="year",
+        )
+    if workload == "generic_pr_sum_bootstrap_yearly":
+        pr = _open_var(PR_GLOB, "pr")
+        return icclim.sum(
+            in_files=pr,
+            var_name="pr",
+            threshold=icclim.build_threshold(
+                "> 95 doy_per",
+                threshold_min_value="1 mm/day",
+                reference_period=BASE_PERIOD,
+            ),
+            time_range=TIME_RANGE,
+            slice_mode="year",
+        )
+    if workload == "generic_pr_average_bootstrap_yearly":
+        pr = _open_var(PR_GLOB, "pr")
+        return icclim.average(
+            in_files=pr,
+            var_name="pr",
+            threshold=icclim.build_threshold(
+                "> 95 doy_per",
+                threshold_min_value="1 mm/day",
+                reference_period=BASE_PERIOD,
+            ),
+            time_range=TIME_RANGE,
+            slice_mode="year",
+        )
     if workload == "generic_tas_fraction_bootstrap_yearly":
         tas = _open_var(TAS_GLOB, "tas")
         return icclim.fraction_of_total(

--- a/tools/summarize_real_data_validation.py
+++ b/tools/summarize_real_data_validation.py
@@ -148,6 +148,15 @@ def _workload_notes(workload: str) -> str:
         "generic_pr_fraction_bootstrap_yearly": (
             "filtered value aggregate; wet-day style threshold_min_value"
         ),
+        "generic_pr_count_bootstrap_yearly": (
+            "filtered count; wet-day style threshold_min_value"
+        ),
+        "generic_pr_sum_bootstrap_yearly": (
+            "filtered value aggregate; wet-day style threshold_min_value"
+        ),
+        "generic_pr_average_bootstrap_yearly": (
+            "filtered value aggregate; wet-day style threshold_min_value"
+        ),
         "generic_tas_fraction_bootstrap_yearly": (
             "unfiltered value aggregate; optimized fraction_of_total candidate"
         ),

--- a/tools/summarize_real_data_validation.py
+++ b/tools/summarize_real_data_validation.py
@@ -47,6 +47,9 @@ def _parse_compare_file(path: Path) -> ComparisonSummary:
         elif remainder.startswith("v717-bounded-hotfix-"):
             baseline_label = "v717"
             workload = remainder.removeprefix("v717-bounded-hotfix-")
+        elif remainder.startswith("baseline717-"):
+            baseline_label = "v717"
+            workload = remainder.removeprefix("baseline717-")
         elif remainder.startswith("master-"):
             baseline_label = "master"
             workload = remainder.removeprefix("master-")


### PR DESCRIPTION
## Summary

This PR extends the validated wet-day bootstrap boundary for day-of-year percentile indices using `threshold_min_value`.

It keeps the reducer-specific boundary that Kraken real-data validation now supports:

- filtered `count_occurrences`: exact through the exact tiled bootstrap path
- filtered `average`: exact through the exact tiled bootstrap path
- filtered `sum`: exact through the optimized path
- filtered `fraction_of_total`: exact through the optimized path

It also updates the bootstrap validation tooling and maintainer docs to reflect that validated split.

## Code changes

- route filtered percentile counts to the exact tiled bootstrap path
- route filtered percentile averages to the exact tiled bootstrap path
- keep filtered percentile sums and filtered `fraction_of_total` on the optimized path
- extend the real-data validation harness with filtered `pr` count / sum / average workloads
- make the validation summary tool tolerate older `baseline717` compare filenames
- update bootstrap maintainer docs with the validated wet-day boundary

## Validation

Focused local validation:

- `pytest -q tests/test_bootstrap_capability.py tests/test_main.py -k 'threshold_min_value or wet_day or filtered_optimized_bootstrap or filtered_exact_tiled_bootstrap or bootstrap'`
- result: `38 passed`

Kraken real-data validation on Friday, July 31, 2026:

### Exactness vs trusted baselines

- `generic_pr_count_bootstrap_yearly`
  - exact vs `master`
  - exact vs `v7.1.7`
- `generic_pr_average_bootstrap_yearly`
  - exact vs `master`
  - exact vs `v7.1.7`
- `generic_pr_sum_bootstrap_yearly`
  - exact vs `master`
  - exact vs `v7.1.7`
- `generic_pr_fraction_bootstrap_yearly`
  - exact vs `master`
  - exact vs `v7.1.7`

### Performance on Kraken real data

- `generic_pr_count_bootstrap_yearly`
  - current: `755.09s`
  - `master`: `810.75s`
  - `v7.1.7`: `806.01s`
- `generic_pr_average_bootstrap_yearly`
  - current: `123.92s`
  - `master`: `90.57s`
  - `v7.1.7`: `90.29s`
- `generic_pr_sum_bootstrap_yearly`
  - current: `89.97s`
  - `master`: `90.57s`
  - `v7.1.7`: `92.02s`
- `generic_pr_fraction_bootstrap_yearly`
  - current: `69.45s`
  - `master`: `90.87s`
  - `v7.1.7`: `91.82s`

So the wet-day boundary is now correctness-complete for these four filtered workloads, with mixed but explicit performance characteristics.
