### PR TITLE
Route compound bootstrap counts through leaf masks

### DIFF
--- a/doc/source/dev/bootstrap_architecture.rst
+++ b/doc/source/dev/bootstrap_architecture.rst
@@ -127,6 +127,16 @@ Examples:
 - ``CD``, ``CW``, ``WD``, ``WW``;
 - generic multi-threshold percentile compositions.
 
+As of Saturday, August 1, 2026, compound count routing is split into two
+practical cases:
+
+- multi-variable compound counts can combine bootstrap leaf masks, using
+  the best available leaf path for each variable before applying the
+  logical link;
+- single-variable bounded thresholds still stay on the reference
+  bootstrap path because the leaf-mask route was exact but slower on
+  Kraken real-data validation.
+
 Non-bootstrap family
 --------------------
 
@@ -191,8 +201,9 @@ generic indicator families:
 - filtered day-of-year percentile count;
 - value aggregates such as ``fraction_of_total``;
 - spell reducers such as ``sum_of_spell_lengths``;
-- bounded percentile compositions that currently stay on the reference
-  bootstrap path.
+- multi-variable compound counts that can combine bootstrap leaf masks;
+- bounded single-variable percentile compositions that currently stay on
+  the reference bootstrap path.
 
 Reusable bootstrap primitives
 =============================
@@ -545,7 +556,8 @@ The best coverage-per-effort order is:
 3. keep the current count reducer on top of that shared layer;
 4. add masked-value and fraction reducers for ``R*pTOT``-style indices;
 5. add a spell reducer for ``WSDI`` and ``CSDI``;
-6. add compound-mask composition for indices such as ``CD`` and ``CW``.
+6. extend compound-mask composition beyond the current validated
+   multi-variable count cases such as ``CD`` and ``CW``.
 
 At each step:
 

--- a/doc/source/dev/percentile_bootstrap.rst
+++ b/doc/source/dev/percentile_bootstrap.rst
@@ -65,6 +65,12 @@ most useful future extensions are likely:
   percentile spell reducers such as ``sum_of_spell_lengths`` now use an
   optimized compiled union-mask path after Kraken validation against
   ``master``. More complex spell cases still fall back.
+- compound percentile counts beyond the currently validated split. As of
+  Saturday, August 1, 2026, multi-variable compound counts such as
+  ``CD`` can reuse bootstrap leaf masks and stay field-identical to the
+  fresh ``master`` baseline on Kraken real data. Single-variable bounded
+  thresholds still stay on the reference bootstrap path because the
+  leaf-mask route was exact but slower there.
 
 For future spell/run-length optimization work, the likely direction is a
 two-stage design:

--- a/src/icclim/_core/generic/bootstrap_capability.py
+++ b/src/icclim/_core/generic/bootstrap_capability.py
@@ -10,6 +10,7 @@ data.
 from __future__ import annotations
 
 import os
+from dataclasses import replace
 from dataclasses import dataclass
 from enum import Enum
 from typing import TYPE_CHECKING
@@ -78,6 +79,7 @@ class BootstrapThresholdInventory:
 
     required_percentile_thresholds: tuple[PercentileThreshold, ...]
     has_bounded_threshold: bool
+    threshold_count: int
     has_filtered_percentile: bool
     has_bootstrap_disabled_percentile: bool
 
@@ -332,6 +334,17 @@ def classify_generic_indicator_bootstrap(
             climate_var=climate_vars[0],
             resample_frequency=resample_frequency,
         )
+    elif _uses_specialized_compound_count_routing(
+        reducer_kind=reducer_kind,
+        climate_vars=climate_vars,
+        date_event=date_event,
+        inventory=inventory,
+    ):
+        specialized_capability = classify_compound_count_bootstrap(
+            climate_vars=climate_vars,
+            resample_frequency=resample_frequency,
+            inventory=inventory,
+        )
     if specialized_capability is not None:
         return specialized_capability
     return _reference_bootstrap_path(
@@ -430,12 +443,14 @@ def _build_bootstrap_threshold_inventory(
 ) -> BootstrapThresholdInventory:
     required_thresholds: list[PercentileThreshold] = []
     has_bounded_threshold = False
+    threshold_count = 0
     has_filtered_percentile = False
     has_bootstrap_disabled_percentile = False
     for climate_var in climate_vars:
         threshold_spec = climate_var.threshold
         if threshold_spec is None:
             continue
+        threshold_count += 1
         if isinstance(threshold_spec, BoundedThreshold):
             has_bounded_threshold = True
         for percentile_threshold in _iter_percentile_thresholds(threshold_spec):
@@ -456,6 +471,7 @@ def _build_bootstrap_threshold_inventory(
     return BootstrapThresholdInventory(
         required_percentile_thresholds=tuple(required_thresholds),
         has_bounded_threshold=has_bounded_threshold,
+        threshold_count=threshold_count,
         has_filtered_percentile=has_filtered_percentile,
         has_bootstrap_disabled_percentile=has_bootstrap_disabled_percentile,
     )
@@ -479,7 +495,7 @@ def _classify_generic_bootstrap_family(
     reducer_kind: BootstrapReducerKind,
     inventory: BootstrapThresholdInventory,
 ) -> BootstrapComputationFamily:
-    if inventory.has_bounded_threshold:
+    if inventory.has_bounded_threshold or inventory.threshold_count > 1:
         family_group = "compound"
     elif reducer_kind == BootstrapReducerKind.COUNT:
         family_group = "count"
@@ -569,6 +585,20 @@ def _uses_specialized_spell_routing(
     )
 
 
+def _uses_specialized_compound_count_routing(
+    *,
+    reducer_kind: BootstrapReducerKind,
+    climate_vars: list[ClimateVariable],
+    date_event: bool,
+    inventory: BootstrapThresholdInventory,
+) -> bool:
+    if reducer_kind != BootstrapReducerKind.COUNT or date_event:
+        return False
+    return inventory.bootstrap_required and (
+        inventory.has_bounded_threshold or inventory.threshold_count > 1
+    )
+
+
 def _reference_bootstrap_reason_code(
     *,
     reducer_kind: BootstrapReducerKind,
@@ -576,8 +606,8 @@ def _reference_bootstrap_reason_code(
     date_event: bool,
     inventory: BootstrapThresholdInventory,
 ) -> str:
-    if inventory.has_bounded_threshold:
-        return "bounded_threshold_uses_reference_bootstrap_path"
+    if inventory.has_bounded_threshold or inventory.threshold_count > 1:
+        return "compound_bootstrap_uses_reference_bootstrap_path"
     if len(climate_vars) > 1:
         return "multiple_climate_variables_use_reference_bootstrap_path"
     if date_event:
@@ -587,6 +617,98 @@ def _reference_bootstrap_reason_code(
     if reducer_kind == BootstrapReducerKind.SPELL:
         return "spell_uses_reference_bootstrap_path"
     return "count_uses_reference_bootstrap_path"
+
+
+def classify_compound_count_bootstrap(
+    *,
+    climate_vars: list[ClimateVariable],
+    resample_frequency: Frequency,
+    inventory: BootstrapThresholdInventory,
+) -> BootstrapCapability:
+    family = _classify_generic_bootstrap_family(
+        reducer_kind=BootstrapReducerKind.COUNT,
+        inventory=inventory,
+    )
+    leaf_capabilities = [
+        leaf_capability
+        for climate_var in climate_vars
+        for leaf_capability in _iter_compound_count_leaf_capabilities(
+            climate_var=climate_var,
+            threshold_spec=climate_var.threshold,
+            resample_frequency=resample_frequency,
+        )
+    ]
+    if not leaf_capabilities:
+        return _reference_bootstrap_path(
+            family,
+            "compound_bootstrap_uses_reference_bootstrap_path",
+        )
+    if any(
+        leaf_capability.uses_reference_bootstrap_path
+        for leaf_capability in leaf_capabilities
+    ):
+        return _reference_bootstrap_path(
+            family,
+            "compound_leaf_requires_reference_bootstrap_path",
+        )
+    if any(
+        leaf_capability.uses_exact_tiled_bootstrap
+        for leaf_capability in leaf_capabilities
+    ):
+        return _exact_tiled_bootstrap(
+            family,
+            "compound_leaf_requires_exact_tiled_bootstrap",
+        )
+    return BootstrapCapability(
+        family=family,
+        execution_kind=BootstrapExecutionKind.OPTIMIZED_BOOTSTRAP,
+        bootstrap_required=True,
+        reason_code="optimized_compound_bootstrap_supported",
+    )
+
+
+def _iter_compound_count_leaf_capabilities(
+    *,
+    climate_var: ClimateVariable,
+    threshold_spec: Threshold | None,
+    resample_frequency: Frequency,
+) -> tuple[BootstrapCapability, ...]:
+    if threshold_spec is None:
+        return ()
+    if isinstance(threshold_spec, BoundedThreshold):
+        return (
+            *_iter_compound_count_leaf_capabilities(
+                climate_var=climate_var,
+                threshold_spec=threshold_spec.left_threshold,
+                resample_frequency=resample_frequency,
+            ),
+            *_iter_compound_count_leaf_capabilities(
+                climate_var=climate_var,
+                threshold_spec=threshold_spec.right_threshold,
+                resample_frequency=resample_frequency,
+            ),
+        )
+    if not isinstance(threshold_spec, PercentileThreshold):
+        return ()
+    if not must_run_bootstrap(
+        climate_var.studied_data,
+        threshold_spec,
+        climate_var.bootstrap,
+    ):
+        return ()
+    if not threshold_spec.is_doy_per_threshold:
+        return (
+            _reference_bootstrap_path(
+                _classify_count_family(threshold_spec),
+                "compound_period_percentile_uses_reference_bootstrap_path",
+            ),
+        )
+    return (
+        classify_doy_percentile_spell_bootstrap(
+            climate_var=replace(climate_var, threshold=threshold_spec),
+            resample_frequency=resample_frequency,
+        ),
+    )
 
 
 def _count_bootstrap_not_required_reason(

--- a/src/icclim/_core/generic/bootstrap_capability.py
+++ b/src/icclim/_core/generic/bootstrap_capability.py
@@ -10,8 +10,7 @@ data.
 from __future__ import annotations
 
 import os
-from dataclasses import replace
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from enum import Enum
 from typing import TYPE_CHECKING
 

--- a/src/icclim/_core/generic/bootstrap_capability.py
+++ b/src/icclim/_core/generic/bootstrap_capability.py
@@ -594,6 +594,8 @@ def _uses_specialized_compound_count_routing(
 ) -> bool:
     if reducer_kind != BootstrapReducerKind.COUNT or date_event:
         return False
+    if len(climate_vars) <= 1:
+        return False
     return inventory.bootstrap_required and (
         inventory.has_bounded_threshold or inventory.threshold_count > 1
     )
@@ -606,7 +608,9 @@ def _reference_bootstrap_reason_code(
     date_event: bool,
     inventory: BootstrapThresholdInventory,
 ) -> str:
-    if inventory.has_bounded_threshold or inventory.threshold_count > 1:
+    if inventory.has_bounded_threshold:
+        return "bounded_threshold_uses_reference_bootstrap_path"
+    if inventory.threshold_count > 1:
         return "compound_bootstrap_uses_reference_bootstrap_path"
     if len(climate_vars) > 1:
         return "multiple_climate_variables_use_reference_bootstrap_path"

--- a/src/icclim/_core/generic/functions.py
+++ b/src/icclim/_core/generic/functions.py
@@ -190,7 +190,7 @@ def count_occurrences(
         reducer_op = partial(DataArrayResample.sum, dim="time")
     combined_exceedance_mask = _compute_combined_exceedance_mask(
         climate_vars,
-        resample_freq.pandas_freq,
+        resample_freq,
         logical_link,
     )
     result = reducer_op(
@@ -292,7 +292,7 @@ def max_consecutive_occurrence(
             )
     combined_exceedance_mask = _compute_combined_exceedance_mask(
         climate_vars,
-        resample_freq.pandas_freq,
+        resample_freq,
         logical_link,
     )
     from xclim.indices import run_length  # noqa: PLC0415
@@ -382,7 +382,7 @@ def sum_of_spell_lengths(
             )
     combined_exceedance_mask = _compute_combined_exceedance_mask(
         climate_vars,
-        resample_freq.pandas_freq,
+        resample_freq,
         logical_link,
     )
     from xclim.indices import run_length  # noqa: PLC0415
@@ -2241,7 +2241,7 @@ def _rate_to_amount_for_daily_subseries(filtered_study: DataArray) -> DataArray:
 
 def _compute_combined_exceedance_mask(
     climate_vars: list[ClimateVariable],
-    resample_freq: str,
+    resample_freq: Frequency,
     logical_link: LogicalLink,
 ) -> DataArray:
     exceedance_masks = []
@@ -2250,18 +2250,74 @@ def _compute_combined_exceedance_mask(
             msg = "No threshold found"
             raise InvalidIcclimArgumentError(msg)
         exceedance_masks.append(
-            _compute_exceedance_mask(
-                study=climate_var.studied_data,
+            _compute_threshold_exceedance_mask(
+                climate_var=climate_var,
                 threshold=climate_var.threshold,
-                freq=resample_freq,
-                bootstrap=must_run_bootstrap(
-                    climate_var.studied_data,
-                    climate_var.threshold,
-                    climate_var.bootstrap,
-                ),
+                resample_freq=resample_freq,
             ).squeeze()
         )
     return logical_link(exceedance_masks)
+
+
+def _compute_threshold_exceedance_mask(
+    *,
+    climate_var: ClimateVariable,
+    threshold: Threshold,
+    resample_freq: Frequency,
+) -> DataArray:
+    from icclim._core.generic.threshold.bounded import BoundedThreshold  # noqa: PLC0415
+    from icclim._core.generic.threshold.percentile import (  # noqa: PLC0415
+        PercentileThreshold,
+    )
+
+    if isinstance(threshold, BoundedThreshold):
+        left_mask = _compute_threshold_exceedance_mask(
+            climate_var=replace(climate_var, threshold=threshold.left_threshold),
+            threshold=threshold.left_threshold,
+            resample_freq=resample_freq,
+        )
+        right_mask = _compute_threshold_exceedance_mask(
+            climate_var=replace(climate_var, threshold=threshold.right_threshold),
+            threshold=threshold.right_threshold,
+            resample_freq=resample_freq,
+        )
+        return _transpose_like_study(
+            threshold.logical_link.compute([left_mask.squeeze(), right_mask.squeeze()]),
+            climate_var.studied_data,
+        )
+
+    bootstrap_required = must_run_bootstrap(
+        climate_var.studied_data,
+        threshold,
+        climate_var.bootstrap,
+    )
+    if isinstance(threshold, PercentileThreshold) and threshold.is_doy_per_threshold:
+        leaf_climate_var = replace(climate_var, threshold=threshold)
+        capability = classify_doy_percentile_spell_bootstrap(
+            leaf_climate_var,
+            resample_freq,
+        )
+        if capability.uses_optimized_bootstrap:
+            optimized_mask = _compute_fast_tiled_bootstrap_spell_mask(
+                leaf_climate_var,
+                resample_freq,
+                _get_fast_bootstrap_max_cells(climate_var.studied_data),
+            )
+            if optimized_mask is not None:
+                return optimized_mask
+        if capability.uses_exact_tiled_bootstrap:
+            exact_mask = _compute_exact_tiled_bootstrap_spell_mask(
+                leaf_climate_var,
+                resample_freq,
+            )
+            if exact_mask is not None:
+                return exact_mask
+    return _compute_exceedance_mask(
+        study=climate_var.studied_data,
+        threshold=threshold,
+        freq=resample_freq.pandas_freq,
+        bootstrap=bootstrap_required,
+    )
 
 
 def _get_thresholded_var(

--- a/tests/test_bootstrap_capability.py
+++ b/tests/test_bootstrap_capability.py
@@ -288,11 +288,11 @@ def test_bounded_threshold_bootstrap_routes_to_reference_path() -> None:
     )
 
     assert decision.family == BootstrapComputationFamily.DAY_OF_YEAR_PERCENTILE_COMPOUND
-    assert decision.execution_kind == BootstrapExecutionKind.OPTIMIZED_BOOTSTRAP
-    assert decision.reason_code == "optimized_compound_bootstrap_supported"
+    assert decision.execution_kind == BootstrapExecutionKind.REFERENCE_BOOTSTRAP
+    assert decision.reason_code == "bounded_threshold_uses_reference_bootstrap_path"
 
 
-def test_multi_variable_percentile_count_is_classified_as_compound() -> None:
+def test_multi_variable_percentile_count_routes_to_exact_tiled_compound_path() -> None:
     tas = stub_tas(27 + K2C).chunk({"time": 365, "lat": 1, "lon": 1})
     pr = stub_tas(5.0).rename("pr")
     pr.attrs["units"] = "mm/day"
@@ -323,7 +323,10 @@ def test_multi_variable_percentile_count_is_classified_as_compound() -> None:
         resample_frequency=FrequencyRegistry.YEAR,
     )
 
-    assert decision.family == BootstrapComputationFamily.FILTERED_DAY_OF_YEAR_PERCENTILE_COMPOUND
+    assert (
+        decision.family
+        == BootstrapComputationFamily.FILTERED_DAY_OF_YEAR_PERCENTILE_COMPOUND
+    )
     assert decision.execution_kind == BootstrapExecutionKind.EXACT_TILED_BOOTSTRAP
     assert decision.reason_code == "compound_leaf_requires_exact_tiled_bootstrap"
 

--- a/tests/test_bootstrap_capability.py
+++ b/tests/test_bootstrap_capability.py
@@ -288,8 +288,44 @@ def test_bounded_threshold_bootstrap_routes_to_reference_path() -> None:
     )
 
     assert decision.family == BootstrapComputationFamily.DAY_OF_YEAR_PERCENTILE_COMPOUND
-    assert decision.execution_kind == BootstrapExecutionKind.REFERENCE_BOOTSTRAP
-    assert decision.reason_code == "bounded_threshold_uses_reference_bootstrap_path"
+    assert decision.execution_kind == BootstrapExecutionKind.OPTIMIZED_BOOTSTRAP
+    assert decision.reason_code == "optimized_compound_bootstrap_supported"
+
+
+def test_multi_variable_percentile_count_is_classified_as_compound() -> None:
+    tas = stub_tas(27 + K2C).chunk({"time": 365, "lat": 1, "lon": 1})
+    pr = stub_tas(5.0).rename("pr")
+    pr.attrs["units"] = "mm/day"
+    pr = pr.chunk({"time": 365, "lat": 1, "lon": 1})
+    tas_climate_var = _build_climate_variable(
+        tas,
+        {
+            "query": "> 90 doy_per",
+            "reference_period": ("2042-01-01", "2043-12-31"),
+        },
+    )
+    pr_climate_var = ClimateVariable(
+        name="pr",
+        standard_var=StandardVariableRegistry.PR,
+        studied_data=pr,
+        threshold=build_threshold(
+            "> 90 doy_per",
+            threshold_min_value="1 mm/day",
+            reference_period=("2042-01-01", "2043-12-31"),
+        ),
+        source_frequency=FrequencyRegistry.DAY,
+        global_metadata={},
+    )
+
+    decision = classify_generic_indicator_bootstrap(
+        indicator_name="count_occurrences",
+        climate_vars=[tas_climate_var, pr_climate_var],
+        resample_frequency=FrequencyRegistry.YEAR,
+    )
+
+    assert decision.family == BootstrapComputationFamily.FILTERED_DAY_OF_YEAR_PERCENTILE_COMPOUND
+    assert decision.execution_kind == BootstrapExecutionKind.EXACT_TILED_BOOTSTRAP
+    assert decision.reason_code == "compound_leaf_requires_exact_tiled_bootstrap"
 
 
 def test_bounded_threshold_recursively_requires_bootstrap() -> None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1090,7 +1090,7 @@ class TestIntegration:
             reference.average,
         )
 
-    def test_count_occurrences__bounded_percentile_bootstrap_uses_reference_path(
+    def test_count_occurrences__bounded_percentile_bootstrap_uses_compound_path(
         self,
         monkeypatch,
     ) -> None:
@@ -1120,10 +1120,10 @@ class TestIntegration:
         default = icclim.count_occurrences(**common_kwargs)
         profile = generic_functions.get_bootstrap_profile()
 
-        assert profile["bootstrap_execution_kind"] == "reference_bootstrap"
+        assert profile["bootstrap_execution_kind"] == "optimized_bootstrap"
         assert (
             profile["bootstrap_reason_code"]
-            == "bounded_threshold_uses_reference_bootstrap_path"
+            == "optimized_compound_bootstrap_supported"
         )
         assert profile["bootstrap_family"] == "day_of_year_percentile_compound"
         xr.testing.assert_allclose(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1090,7 +1090,7 @@ class TestIntegration:
             reference.average,
         )
 
-    def test_count_occurrences__bounded_percentile_bootstrap_uses_compound_path(
+    def test_count_occurrences__bounded_percentile_bootstrap_uses_reference_path(
         self,
         monkeypatch,
     ) -> None:
@@ -1120,10 +1120,10 @@ class TestIntegration:
         default = icclim.count_occurrences(**common_kwargs)
         profile = generic_functions.get_bootstrap_profile()
 
-        assert profile["bootstrap_execution_kind"] == "optimized_bootstrap"
+        assert profile["bootstrap_execution_kind"] == "reference_bootstrap"
         assert (
             profile["bootstrap_reason_code"]
-            == "optimized_compound_bootstrap_supported"
+            == "bounded_threshold_uses_reference_bootstrap_path"
         )
         assert profile["bootstrap_family"] == "day_of_year_percentile_compound"
         xr.testing.assert_allclose(

--- a/tools/summarize_real_data_validation.py
+++ b/tools/summarize_real_data_validation.py
@@ -35,10 +35,17 @@ def _parse_summary_file(path: Path) -> RunSummary:
     )
 
 
+def _remove_suffix(text: str, suffix: str) -> str:
+    if text.endswith(suffix):
+        return text[: -len(suffix)]
+    return text
+
+
 def _parse_compare_file(path: Path) -> ComparisonSummary:
     payload = json.loads(path.read_text())
-    filename = path.name.removesuffix(".compare.json")
+    filename = _remove_suffix(path.name, ".compare.json")
     current_prefix = "current-vs-"
+    current_debug_prefix = "current-debug-vs-"
     if filename.startswith(current_prefix):
         remainder = filename.removeprefix(current_prefix)
         if remainder.startswith("master-bounded-hotfix-"):
@@ -60,6 +67,15 @@ def _parse_compare_file(path: Path) -> ComparisonSummary:
             msg = f"Unsupported compare filename: {path.name}"
             raise ValueError(msg)
         current_label = "current"
+    elif filename.startswith(current_debug_prefix):
+        remainder = filename.removeprefix(current_debug_prefix)
+        if remainder.startswith("master-debug-"):
+            baseline_label = "master-debug"
+            workload = remainder.removeprefix("master-debug-")
+        else:
+            msg = f"Unsupported compare filename: {path.name}"
+            raise ValueError(msg)
+        current_label = "current-debug"
     elif filename.startswith("master-vs-v717-"):
         current_label = "master"
         baseline_label = "v717"
@@ -174,6 +190,10 @@ def _workload_notes(workload: str) -> str:
         ),
         "wsdi_yearly": "standard warm-spell duration index",
         "generic_tas_count_date_event_monthly": "date_event count control path",
+        "combined_cd_yearly": (
+            "compound tas+pr count; combines specialized leaf masks through"
+            " logical-link composition"
+        ),
     }
     return notes.get(workload, "")
 


### PR DESCRIPTION
## Summary
- add compound count routing that composes bootstrap leaf masks across variables before applying the logical link
- keep single-variable bounded thresholds on the reference bootstrap path after Kraken showed the leaf-mask route was exact but slower there
- document the validated compound bootstrap boundary in the maintainer notes

## Local validation
- `pytest -q tests/test_bootstrap_capability.py tests/test_main.py -k 'compound or bounded or CD or count_occurrences__bounded or bootstrap'`
  - `43 passed, 60 deselected`

## Kraken real-data validation
Trusted baseline: fresh `master`

- `combined_cd_yearly`
  - exact vs `master`
  - current `84.00s`
  - `master` `96.72s`
  - speedup `1.15x`

- `generic_tas_bounded_count_yearly`
  - exact vs `master`
  - current rerun `118.90s`
  - earlier current run `122.53s`
  - `master` `109.46s`
  - interpretation: correct, but still slightly slower, so bounded single-variable thresholds stay on the reference bootstrap path

## Notes
- `CD` is now validated both on `prod` and on a smaller `debug` confirmation pair, with exact field agreement in both cases
- the summary tooling was updated to handle the compound validation filenames and to stay compatible with older Python runtimes
