### PR TITLE
Optimize simple percentile spell bootstrap

### DIFF
--- a/doc/source/dev/bootstrap_architecture.rst
+++ b/doc/source/dev/bootstrap_architecture.rst
@@ -110,6 +110,12 @@ Examples:
 - generic spell or consecutive-event indicators using percentile
   thresholds.
 
+As of Friday, July 31, 2026, simple one-threshold day-of-year
+percentile spell reducers now have a compiled optimized union-mask
+bootstrap implementation validated against ``master`` on Kraken.
+Filtered and more complex spell cases still need a separate fallback or
+future extension, so this family remains only partially specialized.
+
 Percentile compound family
 --------------------------
 

--- a/doc/source/dev/percentile_bootstrap.rst
+++ b/doc/source/dev/percentile_bootstrap.rst
@@ -60,10 +60,14 @@ most useful future extensions are likely:
   remaining one-cell mismatch on a Gregorian-like ``cftime`` case, so
   the release path keeps ``cftime`` on the exact safe tiled fallback
   until the fast-path semantics are field-identical;
-- spell/run-length indices, which likely need a different algorithm
-  because the bootstrap cannot be reduced to independent daily counts.
+- spell/run-length extension beyond the simple day-of-year percentile
+  case. As of Friday, July 31, 2026, simple one-threshold day-of-year
+  percentile spell reducers such as ``sum_of_spell_lengths`` now use an
+  optimized compiled union-mask path after Kraken validation against
+  ``master``. More complex spell cases still fall back.
 
-For spell/run-length work, the likely direction is a two-stage design:
+For future spell/run-length optimization work, the likely direction is a
+two-stage design:
 
 - compute or bootstrap a daily exceedance mask first, reusing the
   current substitute-year percentile machinery;

--- a/src/icclim/_core/generic/bootstrap.py
+++ b/src/icclim/_core/generic/bootstrap.py
@@ -188,6 +188,59 @@ def compute_doy_percentile_bootstrap_union_exceedance_count(
     return out.assign_coords(percentiles=threshold.percentile_coord().item())
 
 
+def compute_doy_percentile_bootstrap_union_exceedance_mask(
+    study: DataArray,
+    threshold: PercentileThreshold,
+    freq: str,
+) -> DataArray | None:
+    """Compute the daily union exceedance mask for spell-style bootstrap reducers."""
+    if not _can_compute_optimized_bootstrap(study, threshold, freq):
+        return None
+    import xarray as xr  # noqa: PLC0415
+
+    reference_sample = build_bootstrap_reference_sample(study, threshold)
+    temporal_indexing = build_bootstrap_temporal_indexing(
+        reference_sample.study,
+        reference_sample.reference_sample,
+        freq,
+        doy_window_width=threshold.doy_window_width,
+    )
+    array_inputs = build_bootstrap_array_inputs(reference_sample, dtype=np.float32)
+    flat_result = _bootstrap_union_mask_kernel(
+        array_inputs.flat_reference_raw,
+        array_inputs.flat_reference_filtered,
+        array_inputs.flat_study,
+        temporal_indexing.sample_indices_by_day_of_year,
+        temporal_indexing.reference_index_year,
+        temporal_indexing.reference_index_position,
+        temporal_indexing.substitute_alignment,
+        temporal_indexing.study_year_starts,
+        temporal_indexing.study_year_lengths,
+        temporal_indexing.year_max_day_of_years,
+        temporal_indexing.year_to_reference_index,
+        temporal_indexing.study_day_of_years,
+        float(threshold.percentile_coord().item()) / 100.0,
+        float(threshold.interpolation.alpha),
+        float(threshold.interpolation.beta),
+        _operator_code(threshold.operator),
+        (
+            np.nan
+            if reference_sample.threshold_floor_in_reference_units is None
+            else float(reference_sample.threshold_floor_in_reference_units)
+        ),
+    )
+    data = flat_result.reshape(reference_sample.study.shape)
+    out = xr.DataArray(
+        data,
+        dims=reference_sample.study.dims,
+        coords=reference_sample.study.coords,
+        attrs={"climatology_bounds": reference_sample.climatology_bounds},
+    )
+    out.attrs[REFERENCE_PERIOD_ID] = reference_sample.climatology_bounds
+    del out.attrs["climatology_bounds"]
+    return out.assign_coords(percentiles=threshold.percentile_coord().item())
+
+
 def compute_doy_percentile_bootstrap_exceedance_average(
     study: DataArray,
     threshold: PercentileThreshold,
@@ -650,6 +703,102 @@ if njit is not None:
                     year_max_doys[year_i],
                     op_code,
                 )
+        return out
+
+    @njit(parallel=True, cache=True)
+    def _bootstrap_union_mask_kernel(
+        flat_ref_raw,
+        flat_ref_masked,
+        flat_study,
+        sample_indices,
+        index_year,
+        index_pos,
+        substitute_aligned,
+        study_year_starts,
+        study_year_lengths,
+        year_max_doys,
+        year_to_ref,
+        study_doys,
+        quantile,
+        alpha,
+        beta,
+        op_code,
+        min_threshold,
+    ):
+        """Build the daily union exceedance mask for spell-style bootstrap reducers."""
+        n_years = len(year_to_ref)
+        n_times = flat_study.shape[0]
+        n_cells = flat_study.shape[1]
+        out = np.empty((n_times, n_cells), dtype=np.float32)
+        n_ref_years = substitute_aligned.shape[1]
+        max_samples = sample_indices.shape[1]
+        for flat_i in prange(n_years * n_cells):
+            year_i = flat_i // n_cells
+            cell = flat_i % n_cells
+            target_ref_i = year_to_ref[year_i]
+            year_start = study_year_starts[year_i]
+            year_length = study_year_lengths[year_i]
+            overlap_reference = (
+                flat_ref_masked if not np.isnan(min_threshold) else flat_ref_raw
+            )
+            if target_ref_i < 0:
+                thresholds = _build_float32_bootstrap_threshold_series_for_cell(
+                    _build_bootstrap_threshold_series_for_cell(
+                        flat_ref_masked,
+                        sample_indices,
+                        index_year,
+                        index_pos,
+                        substitute_aligned,
+                        -1,
+                        -1,
+                        cell,
+                        max_samples,
+                        quantile,
+                        alpha,
+                        beta,
+                        min_threshold,
+                    )
+                )
+            else:
+                thresholds = _initialize_union_threshold_series(op_code)
+                for substitute_i in range(n_ref_years):
+                    if substitute_i == target_ref_i:
+                        continue
+                    substitute_thresholds = (
+                        _build_float32_bootstrap_threshold_series_for_cell(
+                            _build_bootstrap_threshold_series_for_cell(
+                                overlap_reference,
+                                sample_indices,
+                                index_year,
+                                index_pos,
+                                substitute_aligned,
+                                target_ref_i,
+                                substitute_i,
+                                cell,
+                                max_samples,
+                                quantile,
+                                alpha,
+                                beta,
+                                min_threshold,
+                            )
+                        )
+                    )
+                    _update_union_threshold_series(
+                        thresholds,
+                        substitute_thresholds,
+                        op_code,
+                    )
+            _write_union_mask_year_for_cell(
+                out,
+                flat_study,
+                thresholds,
+                study_doys,
+                year_start,
+                year_length,
+                cell,
+                year_max_doys[year_i],
+                op_code,
+            )
         return out
 
     @njit(parallel=True, cache=True)
@@ -1260,6 +1409,25 @@ if njit is not None:
             )
 
     @njit(cache=True)
+    def _write_union_mask_year_for_cell(
+        out,
+        flat_study,
+        thresholds,
+        study_doys,
+        year_start,
+        year_length,
+        cell,
+        max_target_doy,
+        op_code,
+    ):
+        for offset in range(year_length):
+            study_i = year_start + offset
+            doy = study_doys[study_i]
+            threshold = _adjusted_threshold(thresholds, doy, max_target_doy)
+            value = flat_study[study_i, cell]
+            out[study_i, cell] = np.float32(_compare(value, threshold, op_code))
+
+    @njit(cache=True)
     def _accumulate_sum_groups_for_cell(
         out,
         flat_study,
@@ -1329,6 +1497,9 @@ else:
         return None
 
     def _bootstrap_union_count_kernel(*args, **kwargs):  # noqa: ARG001
+        return None
+
+    def _bootstrap_union_mask_kernel(*args, **kwargs):  # noqa: ARG001
         return None
 
     def _bootstrap_average_kernel(*args, **kwargs):  # noqa: ARG001

--- a/src/icclim/_core/generic/bootstrap_capability.py
+++ b/src/icclim/_core/generic/bootstrap_capability.py
@@ -185,6 +185,39 @@ def classify_doy_percentile_value_aggregate_bootstrap(
     )
 
 
+def classify_doy_percentile_spell_bootstrap(
+    climate_var: ClimateVariable,
+    resample_frequency: Frequency,
+) -> BootstrapCapability:
+    """Classify bootstrap routing for day-of-year percentile spell reducers."""
+    threshold_spec = climate_var.threshold
+    threshold_kind = classify_threshold_kind(threshold_spec)
+    not_required_reason = _count_bootstrap_not_required_reason(threshold_kind)
+    if not_required_reason is not None:
+        return _not_required(not_required_reason)
+    if not isinstance(threshold_spec, PercentileThreshold):
+        return _not_required("threshold_is_not_day_of_year_percentile")
+    if climate_var.bootstrap is False:
+        return _not_required("bootstrap_disabled_by_user")
+    if not must_run_bootstrap(
+        climate_var.studied_data,
+        threshold_spec,
+        climate_var.bootstrap,
+    ):
+        return _not_required("bootstrap_not_needed_for_overlap")
+    if threshold_spec.threshold_min_value is not None:
+        return _classify_required_exact_tiled_percentile_bootstrap(
+            family=_classify_spell_family(threshold_spec),
+            study=climate_var.studied_data,
+        )
+    return _classify_required_optimized_percentile_bootstrap(
+        family=_classify_spell_family(threshold_spec),
+        study=climate_var.studied_data,
+        threshold_spec=threshold_spec,
+        output_frequency=resample_frequency.pandas_freq,
+    )
+
+
 def _classify_required_optimized_percentile_bootstrap(
     *,
     family: BootstrapComputationFamily,
@@ -221,6 +254,29 @@ def _classify_required_optimized_percentile_bootstrap(
     )
 
 
+def _classify_required_exact_tiled_percentile_bootstrap(
+    *,
+    family: BootstrapComputationFamily,
+    study: DataArray,
+) -> BootstrapCapability:
+    from xclim.core.utils import uses_dask  # noqa: PLC0415
+
+    if not uses_dask(study):
+        return _reference_bootstrap_path(
+            family,
+            "eager_input_uses_reference_bootstrap_path",
+        )
+    if os.environ.get("ICCLIM_BOOTSTRAP_MODE") == "default":
+        return _reference_bootstrap_path(
+            family,
+            "reference_bootstrap_mode_forced",
+        )
+    return _exact_tiled_bootstrap(
+        family=family,
+        reason_code="spell_requires_exact_tiled_bootstrap",
+    )
+
+
 def classify_generic_indicator_bootstrap(
     *,
     indicator_name: str,
@@ -243,28 +299,41 @@ def classify_generic_indicator_bootstrap(
         reducer_kind=reducer_kind,
         inventory=inventory,
     )
+    specialized_capability = None
     if _uses_specialized_count_routing(
         reducer_kind=reducer_kind,
         climate_vars=climate_vars,
         date_event=date_event,
         inventory=inventory,
     ):
-        return classify_doy_percentile_count_bootstrap(
+        specialized_capability = classify_doy_percentile_count_bootstrap(
             climate_var=climate_vars[0],
             resample_frequency=resample_frequency,
         )
-    if _uses_specialized_value_aggregate_routing(
+    elif _uses_specialized_value_aggregate_routing(
         indicator_name=indicator_name,
         reducer_kind=reducer_kind,
         climate_vars=climate_vars,
         date_event=date_event,
         inventory=inventory,
     ):
-        return classify_doy_percentile_value_aggregate_bootstrap(
+        specialized_capability = classify_doy_percentile_value_aggregate_bootstrap(
             indicator_name=indicator_name,
             climate_var=climate_vars[0],
             resample_frequency=resample_frequency,
         )
+    elif _uses_specialized_spell_routing(
+        reducer_kind=reducer_kind,
+        climate_vars=climate_vars,
+        date_event=date_event,
+        inventory=inventory,
+    ):
+        specialized_capability = classify_doy_percentile_spell_bootstrap(
+            climate_var=climate_vars[0],
+            resample_frequency=resample_frequency,
+        )
+    if specialized_capability is not None:
+        return specialized_capability
     return _reference_bootstrap_path(
         family,
         _reference_bootstrap_reason_code(
@@ -318,6 +387,14 @@ def _classify_value_aggregate_family(
             BootstrapComputationFamily.FILTERED_DAY_OF_YEAR_PERCENTILE_VALUE_AGGREGATE
         )
     return BootstrapComputationFamily.DAY_OF_YEAR_PERCENTILE_VALUE_AGGREGATE
+
+
+def _classify_spell_family(
+    threshold_spec: PercentileThreshold,
+) -> BootstrapComputationFamily:
+    if threshold_spec.threshold_min_value is not None:
+        return BootstrapComputationFamily.FILTERED_DAY_OF_YEAR_PERCENTILE_SPELL
+    return BootstrapComputationFamily.DAY_OF_YEAR_PERCENTILE_SPELL
 
 
 def _classify_bootstrap_reducer_kind(
@@ -466,6 +543,23 @@ def _uses_specialized_value_aggregate_routing(
     if indicator_name not in {"average", "fraction_of_total", "sum"}:
         return False
     if reducer_kind != BootstrapReducerKind.VALUE_AGGREGATE:
+        return False
+    if date_event or len(climate_vars) != 1 or inventory.has_bounded_threshold:
+        return False
+    threshold_spec = climate_vars[0].threshold
+    return isinstance(threshold_spec, PercentileThreshold) and bool(
+        inventory.required_percentile_thresholds
+    )
+
+
+def _uses_specialized_spell_routing(
+    *,
+    reducer_kind: BootstrapReducerKind,
+    climate_vars: list[ClimateVariable],
+    date_event: bool,
+    inventory: BootstrapThresholdInventory,
+) -> bool:
+    if reducer_kind != BootstrapReducerKind.SPELL:
         return False
     if date_event or len(climate_vars) != 1 or inventory.has_bounded_threshold:
         return False

--- a/src/icclim/_core/generic/bootstrap_primitives.py
+++ b/src/icclim/_core/generic/bootstrap_primitives.py
@@ -43,6 +43,8 @@ class BootstrapTemporalIndexing:
     study_year_indices: dict[int, np.ndarray]
     output_group_indices: dict[np.datetime64, np.ndarray]
     output_group_labels: list[np.datetime64]
+    study_year_starts: np.ndarray
+    study_year_lengths: np.ndarray
     output_starts: np.ndarray
     output_lengths: np.ndarray
     output_years: np.ndarray
@@ -180,6 +182,19 @@ def build_bootstrap_temporal_indexing(
     reference_years = np.asarray(list(reference_year_indices), dtype=np.int64)
     output_group_indices = indices_by_resample_group(study, freq)
     output_group_labels = list(output_group_indices)
+    output_years = np.asarray(
+        [int(study_time[indices[0]].year) for indices in output_group_indices.values()],
+        dtype=np.int64,
+    )
+    bootstrap_years = np.asarray(list(dict.fromkeys(output_years)), dtype=np.int64)
+    study_year_starts = np.asarray(
+        [study_year_indices[year][0] for year in bootstrap_years],
+        dtype=np.int64,
+    )
+    study_year_lengths = np.asarray(
+        [len(study_year_indices[year]) for year in bootstrap_years],
+        dtype=np.int64,
+    )
     output_starts = np.asarray(
         [indices[0] for indices in output_group_indices.values()],
         dtype=np.int64,
@@ -195,11 +210,6 @@ def build_bootstrap_temporal_indexing(
         else int(study_time[indices].dayofyear.max())
         for year, indices in study_year_indices.items()
     }
-    output_years = np.asarray(
-        [int(study_time[indices[0]].year) for indices in output_group_indices.values()],
-        dtype=np.int64,
-    )
-    bootstrap_years = np.asarray(list(dict.fromkeys(output_years)), dtype=np.int64)
     year_group_starts, year_group_stops = group_bounds_by_year(
         output_years,
         bootstrap_years,
@@ -234,6 +244,8 @@ def build_bootstrap_temporal_indexing(
         study_year_indices=study_year_indices,
         output_group_indices=output_group_indices,
         output_group_labels=output_group_labels,
+        study_year_starts=study_year_starts,
+        study_year_lengths=study_year_lengths,
         output_starts=output_starts,
         output_lengths=output_lengths,
         output_years=output_years,

--- a/src/icclim/_core/generic/functions.py
+++ b/src/icclim/_core/generic/functions.py
@@ -22,6 +22,7 @@ import os
 import warnings
 from collections.abc import Callable
 from copy import copy
+from dataclasses import replace
 from functools import partial
 from time import perf_counter
 from typing import TYPE_CHECKING, Any, cast
@@ -51,6 +52,7 @@ from icclim._core.generic.bootstrap_capability import (
     BootstrapCapability,
     BootstrapExecutionKind,
     classify_doy_percentile_count_bootstrap,
+    classify_doy_percentile_spell_bootstrap,
     classify_generic_indicator_bootstrap,
 )
 from icclim._core.input_parsing import PercentileDataArray
@@ -257,11 +259,37 @@ def max_consecutive_occurrence(
     >>> int(result.max_consecutive_occurrence.isel(time=0).values)
     365
     """
-    _note_generic_bootstrap_capability(
+    bootstrap_capability = _note_generic_bootstrap_capability(
         indicator_name="max_consecutive_occurrence",
         climate_vars=climate_vars,
         resample_freq=resample_freq,
+        date_event=date_event,
     )
+    if len(climate_vars) == 1 and not date_event:
+        bootstrap_spell_mask = _compute_bootstrap_spell_mask(
+            climate_vars[0],
+            resample_freq,
+            bootstrap_capability=bootstrap_capability,
+        )
+        if bootstrap_spell_mask is not None:
+            from xclim.indices import run_length  # noqa: PLC0415
+
+            spell_run_lengths = run_length.rle(
+                bootstrap_spell_mask,
+                dim="time",
+                index=kwargs.get("run_index", "first"),
+            )
+            result = spell_run_lengths.resample(time=resample_freq.pandas_freq).max(
+                dim="time"
+            )
+            result = _transpose_like_study(result, climate_vars[0].studied_data)
+            freq = check_freq(climate_vars[0].studied_data, dim="time")
+            return _safe_to_agg_units(
+                result,
+                climate_vars[0].studied_data,
+                "count",
+                deffreq=freq,
+            )
     combined_exceedance_mask = _compute_combined_exceedance_mask(
         climate_vars,
         resample_freq.pandas_freq,
@@ -318,11 +346,40 @@ def sum_of_spell_lengths(
     DataArray
         The sum of the lengths of all spells in the data.
     """
-    _note_generic_bootstrap_capability(
+    bootstrap_capability = _note_generic_bootstrap_capability(
         indicator_name="sum_of_spell_lengths",
         climate_vars=climate_vars,
         resample_freq=resample_freq,
     )
+    if len(climate_vars) == 1:
+        bootstrap_spell_mask = _compute_bootstrap_spell_mask(
+            climate_vars[0],
+            resample_freq,
+            bootstrap_capability=bootstrap_capability,
+        )
+        if bootstrap_spell_mask is not None:
+            from xclim.indices import run_length  # noqa: PLC0415
+
+            spell_run_lengths = run_length.rle(
+                bootstrap_spell_mask,
+                dim="time",
+                index=kwargs.get("run_index", "first"),
+            )
+            cropped_run_lengths = spell_run_lengths.where(
+                spell_run_lengths >= min_spell_length,
+                other=0,
+            )
+            result = cropped_run_lengths.resample(time=resample_freq.pandas_freq).sum(
+                dim="time"
+            )
+            result = _transpose_like_study(result, climate_vars[0].studied_data)
+            freq = check_freq(climate_vars[0].studied_data, dim="time")
+            return _safe_to_agg_units(
+                result,
+                climate_vars[0].studied_data,
+                "count",
+                deffreq=freq,
+            )
     combined_exceedance_mask = _compute_combined_exceedance_mask(
         climate_vars,
         resample_freq.pandas_freq,
@@ -1629,6 +1686,156 @@ def _compute_fast_tiled_bootstrap_reducer(
     return result
 
 
+def _compute_bootstrap_spell_mask(
+    climate_var: ClimateVariable,
+    resample_freq: Frequency,
+    *,
+    bootstrap_capability: BootstrapCapability,
+) -> DataArray | None:
+    if not bootstrap_capability.bootstrap_required:
+        return None
+    if bootstrap_capability.uses_optimized_bootstrap:
+        return _compute_fast_tiled_bootstrap_spell_mask(
+            climate_var,
+            resample_freq,
+            _get_fast_bootstrap_max_cells(climate_var.studied_data),
+        )
+    if bootstrap_capability.uses_exact_tiled_bootstrap:
+        return _compute_exact_tiled_bootstrap_spell_mask(
+            climate_var,
+            resample_freq,
+        )
+    return None
+
+
+def _compute_fast_tiled_bootstrap_spell_mask(
+    climate_var: ClimateVariable,
+    resample_freq: Frequency,
+    max_cells: int,
+) -> DataArray | None:
+    from icclim._core.generic.bootstrap import (  # noqa: PLC0415
+        compute_doy_percentile_bootstrap_union_exceedance_mask,
+    )
+
+    optimized_start = perf_counter()
+    tile_results: list[DataArray] = []
+    threshold = climate_var.threshold
+    if threshold is None:
+        return None
+    for tile_indexers in _iter_spatial_tiles(climate_var.studied_data, max_cells):
+        tile_study = climate_var.studied_data.isel(tile_indexers)
+        tile_threshold = _slice_threshold_for_tile(threshold, tile_indexers)
+        tile_result = compute_doy_percentile_bootstrap_union_exceedance_mask(
+            tile_study,
+            tile_threshold,
+            resample_freq.pandas_freq,
+        )
+        if tile_result is None:
+            return None
+        tile_results.append(tile_result)
+        _profile_bootstrap_inc("bootstrap_optimized_tile_count")
+    if len(tile_results) == 1:
+        result = tile_results[0]
+    else:
+        result = xr.combine_by_coords(
+            [tile.to_dataset(name="__icclim_bootstrap_tile") for tile in tile_results],
+            combine_attrs="override",
+        )["__icclim_bootstrap_tile"]
+    result.attrs.update(tile_results[-1].attrs)
+    _profile_bootstrap_add(
+        "bootstrap_optimized_total_seconds",
+        perf_counter() - optimized_start,
+    )
+    result = result.transpose(*climate_var.studied_data.dims)
+    if "percentiles" in result.dims:
+        result = result.squeeze("percentiles")
+    if all(
+        climate_var.studied_data.sizes[dim] == 1
+        for dim in climate_var.studied_data.dims
+        if dim != "time"
+    ):
+        result = result.squeeze(drop=False)
+    return result
+
+
+def _compute_exact_tiled_bootstrap_spell_mask(
+    climate_var: ClimateVariable,
+    resample_freq: Frequency,
+) -> DataArray | None:
+    threshold = climate_var.threshold
+    if threshold is None:
+        return None
+    from icclim._core.generic.threshold.percentile import (  # noqa: PLC0415
+        PercentileThreshold,
+    )
+
+    if (
+        not isinstance(threshold, PercentileThreshold)
+        or not threshold.is_doy_per_threshold
+    ):
+        return None
+
+    spell_capability = classify_doy_percentile_spell_bootstrap(climate_var)
+    if (
+        not spell_capability.bootstrap_required
+        or spell_capability.execution_kind
+        != BootstrapExecutionKind.EXACT_TILED_BOOTSTRAP
+    ):
+        return None
+
+    exact_tiled_start = perf_counter()
+    max_cells = _get_safe_bootstrap_max_cells(
+        climate_var.studied_data,
+        threshold,
+        resample_freq,
+    )
+    _profile_bootstrap_set("bootstrap_safe_max_tile_cells", max_cells)
+    tile_results: list[DataArray] = []
+    for tile_indexers in _iter_spatial_tiles(climate_var.studied_data, max_cells):
+        tile_start = perf_counter()
+        tile_study = climate_var.studied_data.isel(tile_indexers).load()
+        tile_climate_var = _slice_climate_var_for_tile(
+            climate_var,
+            tile_indexers,
+            tile_study=tile_study,
+        )
+        tile_exceedance_mask = _compute_exceedance_mask(
+            study=tile_climate_var.studied_data,
+            threshold=tile_climate_var.threshold,
+            freq=resample_freq.pandas_freq,
+            bootstrap=True,
+        )
+        if "percentiles" in tile_exceedance_mask.dims:
+            tile_exceedance_mask = tile_exceedance_mask.squeeze("percentiles")
+        tile_results.append(tile_exceedance_mask.load())
+        _profile_bootstrap_inc("bootstrap_safe_tile_count")
+        _profile_bootstrap_add(
+            "bootstrap_safe_tile_seconds",
+            perf_counter() - tile_start,
+        )
+
+    if len(tile_results) == 1:
+        result = tile_results[0]
+    else:
+        result = xr.combine_by_coords(
+            [tile.to_dataset(name="__icclim_bootstrap_tile") for tile in tile_results],
+            combine_attrs="override",
+        )["__icclim_bootstrap_tile"]
+    result.attrs.update(tile_results[-1].attrs)
+    result = result.transpose(*climate_var.studied_data.dims)
+    if all(
+        climate_var.studied_data.sizes[dim] == 1
+        for dim in climate_var.studied_data.dims
+        if dim != "time"
+    ):
+        result = result.squeeze(drop=False)
+    _profile_bootstrap_add(
+        "bootstrap_safe_total_seconds",
+        perf_counter() - exact_tiled_start,
+    )
+    return result
+
+
 def _get_fast_bootstrap_max_cells(study: DataArray) -> int:
     if max_cells := os.environ.get("ICCLIM_BOOTSTRAP_FAST_TILE_CELLS"):
         return max(1, int(max_cells))
@@ -1774,6 +1981,41 @@ def _slice_threshold_for_tile(
     if value_indexers:
         sliced._prepared_value = value.isel(value_indexers)  # noqa: SLF001
     return sliced
+
+
+def _slice_climate_var_for_tile(
+    climate_var: ClimateVariable,
+    tile_indexers: dict[str, slice],
+    *,
+    tile_study: DataArray | None = None,
+) -> ClimateVariable:
+    if tile_study is None:
+        tile_study = climate_var.studied_data.isel(tile_indexers)
+    threshold = climate_var.threshold
+    if threshold is None:
+        sliced_threshold = None
+    else:
+        from icclim._core.generic.threshold.percentile import (  # noqa: PLC0415
+            PercentileThreshold,
+        )
+
+        if not isinstance(threshold, PercentileThreshold):
+            msg = "Exact tiled spell bootstrap currently supports one percentile threshold"
+            raise NotImplementedError(msg)
+        sliced_threshold = _slice_threshold_for_tile(threshold, tile_indexers)
+        if not sliced_threshold.is_ready:
+            prepare_unit = getattr(sliced_threshold, "_prepare_output_unit", None)
+            sliced_threshold.set_prepare_context(tile_study, prepare_unit)
+    return replace(
+        climate_var,
+        studied_data=tile_study,
+        threshold=sliced_threshold,
+    )
+
+
+def _transpose_like_study(result: DataArray, study: DataArray) -> DataArray:
+    ordered_dims = tuple(dim for dim in study.dims if dim in result.dims)
+    return result.transpose(*ordered_dims)
 
 
 def _is_memory_like_bootstrap_error(err: BaseException) -> bool:

--- a/tests/test_bootstrap_capability.py
+++ b/tests/test_bootstrap_capability.py
@@ -248,7 +248,7 @@ def test_generic_fraction_of_total_routes_to_optimized_bootstrap() -> None:
     assert decision.reason_code == "optimized_bootstrap_supported"
 
 
-def test_generic_spell_routes_to_reference_bootstrap() -> None:
+def test_generic_spell_routes_to_optimized_bootstrap() -> None:
     tas = stub_tas(27 + K2C).chunk({"time": 365, "lat": 1, "lon": 1})
     climate_var = _build_climate_variable(
         tas,
@@ -266,8 +266,8 @@ def test_generic_spell_routes_to_reference_bootstrap() -> None:
     )
 
     assert decision.family == BootstrapComputationFamily.DAY_OF_YEAR_PERCENTILE_SPELL
-    assert decision.execution_kind == BootstrapExecutionKind.REFERENCE_BOOTSTRAP
-    assert decision.reason_code == "spell_uses_reference_bootstrap_path"
+    assert decision.execution_kind == BootstrapExecutionKind.OPTIMIZED_BOOTSTRAP
+    assert decision.reason_code == "optimized_bootstrap_supported"
 
 
 def test_bounded_threshold_bootstrap_routes_to_reference_path() -> None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1756,6 +1756,84 @@ class TestIntegration:
             reference.average,
         )
 
+    def test_sum_of_spell_lengths__dask_percentile_bootstrap_uses_optimized_path(
+        self,
+        monkeypatch,
+    ) -> None:
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS", "1")
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_FAST_TILE_CELLS", "1")
+        tas = stub_tas(tas_value=27 + K2C, lat_length=2, lon_length=2).rename("tas")
+        tas = tas.chunk({"time": 365, "lat": 1, "lon": 1})
+        common_kwargs = {
+            "in_files": tas,
+            "var_name": "tas",
+            "index_name": "sum_of_spell_lengths",
+            "threshold": build_threshold(
+                "> 90 doy_per",
+                reference_period=("2042-01-01", "2043-12-31"),
+            ),
+            "time_range": ("2042-01-01", "2045-12-31"),
+            "out_file": self.OUTPUT_FILE,
+            "slice_mode": "year",
+            "min_spell_length": 6,
+        }
+
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_MODE", "default")
+        reference = icclim.index(**common_kwargs).compute()
+        monkeypatch.delenv("ICCLIM_BOOTSTRAP_MODE")
+        generic_functions.reset_bootstrap_profile()
+
+        optimized = icclim.index(**common_kwargs)
+        profile = generic_functions.get_bootstrap_profile()
+
+        assert not hasattr(optimized.sum_of_spell_lengths.data, "__dask_graph__")
+        assert profile["bootstrap_execution_kind"] == "optimized_bootstrap"
+        assert profile["bootstrap_reason_code"] == "optimized_bootstrap_supported"
+        assert profile["bootstrap_family"] == "day_of_year_percentile_spell"
+        assert profile["bootstrap_optimized_tile_count"] == 4
+        xr.testing.assert_allclose(
+            optimized.sum_of_spell_lengths,
+            reference.sum_of_spell_lengths,
+        )
+
+    def test_sum_of_spell_lengths__optimized_bootstrap_matches_reference_on_overlap_years(
+        self,
+        monkeypatch,
+    ) -> None:
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS", "1")
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_FAST_TILE_CELLS", "1")
+        tas = stub_tas(tas_value=27 + K2C, lat_length=1, lon_length=1).rename("tas")
+        tas.loc[{"time": slice("2042-01-01", "2042-12-31")}] = 26 + K2C
+        tas.loc[{"time": slice("2043-01-01", "2043-12-31")}] = 30 + K2C
+        tas.loc[{"time": slice("2042-07-10", "2042-07-16")}] = 28 + K2C
+        tas.loc[{"time": slice("2043-07-10", "2043-07-16")}] = 28 + K2C
+        tas = tas.chunk({"time": 365, "lat": 1, "lon": 1})
+        common_kwargs = {
+            "in_files": tas,
+            "var_name": "tas",
+            "index_name": "sum_of_spell_lengths",
+            "threshold": build_threshold(
+                "> 90 doy_per",
+                doy_window_width=1,
+                reference_period=("2042-01-01", "2043-12-31"),
+            ),
+            "time_range": ("2042-01-01", "2045-12-31"),
+            "out_file": self.OUTPUT_FILE,
+            "slice_mode": "year",
+            "min_spell_length": 6,
+        }
+
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_MODE", "default")
+        reference = icclim.index(**common_kwargs).compute()
+        monkeypatch.delenv("ICCLIM_BOOTSTRAP_MODE")
+
+        optimized = icclim.index(**common_kwargs).compute()
+
+        xr.testing.assert_allclose(
+            optimized.sum_of_spell_lengths,
+            reference.sum_of_spell_lengths,
+        )
+
     def test_std(self) -> None:
         tas = stub_tas(tas_value=25 + K2C).rename("tas")
         res = icclim.index(

--- a/tools/run_real_data_validation.py
+++ b/tools/run_real_data_validation.py
@@ -259,6 +259,16 @@ def _build_workload(icclim, workload: str) -> xr.Dataset:
             slice_mode="year",
             min_spell_length=6,
         )
+    if workload == "wsdi_yearly":
+        tas = _open_var(TAS_GLOB, "tas")
+        return icclim.index(
+            index_name="WSDI",
+            in_files=tas,
+            var_name="tas",
+            base_period_time_range=BASE_PERIOD,
+            time_range=TIME_RANGE,
+            slice_mode="year",
+        )
     if workload == "tg90p_save_thresholds_monthly":
         tas = _open_var(TAS_GLOB, "tas")
         return icclim.index(

--- a/tools/summarize_real_data_validation.py
+++ b/tools/summarize_real_data_validation.py
@@ -172,6 +172,7 @@ def _workload_notes(workload: str) -> str:
         "generic_tas_spell_bootstrap_yearly": (
             "spell reducer; raw v7.1.7 differs from current and master"
         ),
+        "wsdi_yearly": "standard warm-spell duration index",
         "generic_tas_count_date_event_monthly": "date_event count control path",
     }
     return notes.get(workload, "")


### PR DESCRIPTION
## Summary
- add an optimized compiled union-mask bootstrap path for simple one-threshold day-of-year percentile spell reducers
- route generic spell reducers and `WSDI`/`CSDI` through the validated optimized path when the threshold shape is supported
- extend the real-data validation and performance summary tooling for the spell bootstrap family

## Validation
- `pre-commit run --files src/icclim/_core/generic/bootstrap.py src/icclim/_core/generic/bootstrap_capability.py src/icclim/_core/generic/bootstrap_primitives.py src/icclim/_core/generic/functions.py tests/test_bootstrap_capability.py tests/test_main.py tools/run_real_data_validation.py tools/summarize_real_data_validation.py doc/source/dev/percentile_bootstrap.rst doc/source/dev/bootstrap_architecture.rst`
- `pytest -q tests/test_bootstrap_capability.py tests/test_generic_functions.py tests/test_main.py -k 'spell or WSDI or CSDI or bootstrap'`
  - `41 passed, 71 deselected`

## Kraken real-data validation
Trusted baseline: fresh `master`

- `generic_tas_spell_bootstrap_yearly`
  - exact vs `master`
  - current `84.22s`
  - `master` `105.31s`
  - speedup `1.25x`
- `wsdi_yearly`
  - exact vs `master`
  - current `80.76s`
  - `master` `105.49s`
  - speedup `1.31x`

Historical note:
- both spell workloads differ from raw `v7.1.7`
- fresh `master` differs from raw `v7.1.7` in exactly the same way for both workloads
- this branch therefore preserves current `master` behavior and does not introduce that older release difference
