### PR TITLE
Optimize bounded scalar bootstrap reducers

### DIFF
--- a/doc/source/dev/bootstrap_architecture.rst
+++ b/doc/source/dev/bootstrap_architecture.rst
@@ -127,15 +127,17 @@ Examples:
 - ``CD``, ``CW``, ``WD``, ``WW``;
 - generic multi-threshold percentile compositions.
 
-As of Saturday, August 1, 2026, compound count routing is split into two
+As of Sunday, August 2, 2026, compound count routing is split into two
 practical cases:
 
 - multi-variable compound counts can combine bootstrap leaf masks, using
   the best available leaf path for each variable before applying the
   logical link;
-- single-variable bounded thresholds still stay on the reference
-  bootstrap path because the leaf-mask route was exact but slower on
-  Kraken real-data validation.
+- single-variable bounded scalar guards such as
+  ``> 90 doy_per AND <= 30 degC`` now use a dedicated compiled path for
+  ``count_occurrences``, ``average``, ``sum`` and
+  ``fraction_of_total``. Kraken real-data validation against a trusted
+  ``master`` baseline was exact and faster for all four reducers.
 
 Non-bootstrap family
 --------------------
@@ -202,8 +204,8 @@ generic indicator families:
 - value aggregates such as ``fraction_of_total``;
 - spell reducers such as ``sum_of_spell_lengths``;
 - multi-variable compound counts that can combine bootstrap leaf masks;
-- bounded single-variable percentile compositions that currently stay on
-  the reference bootstrap path.
+- bounded single-variable percentile compositions with one day-of-year
+  percentile leaf and one scalar guard joined by ``AND``.
 
 Reusable bootstrap primitives
 =============================

--- a/doc/source/dev/percentile_bootstrap.rst
+++ b/doc/source/dev/percentile_bootstrap.rst
@@ -65,12 +65,17 @@ most useful future extensions are likely:
   percentile spell reducers such as ``sum_of_spell_lengths`` now use an
   optimized compiled union-mask path after Kraken validation against
   ``master``. More complex spell cases still fall back.
-- compound percentile counts beyond the currently validated split. As of
-  Saturday, August 1, 2026, multi-variable compound counts such as
-  ``CD`` can reuse bootstrap leaf masks and stay field-identical to the
-  fresh ``master`` baseline on Kraken real data. Single-variable bounded
-  thresholds still stay on the reference bootstrap path because the
-  leaf-mask route was exact but slower there.
+- compound percentile shapes beyond the currently validated split. As of
+  Sunday, August 2, 2026:
+
+  - multi-variable compound counts such as ``CD`` can reuse bootstrap
+    leaf masks and stay field-identical to the fresh ``master``
+    baseline on Kraken real data;
+  - single-variable bounded scalar guards such as
+    ``> 90 doy_per AND <= 30 degC`` now use a dedicated compiled path
+    and are field-identical on Kraken real data for
+    ``count_occurrences``, ``average``, ``sum`` and
+    ``fraction_of_total``.
 
 For future spell/run-length optimization work, the likely direction is a
 two-stage design:

--- a/src/icclim/_core/generic/bootstrap.py
+++ b/src/icclim/_core/generic/bootstrap.py
@@ -349,6 +349,237 @@ def compute_doy_percentile_bootstrap_fraction_of_total(
     return out.assign_coords(percentiles=threshold.percentile_coord().item())
 
 
+def compute_doy_percentile_scalar_bounded_bootstrap_count(
+    study: DataArray,
+    threshold: PercentileThreshold,
+    freq: str,
+    scalar_bound: float,
+    scalar_op_code: int,
+) -> DataArray | None:
+    """Compute bounded bootstrap counts for one percentile and one scalar guard."""
+    if not _can_compute_optimized_bootstrap(study, threshold, freq):
+        return None
+    reference_sample = build_bootstrap_reference_sample(study, threshold)
+    temporal_indexing = build_bootstrap_temporal_indexing(
+        reference_sample.study,
+        reference_sample.reference_sample,
+        freq,
+        doy_window_width=threshold.doy_window_width,
+    )
+    array_inputs = build_bootstrap_array_inputs(reference_sample, dtype=np.float32)
+    result = _bootstrap_bounded_count_kernel(
+        array_inputs.flat_reference_raw,
+        array_inputs.flat_reference_filtered,
+        array_inputs.flat_study,
+        temporal_indexing.sample_indices_by_day_of_year,
+        temporal_indexing.reference_index_year,
+        temporal_indexing.reference_index_position,
+        temporal_indexing.substitute_alignment,
+        temporal_indexing.output_starts,
+        temporal_indexing.output_lengths,
+        temporal_indexing.year_group_starts,
+        temporal_indexing.year_group_stops,
+        temporal_indexing.year_max_day_of_years,
+        temporal_indexing.year_to_reference_index,
+        temporal_indexing.study_day_of_years,
+        float(threshold.percentile_coord().item()) / 100.0,
+        float(threshold.interpolation.alpha),
+        float(threshold.interpolation.beta),
+        _operator_code(threshold.operator),
+        (
+            np.nan
+            if reference_sample.threshold_floor_in_reference_units is None
+            else float(reference_sample.threshold_floor_in_reference_units)
+        ),
+        np.float32(scalar_bound),
+        scalar_op_code,
+    )
+    out = build_bootstrap_output(
+        flat_result=result,
+        reference_sample=reference_sample,
+        temporal_indexing=temporal_indexing,
+        spatial_shape=array_inputs.spatial_shape,
+        units="d",
+    )
+    out.attrs[REFERENCE_PERIOD_ID] = reference_sample.climatology_bounds
+    del out.attrs["climatology_bounds"]
+    return out.assign_coords(percentiles=threshold.percentile_coord().item())
+
+
+def compute_doy_percentile_scalar_bounded_bootstrap_exceedance_sum(
+    study: DataArray,
+    threshold: PercentileThreshold,
+    freq: str,
+    scalar_bound: float,
+    scalar_op_code: int,
+) -> DataArray | None:
+    """Compute bounded bootstrap sums for one percentile and one scalar guard."""
+    if not _can_compute_optimized_bootstrap(study, threshold, freq):
+        return None
+    reference_sample = build_bootstrap_reference_sample(study, threshold)
+    temporal_indexing = build_bootstrap_temporal_indexing(
+        reference_sample.study,
+        reference_sample.reference_sample,
+        freq,
+        doy_window_width=threshold.doy_window_width,
+    )
+    array_inputs = build_bootstrap_array_inputs(reference_sample, dtype=np.float32)
+    result = _bootstrap_bounded_sum_kernel(
+        array_inputs.flat_reference_raw,
+        array_inputs.flat_reference_filtered,
+        array_inputs.flat_study,
+        temporal_indexing.sample_indices_by_day_of_year,
+        temporal_indexing.reference_index_year,
+        temporal_indexing.reference_index_position,
+        temporal_indexing.substitute_alignment,
+        temporal_indexing.output_starts,
+        temporal_indexing.output_lengths,
+        temporal_indexing.year_group_starts,
+        temporal_indexing.year_group_stops,
+        temporal_indexing.year_max_day_of_years,
+        temporal_indexing.year_to_reference_index,
+        temporal_indexing.study_day_of_years,
+        float(threshold.percentile_coord().item()) / 100.0,
+        float(threshold.interpolation.alpha),
+        float(threshold.interpolation.beta),
+        _operator_code(threshold.operator),
+        (
+            np.nan
+            if reference_sample.threshold_floor_in_reference_units is None
+            else float(reference_sample.threshold_floor_in_reference_units)
+        ),
+        np.float32(scalar_bound),
+        scalar_op_code,
+    )
+    out = build_bootstrap_output(
+        flat_result=result,
+        reference_sample=reference_sample,
+        temporal_indexing=temporal_indexing,
+        spatial_shape=array_inputs.spatial_shape,
+        units=reference_sample.study.attrs.get("units", ""),
+    )
+    out = out.astype(reference_sample.study.dtype)
+    out.attrs[REFERENCE_PERIOD_ID] = reference_sample.climatology_bounds
+    del out.attrs["climatology_bounds"]
+    return out.assign_coords(percentiles=threshold.percentile_coord().item())
+
+
+def compute_doy_percentile_scalar_bounded_bootstrap_exceedance_average(
+    study: DataArray,
+    threshold: PercentileThreshold,
+    freq: str,
+    scalar_bound: float,
+    scalar_op_code: int,
+) -> DataArray | None:
+    """Compute bounded bootstrap averages for one percentile and one scalar guard."""
+    if not _can_compute_optimized_bootstrap(study, threshold, freq):
+        return None
+    reference_sample = build_bootstrap_reference_sample(study, threshold)
+    temporal_indexing = build_bootstrap_temporal_indexing(
+        reference_sample.study,
+        reference_sample.reference_sample,
+        freq,
+        doy_window_width=threshold.doy_window_width,
+    )
+    array_inputs = build_bootstrap_array_inputs(reference_sample, dtype=np.float32)
+    result = _bootstrap_bounded_average_kernel(
+        array_inputs.flat_reference_raw,
+        array_inputs.flat_reference_filtered,
+        array_inputs.flat_study,
+        temporal_indexing.sample_indices_by_day_of_year,
+        temporal_indexing.reference_index_year,
+        temporal_indexing.reference_index_position,
+        temporal_indexing.substitute_alignment,
+        temporal_indexing.output_starts,
+        temporal_indexing.output_lengths,
+        temporal_indexing.year_group_starts,
+        temporal_indexing.year_group_stops,
+        temporal_indexing.year_max_day_of_years,
+        temporal_indexing.year_to_reference_index,
+        temporal_indexing.study_day_of_years,
+        float(threshold.percentile_coord().item()) / 100.0,
+        float(threshold.interpolation.alpha),
+        float(threshold.interpolation.beta),
+        _operator_code(threshold.operator),
+        (
+            np.nan
+            if reference_sample.threshold_floor_in_reference_units is None
+            else float(reference_sample.threshold_floor_in_reference_units)
+        ),
+        np.float32(scalar_bound),
+        scalar_op_code,
+    )
+    out = build_bootstrap_output(
+        flat_result=result,
+        reference_sample=reference_sample,
+        temporal_indexing=temporal_indexing,
+        spatial_shape=array_inputs.spatial_shape,
+        units=reference_sample.study.attrs.get("units", ""),
+    )
+    out = out.astype(reference_sample.study.dtype)
+    out.attrs[REFERENCE_PERIOD_ID] = reference_sample.climatology_bounds
+    del out.attrs["climatology_bounds"]
+    return out.assign_coords(percentiles=threshold.percentile_coord().item())
+
+
+def compute_doy_percentile_scalar_bounded_bootstrap_fraction_of_total(
+    study: DataArray,
+    threshold: PercentileThreshold,
+    freq: str,
+    scalar_bound: float,
+    scalar_op_code: int,
+) -> DataArray | None:
+    """Compute bounded bootstrap fractions for one percentile and one scalar guard."""
+    if not _can_compute_optimized_bootstrap(study, threshold, freq):
+        return None
+    reference_sample = build_bootstrap_reference_sample(study, threshold)
+    temporal_indexing = build_bootstrap_temporal_indexing(
+        reference_sample.study,
+        reference_sample.reference_sample,
+        freq,
+        doy_window_width=threshold.doy_window_width,
+    )
+    array_inputs = build_bootstrap_array_inputs(reference_sample, dtype=np.float32)
+    result = _bootstrap_bounded_fraction_kernel(
+        array_inputs.flat_reference_raw,
+        array_inputs.flat_reference_filtered,
+        array_inputs.flat_study,
+        temporal_indexing.sample_indices_by_day_of_year,
+        temporal_indexing.reference_index_year,
+        temporal_indexing.reference_index_position,
+        temporal_indexing.substitute_alignment,
+        temporal_indexing.output_starts,
+        temporal_indexing.output_lengths,
+        temporal_indexing.year_group_starts,
+        temporal_indexing.year_group_stops,
+        temporal_indexing.year_max_day_of_years,
+        temporal_indexing.year_to_reference_index,
+        temporal_indexing.study_day_of_years,
+        float(threshold.percentile_coord().item()) / 100.0,
+        float(threshold.interpolation.alpha),
+        float(threshold.interpolation.beta),
+        _operator_code(threshold.operator),
+        (
+            np.nan
+            if reference_sample.threshold_floor_in_reference_units is None
+            else float(reference_sample.threshold_floor_in_reference_units)
+        ),
+        np.float32(scalar_bound),
+        scalar_op_code,
+    )
+    out = build_bootstrap_output(
+        flat_result=result,
+        reference_sample=reference_sample,
+        temporal_indexing=temporal_indexing,
+        spatial_shape=array_inputs.spatial_shape,
+        units="1",
+    )
+    out = out.astype(reference_sample.study.dtype)
+    out.attrs[REFERENCE_PERIOD_ID] = reference_sample.climatology_bounds
+    del out.attrs["climatology_bounds"]
+    return out.assign_coords(percentiles=threshold.percentile_coord().item())
+
+
 def _can_compute_optimized_bootstrap(
     study: DataArray,
     threshold: PercentileThreshold,
@@ -1025,6 +1256,470 @@ if njit is not None:
                 )
         return out
 
+    @njit(parallel=True, cache=True)
+    def _bootstrap_bounded_count_kernel(
+        flat_ref_raw,
+        flat_ref_masked,
+        flat_study,
+        sample_indices,
+        index_year,
+        index_pos,
+        substitute_aligned,
+        study_starts,
+        study_lengths,
+        year_group_starts,
+        year_group_stops,
+        year_max_doys,
+        year_to_ref,
+        study_doys,
+        quantile,
+        alpha,
+        beta,
+        op_code,
+        min_threshold,
+        scalar_bound,
+        scalar_op_code,
+    ):
+        n_years = len(year_to_ref)
+        n_groups = len(study_starts)
+        n_cells = flat_study.shape[1]
+        out = np.empty((n_groups, n_cells), dtype=np.float64)
+        n_ref_years = substitute_aligned.shape[1]
+        max_samples = sample_indices.shape[1]
+        for flat_i in prange(n_years * n_cells):
+            year_i = flat_i // n_cells
+            cell = flat_i % n_cells
+            target_ref_i = year_to_ref[year_i]
+            group_start = year_group_starts[year_i]
+            group_stop = year_group_stops[year_i]
+            overlap_reference = (
+                flat_ref_masked if not np.isnan(min_threshold) else flat_ref_raw
+            )
+            if target_ref_i < 0:
+                thresholds = _build_float32_bootstrap_threshold_series_for_cell(
+                    _build_bootstrap_threshold_series_for_cell(
+                        flat_ref_masked,
+                        sample_indices,
+                        index_year,
+                        index_pos,
+                        substitute_aligned,
+                        -1,
+                        -1,
+                        cell,
+                        max_samples,
+                        quantile,
+                        alpha,
+                        beta,
+                        min_threshold,
+                    )
+                )
+                _write_bounded_count_groups_for_cell(
+                    out,
+                    flat_study,
+                    thresholds,
+                    study_doys,
+                    study_starts,
+                    study_lengths,
+                    group_start,
+                    group_stop,
+                    cell,
+                    year_max_doys[year_i],
+                    op_code,
+                    scalar_bound,
+                    scalar_op_code,
+                )
+            else:
+                union_thresholds = _initialize_union_threshold_series(op_code)
+                for substitute_i in range(n_ref_years):
+                    if substitute_i == target_ref_i:
+                        continue
+                    thresholds = _build_float32_bootstrap_threshold_series_for_cell(
+                        _build_bootstrap_threshold_series_for_cell(
+                            overlap_reference,
+                            sample_indices,
+                            index_year,
+                            index_pos,
+                            substitute_aligned,
+                            target_ref_i,
+                            substitute_i,
+                            cell,
+                            max_samples,
+                            quantile,
+                            alpha,
+                            beta,
+                            min_threshold,
+                        )
+                    )
+                    _update_union_threshold_series(
+                        union_thresholds,
+                        thresholds,
+                        op_code,
+                    )
+                _write_bounded_count_groups_for_cell(
+                    out,
+                    flat_study,
+                    union_thresholds,
+                    study_doys,
+                    study_starts,
+                    study_lengths,
+                    group_start,
+                    group_stop,
+                    cell,
+                    year_max_doys[year_i],
+                    op_code,
+                    scalar_bound,
+                    scalar_op_code,
+                )
+        return out
+
+    @njit(parallel=True, cache=True)
+    def _bootstrap_bounded_sum_kernel(
+        flat_ref_raw,
+        flat_ref_masked,
+        flat_study,
+        sample_indices,
+        index_year,
+        index_pos,
+        substitute_aligned,
+        study_starts,
+        study_lengths,
+        year_group_starts,
+        year_group_stops,
+        year_max_doys,
+        year_to_ref,
+        study_doys,
+        quantile,
+        alpha,
+        beta,
+        op_code,
+        min_threshold,
+        scalar_bound,
+        scalar_op_code,
+    ):
+        n_years = len(year_to_ref)
+        n_groups = len(study_starts)
+        n_cells = flat_study.shape[1]
+        out = np.empty((n_groups, n_cells), dtype=np.float64)
+        n_ref_years = substitute_aligned.shape[1]
+        max_samples = sample_indices.shape[1]
+        for flat_i in prange(n_years * n_cells):
+            year_i = flat_i // n_cells
+            cell = flat_i % n_cells
+            target_ref_i = year_to_ref[year_i]
+            group_start = year_group_starts[year_i]
+            group_stop = year_group_stops[year_i]
+            overlap_reference = (
+                flat_ref_masked if not np.isnan(min_threshold) else flat_ref_raw
+            )
+            if target_ref_i < 0:
+                thresholds = _build_float32_bootstrap_threshold_series_for_cell(
+                    _build_bootstrap_threshold_series_for_cell(
+                        flat_ref_masked,
+                        sample_indices,
+                        index_year,
+                        index_pos,
+                        substitute_aligned,
+                        -1,
+                        -1,
+                        cell,
+                        max_samples,
+                        quantile,
+                        alpha,
+                        beta,
+                        min_threshold,
+                    )
+                )
+                _write_bounded_sum_groups_for_cell(
+                    out,
+                    flat_study,
+                    thresholds,
+                    study_doys,
+                    study_starts,
+                    study_lengths,
+                    group_start,
+                    group_stop,
+                    cell,
+                    year_max_doys[year_i],
+                    op_code,
+                    scalar_bound,
+                    scalar_op_code,
+                )
+            else:
+                union_thresholds = _initialize_union_threshold_series(op_code)
+                for substitute_i in range(n_ref_years):
+                    if substitute_i == target_ref_i:
+                        continue
+                    thresholds = _build_float32_bootstrap_threshold_series_for_cell(
+                        _build_bootstrap_threshold_series_for_cell(
+                            overlap_reference,
+                            sample_indices,
+                            index_year,
+                            index_pos,
+                            substitute_aligned,
+                            target_ref_i,
+                            substitute_i,
+                            cell,
+                            max_samples,
+                            quantile,
+                            alpha,
+                            beta,
+                            min_threshold,
+                        )
+                    )
+                    _update_union_threshold_series(
+                        union_thresholds,
+                        thresholds,
+                        op_code,
+                    )
+                _write_bounded_sum_groups_for_cell(
+                    out,
+                    flat_study,
+                    union_thresholds,
+                    study_doys,
+                    study_starts,
+                    study_lengths,
+                    group_start,
+                    group_stop,
+                    cell,
+                    year_max_doys[year_i],
+                    op_code,
+                    scalar_bound,
+                    scalar_op_code,
+                )
+        return out
+
+    @njit(parallel=True, cache=True)
+    def _bootstrap_bounded_average_kernel(
+        flat_ref_raw,
+        flat_ref_masked,
+        flat_study,
+        sample_indices,
+        index_year,
+        index_pos,
+        substitute_aligned,
+        study_starts,
+        study_lengths,
+        year_group_starts,
+        year_group_stops,
+        year_max_doys,
+        year_to_ref,
+        study_doys,
+        quantile,
+        alpha,
+        beta,
+        op_code,
+        min_threshold,
+        scalar_bound,
+        scalar_op_code,
+    ):
+        n_years = len(year_to_ref)
+        n_groups = len(study_starts)
+        n_cells = flat_study.shape[1]
+        out = np.empty((n_groups, n_cells), dtype=np.float64)
+        n_ref_years = substitute_aligned.shape[1]
+        max_samples = sample_indices.shape[1]
+        for flat_i in prange(n_years * n_cells):
+            year_i = flat_i // n_cells
+            cell = flat_i % n_cells
+            target_ref_i = year_to_ref[year_i]
+            group_start = year_group_starts[year_i]
+            group_stop = year_group_stops[year_i]
+            overlap_reference = (
+                flat_ref_masked if not np.isnan(min_threshold) else flat_ref_raw
+            )
+            if target_ref_i < 0:
+                thresholds = _build_float32_bootstrap_threshold_series_for_cell(
+                    _build_bootstrap_threshold_series_for_cell(
+                        flat_ref_masked,
+                        sample_indices,
+                        index_year,
+                        index_pos,
+                        substitute_aligned,
+                        -1,
+                        -1,
+                        cell,
+                        max_samples,
+                        quantile,
+                        alpha,
+                        beta,
+                        min_threshold,
+                    )
+                )
+                _write_bounded_average_groups_for_cell(
+                    out,
+                    flat_study,
+                    thresholds,
+                    study_doys,
+                    study_starts,
+                    study_lengths,
+                    group_start,
+                    group_stop,
+                    cell,
+                    year_max_doys[year_i],
+                    op_code,
+                    scalar_bound,
+                    scalar_op_code,
+                )
+            else:
+                union_thresholds = _initialize_union_threshold_series(op_code)
+                for substitute_i in range(n_ref_years):
+                    if substitute_i == target_ref_i:
+                        continue
+                    thresholds = _build_float32_bootstrap_threshold_series_for_cell(
+                        _build_bootstrap_threshold_series_for_cell(
+                            overlap_reference,
+                            sample_indices,
+                            index_year,
+                            index_pos,
+                            substitute_aligned,
+                            target_ref_i,
+                            substitute_i,
+                            cell,
+                            max_samples,
+                            quantile,
+                            alpha,
+                            beta,
+                            min_threshold,
+                        )
+                    )
+                    _update_union_threshold_series(
+                        union_thresholds,
+                        thresholds,
+                        op_code,
+                    )
+                _write_bounded_average_groups_for_cell(
+                    out,
+                    flat_study,
+                    union_thresholds,
+                    study_doys,
+                    study_starts,
+                    study_lengths,
+                    group_start,
+                    group_stop,
+                    cell,
+                    year_max_doys[year_i],
+                    op_code,
+                    scalar_bound,
+                    scalar_op_code,
+                )
+        return out
+
+    @njit(parallel=True, cache=True)
+    def _bootstrap_bounded_fraction_kernel(
+        flat_ref_raw,
+        flat_ref_masked,
+        flat_study,
+        sample_indices,
+        index_year,
+        index_pos,
+        substitute_aligned,
+        study_starts,
+        study_lengths,
+        year_group_starts,
+        year_group_stops,
+        year_max_doys,
+        year_to_ref,
+        study_doys,
+        quantile,
+        alpha,
+        beta,
+        op_code,
+        min_threshold,
+        scalar_bound,
+        scalar_op_code,
+    ):
+        n_years = len(year_to_ref)
+        n_groups = len(study_starts)
+        n_cells = flat_study.shape[1]
+        out = np.empty((n_groups, n_cells), dtype=np.float64)
+        n_ref_years = substitute_aligned.shape[1]
+        max_samples = sample_indices.shape[1]
+        for flat_i in prange(n_years * n_cells):
+            year_i = flat_i // n_cells
+            cell = flat_i % n_cells
+            target_ref_i = year_to_ref[year_i]
+            group_start = year_group_starts[year_i]
+            group_stop = year_group_stops[year_i]
+            overlap_reference = (
+                flat_ref_masked if not np.isnan(min_threshold) else flat_ref_raw
+            )
+            if target_ref_i < 0:
+                thresholds = _build_float32_bootstrap_threshold_series_for_cell(
+                    _build_bootstrap_threshold_series_for_cell(
+                        flat_ref_masked,
+                        sample_indices,
+                        index_year,
+                        index_pos,
+                        substitute_aligned,
+                        -1,
+                        -1,
+                        cell,
+                        max_samples,
+                        quantile,
+                        alpha,
+                        beta,
+                        min_threshold,
+                    )
+                )
+                _write_bounded_fraction_groups_for_cell(
+                    out,
+                    flat_study,
+                    thresholds,
+                    study_doys,
+                    study_starts,
+                    study_lengths,
+                    group_start,
+                    group_stop,
+                    cell,
+                    year_max_doys[year_i],
+                    op_code,
+                    scalar_bound,
+                    scalar_op_code,
+                )
+            else:
+                union_thresholds = _initialize_union_threshold_series(op_code)
+                for substitute_i in range(n_ref_years):
+                    if substitute_i == target_ref_i:
+                        continue
+                    thresholds = _build_float32_bootstrap_threshold_series_for_cell(
+                        _build_bootstrap_threshold_series_for_cell(
+                            overlap_reference,
+                            sample_indices,
+                            index_year,
+                            index_pos,
+                            substitute_aligned,
+                            target_ref_i,
+                            substitute_i,
+                            cell,
+                            max_samples,
+                            quantile,
+                            alpha,
+                            beta,
+                            min_threshold,
+                        )
+                    )
+                    _update_union_threshold_series(
+                        union_thresholds,
+                        thresholds,
+                        op_code,
+                    )
+                _write_bounded_fraction_groups_for_cell(
+                    out,
+                    flat_study,
+                    union_thresholds,
+                    study_doys,
+                    study_starts,
+                    study_lengths,
+                    group_start,
+                    group_stop,
+                    cell,
+                    year_max_doys[year_i],
+                    op_code,
+                    scalar_bound,
+                    scalar_op_code,
+                )
+        return out
+
     @njit(cache=True)
     def _build_bootstrap_threshold_series_for_cell(
         flat_ref,
@@ -1175,6 +1870,30 @@ if njit is not None:
         return count
 
     @njit(cache=True)
+    def _count_bounded_exceedances(
+        flat_study,
+        thresholds,
+        study_doys,
+        start,
+        length,
+        cell,
+        max_target_doy,
+        op_code,
+        scalar_bound,
+        scalar_op_code,
+    ):
+        count = 0.0
+        for offset in range(length):
+            doy = study_doys[start + offset]
+            threshold = _adjusted_threshold(thresholds, doy, max_target_doy)
+            value = flat_study[start + offset, cell]
+            if _compare(value, threshold, op_code) and _compare(
+                value, scalar_bound, scalar_op_code
+            ):
+                count += 1.0
+        return count
+
+    @njit(cache=True)
     def _sum_exceedances(
         flat_study,
         thresholds,
@@ -1191,6 +1910,30 @@ if njit is not None:
             threshold = _adjusted_threshold(thresholds, doy, max_target_doy)
             value = flat_study[start + offset, cell]
             if _compare(value, threshold, op_code):
+                total = np.float32(total + np.float32(value))
+        return float(total)
+
+    @njit(cache=True)
+    def _sum_bounded_exceedances(
+        flat_study,
+        thresholds,
+        study_doys,
+        start,
+        length,
+        cell,
+        max_target_doy,
+        op_code,
+        scalar_bound,
+        scalar_op_code,
+    ):
+        total = np.float32(0.0)
+        for offset in range(length):
+            doy = study_doys[start + offset]
+            threshold = _adjusted_threshold(thresholds, doy, max_target_doy)
+            value = flat_study[start + offset, cell]
+            if _compare(value, threshold, op_code) and _compare(
+                value, scalar_bound, scalar_op_code
+            ):
                 total = np.float32(total + np.float32(value))
         return float(total)
 
@@ -1219,6 +1962,34 @@ if njit is not None:
         return float(np.float32(total / np.float32(count)))
 
     @njit(cache=True)
+    def _average_bounded_exceedances(
+        flat_study,
+        thresholds,
+        study_doys,
+        start,
+        length,
+        cell,
+        max_target_doy,
+        op_code,
+        scalar_bound,
+        scalar_op_code,
+    ):
+        total = np.float32(0.0)
+        count = 0.0
+        for offset in range(length):
+            doy = study_doys[start + offset]
+            threshold = _adjusted_threshold(thresholds, doy, max_target_doy)
+            value = flat_study[start + offset, cell]
+            if _compare(value, threshold, op_code) and _compare(
+                value, scalar_bound, scalar_op_code
+            ):
+                total = np.float32(total + np.float32(value))
+                count += 1.0
+        if count == 0.0:
+            return np.nan
+        return float(np.float32(total / np.float32(count)))
+
+    @njit(cache=True)
     def _fraction_of_total(
         flat_study,
         thresholds,
@@ -1239,6 +2010,34 @@ if njit is not None:
             if np.isnan(min_threshold) or _compare(value, min_threshold, op_code):
                 total = np.float32(total + np.float32(value))
             if _compare(value, threshold, op_code):
+                exceedance_total = np.float32(exceedance_total + np.float32(value))
+        if total == np.float32(0.0):
+            return np.nan
+        return float(np.float32(exceedance_total / total))
+
+    @njit(cache=True)
+    def _bounded_fraction_of_total(
+        flat_study,
+        thresholds,
+        study_doys,
+        start,
+        length,
+        cell,
+        max_target_doy,
+        op_code,
+        scalar_bound,
+        scalar_op_code,
+    ):
+        exceedance_total = np.float32(0.0)
+        total = np.float32(0.0)
+        for offset in range(length):
+            doy = study_doys[start + offset]
+            threshold = _adjusted_threshold(thresholds, doy, max_target_doy)
+            value = flat_study[start + offset, cell]
+            total = np.float32(total + np.float32(value))
+            if _compare(value, threshold, op_code) and _compare(
+                value, scalar_bound, scalar_op_code
+            ):
                 exceedance_total = np.float32(exceedance_total + np.float32(value))
         if total == np.float32(0.0):
             return np.nan
@@ -1303,6 +2102,36 @@ if njit is not None:
             )
 
     @njit(cache=True)
+    def _write_bounded_count_groups_for_cell(
+        out,
+        flat_study,
+        thresholds,
+        study_doys,
+        study_starts,
+        study_lengths,
+        group_start,
+        group_stop,
+        cell,
+        max_target_doy,
+        op_code,
+        scalar_bound,
+        scalar_op_code,
+    ):
+        for group_i in range(group_start, group_stop):
+            out[group_i, cell] = _count_bounded_exceedances(
+                flat_study,
+                thresholds,
+                study_doys,
+                study_starts[group_i],
+                study_lengths[group_i],
+                cell,
+                max_target_doy,
+                op_code,
+                scalar_bound,
+                scalar_op_code,
+            )
+
+    @njit(cache=True)
     def _accumulate_count_groups_for_cell(
         out,
         flat_study,
@@ -1355,6 +2184,36 @@ if njit is not None:
             )
 
     @njit(cache=True)
+    def _write_bounded_sum_groups_for_cell(
+        out,
+        flat_study,
+        thresholds,
+        study_doys,
+        study_starts,
+        study_lengths,
+        group_start,
+        group_stop,
+        cell,
+        max_target_doy,
+        op_code,
+        scalar_bound,
+        scalar_op_code,
+    ):
+        for group_i in range(group_start, group_stop):
+            out[group_i, cell] = _sum_bounded_exceedances(
+                flat_study,
+                thresholds,
+                study_doys,
+                study_starts[group_i],
+                study_lengths[group_i],
+                cell,
+                max_target_doy,
+                op_code,
+                scalar_bound,
+                scalar_op_code,
+            )
+
+    @njit(cache=True)
     def _write_average_groups_for_cell(
         out,
         flat_study,
@@ -1378,6 +2237,36 @@ if njit is not None:
                 cell,
                 max_target_doy,
                 op_code,
+            )
+
+    @njit(cache=True)
+    def _write_bounded_average_groups_for_cell(
+        out,
+        flat_study,
+        thresholds,
+        study_doys,
+        study_starts,
+        study_lengths,
+        group_start,
+        group_stop,
+        cell,
+        max_target_doy,
+        op_code,
+        scalar_bound,
+        scalar_op_code,
+    ):
+        for group_i in range(group_start, group_stop):
+            out[group_i, cell] = _average_bounded_exceedances(
+                flat_study,
+                thresholds,
+                study_doys,
+                study_starts[group_i],
+                study_lengths[group_i],
+                cell,
+                max_target_doy,
+                op_code,
+                scalar_bound,
+                scalar_op_code,
             )
 
     @njit(cache=True)
@@ -1406,6 +2295,36 @@ if njit is not None:
                 max_target_doy,
                 op_code,
                 min_threshold,
+            )
+
+    @njit(cache=True)
+    def _write_bounded_fraction_groups_for_cell(
+        out,
+        flat_study,
+        thresholds,
+        study_doys,
+        study_starts,
+        study_lengths,
+        group_start,
+        group_stop,
+        cell,
+        max_target_doy,
+        op_code,
+        scalar_bound,
+        scalar_op_code,
+    ):
+        for group_i in range(group_start, group_stop):
+            out[group_i, cell] = _bounded_fraction_of_total(
+                flat_study,
+                thresholds,
+                study_doys,
+                study_starts[group_i],
+                study_lengths[group_i],
+                cell,
+                max_target_doy,
+                op_code,
+                scalar_bound,
+                scalar_op_code,
             )
 
     @njit(cache=True)
@@ -1506,4 +2425,16 @@ else:
         return None
 
     def _bootstrap_fraction_kernel(*args, **kwargs):  # noqa: ARG001
+        return None
+
+    def _bootstrap_bounded_count_kernel(*args, **kwargs):  # noqa: ARG001
+        return None
+
+    def _bootstrap_bounded_sum_kernel(*args, **kwargs):  # noqa: ARG001
+        return None
+
+    def _bootstrap_bounded_average_kernel(*args, **kwargs):  # noqa: ARG001
+        return None
+
+    def _bootstrap_bounded_fraction_kernel(*args, **kwargs):  # noqa: ARG001
         return None

--- a/src/icclim/_core/generic/bootstrap_capability.py
+++ b/src/icclim/_core/generic/bootstrap_capability.py
@@ -17,8 +17,10 @@ from typing import TYPE_CHECKING
 import pandas as pd
 
 from icclim._core.climate_variable import ClimateVariable, must_run_bootstrap
+from icclim._core.generic.threshold.basic import BasicThreshold
 from icclim._core.generic.threshold.bounded import BoundedThreshold
 from icclim._core.generic.threshold.percentile import PercentileThreshold
+from icclim._core.model.logical_link import LogicalLinkRegistry
 from icclim._core.model.operator import Operator
 
 if TYPE_CHECKING:
@@ -300,6 +302,38 @@ def classify_generic_indicator_bootstrap(
         reducer_kind=reducer_kind,
         inventory=inventory,
     )
+    specialized_capability = _classify_specialized_generic_bootstrap(
+        indicator_name=indicator_name,
+        climate_vars=climate_vars,
+        resample_frequency=resample_frequency,
+        date_event=date_event,
+        inventory=inventory,
+        reducer_kind=reducer_kind,
+        family=family,
+    )
+    if specialized_capability is not None:
+        return specialized_capability
+    return _reference_bootstrap_path(
+        family,
+        _reference_bootstrap_reason_code(
+            reducer_kind=reducer_kind,
+            climate_vars=climate_vars,
+            date_event=date_event,
+            inventory=inventory,
+        ),
+    )
+
+
+def _classify_specialized_generic_bootstrap(
+    *,
+    indicator_name: str,
+    climate_vars: list[ClimateVariable],
+    resample_frequency: Frequency,
+    date_event: bool,
+    inventory: BootstrapThresholdInventory,
+    reducer_kind: BootstrapReducerKind,
+    family: BootstrapComputationFamily,
+) -> BootstrapCapability | None:
     specialized_capability = None
     if _uses_specialized_count_routing(
         reducer_kind=reducer_kind,
@@ -333,6 +367,19 @@ def classify_generic_indicator_bootstrap(
             climate_var=climate_vars[0],
             resample_frequency=resample_frequency,
         )
+    elif _uses_specialized_scalar_bounded_routing(
+        indicator_name=indicator_name,
+        reducer_kind=reducer_kind,
+        climate_vars=climate_vars,
+        date_event=date_event,
+        inventory=inventory,
+    ):
+        specialized_capability = classify_scalar_bounded_bootstrap(
+            climate_var=climate_vars[0],
+            resample_frequency=resample_frequency,
+            family=family,
+            indicator_name=indicator_name,
+        )
     elif _uses_specialized_compound_count_routing(
         reducer_kind=reducer_kind,
         climate_vars=climate_vars,
@@ -344,17 +391,19 @@ def classify_generic_indicator_bootstrap(
             resample_frequency=resample_frequency,
             inventory=inventory,
         )
-    if specialized_capability is not None:
-        return specialized_capability
-    return _reference_bootstrap_path(
-        family,
-        _reference_bootstrap_reason_code(
-            reducer_kind=reducer_kind,
+    elif _uses_specialized_compound_value_aggregate_routing(
+        indicator_name=indicator_name,
+        reducer_kind=reducer_kind,
+        climate_vars=climate_vars,
+        date_event=date_event,
+        inventory=inventory,
+    ):
+        specialized_capability = classify_compound_value_aggregate_bootstrap(
             climate_vars=climate_vars,
-            date_event=date_event,
+            resample_frequency=resample_frequency,
             inventory=inventory,
-        ),
-    )
+        )
+    return specialized_capability
 
 
 def is_optimized_doy_percentile_count_supported(
@@ -584,6 +633,29 @@ def _uses_specialized_spell_routing(
     )
 
 
+def _uses_specialized_scalar_bounded_routing(
+    *,
+    indicator_name: str,
+    reducer_kind: BootstrapReducerKind,
+    climate_vars: list[ClimateVariable],
+    date_event: bool,
+    inventory: BootstrapThresholdInventory,
+) -> bool:
+    if date_event or len(climate_vars) != 1 or not inventory.has_bounded_threshold:
+        return False
+    if reducer_kind == BootstrapReducerKind.COUNT:
+        return supports_optimized_scalar_bounded_percentile_bootstrap(
+            climate_vars[0].threshold
+        )
+    if reducer_kind == BootstrapReducerKind.VALUE_AGGREGATE:
+        if indicator_name not in {"average", "fraction_of_total", "sum"}:
+            return False
+        return supports_optimized_scalar_bounded_percentile_bootstrap(
+            climate_vars[0].threshold
+        )
+    return False
+
+
 def _uses_specialized_compound_count_routing(
     *,
     reducer_kind: BootstrapReducerKind,
@@ -600,6 +672,25 @@ def _uses_specialized_compound_count_routing(
     )
 
 
+def _uses_specialized_compound_value_aggregate_routing(
+    *,
+    indicator_name: str,
+    reducer_kind: BootstrapReducerKind,
+    climate_vars: list[ClimateVariable],
+    date_event: bool,
+    inventory: BootstrapThresholdInventory,
+) -> bool:
+    if indicator_name not in {"average", "fraction_of_total", "sum"}:
+        return False
+    if reducer_kind != BootstrapReducerKind.VALUE_AGGREGATE or date_event:
+        return False
+    if len(climate_vars) != 1:
+        return False
+    return inventory.bootstrap_required and (
+        inventory.has_bounded_threshold or inventory.threshold_count > 1
+    )
+
+
 def _reference_bootstrap_reason_code(
     *,
     reducer_kind: BootstrapReducerKind,
@@ -607,6 +698,29 @@ def _reference_bootstrap_reason_code(
     date_event: bool,
     inventory: BootstrapThresholdInventory,
 ) -> str:
+    compound_reason = _compound_reference_bootstrap_reason(
+        climate_vars=climate_vars,
+        date_event=date_event,
+        inventory=inventory,
+    )
+    if compound_reason is not None:
+        return compound_reason
+    reducer_reason = {
+        BootstrapReducerKind.VALUE_AGGREGATE: "value_aggregate_uses_reference_bootstrap_path",
+        BootstrapReducerKind.SPELL: "spell_uses_reference_bootstrap_path",
+    }
+    return reducer_reason.get(
+        reducer_kind,
+        "count_uses_reference_bootstrap_path",
+    )
+
+
+def _compound_reference_bootstrap_reason(
+    *,
+    climate_vars: list[ClimateVariable],
+    date_event: bool,
+    inventory: BootstrapThresholdInventory,
+) -> str | None:
     if inventory.has_bounded_threshold:
         return "bounded_threshold_uses_reference_bootstrap_path"
     if inventory.threshold_count > 1:
@@ -615,11 +729,7 @@ def _reference_bootstrap_reason_code(
         return "multiple_climate_variables_use_reference_bootstrap_path"
     if date_event:
         return "date_event_uses_reference_bootstrap_path"
-    if reducer_kind == BootstrapReducerKind.VALUE_AGGREGATE:
-        return "value_aggregate_uses_reference_bootstrap_path"
-    if reducer_kind == BootstrapReducerKind.SPELL:
-        return "spell_uses_reference_bootstrap_path"
-    return "count_uses_reference_bootstrap_path"
+    return None
 
 
 def classify_compound_count_bootstrap(
@@ -635,7 +745,7 @@ def classify_compound_count_bootstrap(
     leaf_capabilities = [
         leaf_capability
         for climate_var in climate_vars
-        for leaf_capability in _iter_compound_count_leaf_capabilities(
+        for leaf_capability in _iter_compound_leaf_mask_capabilities(
             climate_var=climate_var,
             threshold_spec=climate_var.threshold,
             resample_frequency=resample_frequency,
@@ -670,7 +780,102 @@ def classify_compound_count_bootstrap(
     )
 
 
-def _iter_compound_count_leaf_capabilities(
+def classify_compound_value_aggregate_bootstrap(
+    *,
+    climate_vars: list[ClimateVariable],
+    resample_frequency: Frequency,
+    inventory: BootstrapThresholdInventory,
+) -> BootstrapCapability:
+    family = _classify_generic_bootstrap_family(
+        reducer_kind=BootstrapReducerKind.VALUE_AGGREGATE,
+        inventory=inventory,
+    )
+    leaf_capabilities = [
+        leaf_capability
+        for climate_var in climate_vars
+        for leaf_capability in _iter_compound_leaf_mask_capabilities(
+            climate_var=climate_var,
+            threshold_spec=climate_var.threshold,
+            resample_frequency=resample_frequency,
+        )
+    ]
+    if not leaf_capabilities:
+        return _reference_bootstrap_path(
+            family,
+            "compound_value_aggregate_uses_reference_bootstrap_path",
+        )
+    if any(
+        leaf_capability.uses_reference_bootstrap_path
+        for leaf_capability in leaf_capabilities
+    ):
+        return _reference_bootstrap_path(
+            family,
+            "compound_value_aggregate_leaf_requires_reference_bootstrap_path",
+        )
+    if any(
+        leaf_capability.uses_exact_tiled_bootstrap
+        for leaf_capability in leaf_capabilities
+    ):
+        return _exact_tiled_bootstrap(
+            family,
+            "compound_value_aggregate_leaf_requires_exact_tiled_bootstrap",
+        )
+    return BootstrapCapability(
+        family=family,
+        execution_kind=BootstrapExecutionKind.OPTIMIZED_BOOTSTRAP,
+        bootstrap_required=True,
+        reason_code="optimized_compound_value_aggregate_bootstrap_supported",
+    )
+
+
+def classify_scalar_bounded_bootstrap(
+    *,
+    climate_var: ClimateVariable,
+    resample_frequency: Frequency,
+    family: BootstrapComputationFamily,
+    indicator_name: str,
+) -> BootstrapCapability:
+    percentile_threshold = get_optimized_scalar_bounded_percentile_leaf(
+        climate_var.threshold
+    )
+    if percentile_threshold is None:
+        return _reference_bootstrap_path(
+            family,
+            "bounded_threshold_uses_reference_bootstrap_path",
+        )
+    if climate_var.bootstrap is False:
+        return _not_required("bootstrap_disabled_by_user")
+    if not must_run_bootstrap(
+        climate_var.studied_data,
+        percentile_threshold,
+        climate_var.bootstrap,
+    ):
+        return _not_required("bootstrap_not_needed_for_overlap")
+    if (
+        percentile_threshold.threshold_min_value is not None
+        and indicator_name == "average"
+    ):
+        return _exact_tiled_bootstrap(
+            family,
+            "filtered_average_requires_exact_tiled_bootstrap",
+        )
+    capability = _classify_required_optimized_percentile_bootstrap(
+        family=family,
+        study=climate_var.studied_data,
+        threshold_spec=percentile_threshold,
+        output_frequency=resample_frequency.pandas_freq,
+    )
+    if capability.uses_optimized_bootstrap:
+        return BootstrapCapability(
+            family=family,
+            execution_kind=BootstrapExecutionKind.OPTIMIZED_BOOTSTRAP,
+            bootstrap_required=True,
+            reason_code="optimized_scalar_bounded_bootstrap_supported",
+        )
+    return capability
+
+
+def _iter_compound_leaf_mask_capabilities(
     *,
     climate_var: ClimateVariable,
     threshold_spec: Threshold | None,
@@ -680,12 +885,12 @@ def _iter_compound_count_leaf_capabilities(
         return ()
     if isinstance(threshold_spec, BoundedThreshold):
         return (
-            *_iter_compound_count_leaf_capabilities(
+            *_iter_compound_leaf_mask_capabilities(
                 climate_var=climate_var,
                 threshold_spec=threshold_spec.left_threshold,
                 resample_frequency=resample_frequency,
             ),
-            *_iter_compound_count_leaf_capabilities(
+            *_iter_compound_leaf_mask_capabilities(
                 climate_var=climate_var,
                 threshold_spec=threshold_spec.right_threshold,
                 resample_frequency=resample_frequency,
@@ -712,6 +917,54 @@ def _iter_compound_count_leaf_capabilities(
             resample_frequency=resample_frequency,
         ),
     )
+
+
+def supports_optimized_scalar_bounded_percentile_bootstrap(
+    threshold_spec: Threshold | None,
+) -> bool:
+    return get_optimized_scalar_bounded_percentile_leaf(threshold_spec) is not None
+
+
+def get_optimized_scalar_bounded_percentile_leaf(
+    threshold_spec: Threshold | None,
+) -> PercentileThreshold | None:
+    leaves = _extract_scalar_bounded_threshold_leaves(threshold_spec)
+    if leaves is None:
+        return None
+    percentile_threshold, _ = leaves
+    if not percentile_threshold.is_doy_per_threshold:
+        return None
+    if percentile_threshold.threshold_min_value is not None:
+        return None
+    return percentile_threshold
+
+
+def _extract_scalar_bounded_threshold_leaves(
+    threshold_spec: Threshold | None,
+) -> tuple[PercentileThreshold, BasicThreshold] | None:
+    if not isinstance(threshold_spec, BoundedThreshold):
+        return None
+    if threshold_spec.logical_link != LogicalLinkRegistry.LOGICAL_AND:
+        return None
+    left_threshold = threshold_spec.left_threshold
+    right_threshold = threshold_spec.right_threshold
+    if isinstance(left_threshold, PercentileThreshold) and isinstance(
+        right_threshold, BasicThreshold
+    ):
+        percentile_threshold = left_threshold
+        basic_threshold = right_threshold
+    elif isinstance(left_threshold, BasicThreshold) and isinstance(
+        right_threshold, PercentileThreshold
+    ):
+        percentile_threshold = right_threshold
+        basic_threshold = left_threshold
+    else:
+        return None
+    if basic_threshold.value is None or basic_threshold.value.ndim != 0:
+        return None
+    if _operator_code(basic_threshold.operator) < 0:
+        return None
+    return percentile_threshold, basic_threshold
 
 
 def _count_bootstrap_not_required_reason(

--- a/src/icclim/_core/generic/functions.py
+++ b/src/icclim/_core/generic/functions.py
@@ -54,6 +54,7 @@ from icclim._core.generic.bootstrap_capability import (
     classify_doy_percentile_count_bootstrap,
     classify_doy_percentile_spell_bootstrap,
     classify_generic_indicator_bootstrap,
+    get_optimized_scalar_bounded_percentile_leaf,
 )
 from icclim._core.input_parsing import PercentileDataArray
 from icclim._core.model.cf_calendar import CfCalendarRegistry
@@ -81,6 +82,31 @@ _DEFAULT_BOOTSTRAP_SAFE_TILE_MEMORY = "2GB"
 _DEFAULT_BOOTSTRAP_FAST_TILE_MEMORY = "2GB"
 _BOOTSTRAP_SAFE_MEMORY_FACTOR = 12
 _BOOTSTRAP_FAST_MEMORY_FACTOR = 4
+
+
+def _get_scalar_bounded_bootstrap_spec(
+    threshold: Threshold | None,
+) -> tuple[PercentileThreshold, float, int] | None:
+    from icclim._core.generic.threshold.basic import BasicThreshold  # noqa: PLC0415
+    from icclim._core.generic.threshold.bounded import BoundedThreshold  # noqa: PLC0415
+
+    percentile_threshold = get_optimized_scalar_bounded_percentile_leaf(threshold)
+    if percentile_threshold is None or not isinstance(threshold, BoundedThreshold):
+        return None
+    basic_threshold = threshold.right_threshold
+    if not isinstance(basic_threshold, BasicThreshold):
+        basic_threshold = threshold.left_threshold
+    if not isinstance(basic_threshold, BasicThreshold) or basic_threshold.value is None:
+        return None
+    operator_code = _bootstrap_operator_code(basic_threshold.operator)
+    if operator_code < 0:
+        return None
+    return percentile_threshold, float(basic_threshold.value.item()), operator_code
+
+
+def _bootstrap_operator_code(operator: Operator | str) -> int:
+    operand = operator.operand if isinstance(operator, Operator) else str(operator)
+    return {">": 0, ">=": 1, "<": 2, "<=": 3}.get(operand, -1)
 
 
 def reset_bootstrap_profile() -> None:
@@ -166,6 +192,35 @@ def count_occurrences(
         resample_freq=resample_freq,
         date_event=date_event,
     )
+    if len(climate_vars) == 1 and not date_event:
+        study, threshold = get_single_var(climate_vars)
+        bounded_spec = _get_scalar_bounded_bootstrap_spec(threshold)
+        if bounded_spec is not None:
+            percentile_threshold, scalar_bound, scalar_op_code = bounded_spec
+            optimized_bounded_count = (
+                _compute_fast_tiled_scalar_bounded_bootstrap_count(
+                    climate_vars[0],
+                    percentile_threshold,
+                    resample_freq,
+                    scalar_bound,
+                    scalar_op_code,
+                    _get_fast_bootstrap_max_cells(study),
+                )
+            )
+            if optimized_bounded_count is not None:
+                if to_percent:
+                    optimized_bounded_count = _to_percent(
+                        optimized_bounded_count, resample_freq
+                    )
+                    optimized_bounded_count.attrs[UNITS_KEY] = "%"
+                    return optimized_bounded_count
+                freq = check_freq(climate_vars[0].studied_data, dim="time")
+                return _safe_to_agg_units(
+                    optimized_bounded_count,
+                    climate_vars[0].studied_data,
+                    "count",
+                    deffreq=freq,
+                )
     if len(climate_vars) == 1 and not date_event:
         safe_bootstrapped = _compute_safe_tiled_count_occurrences(
             climate_vars[0],
@@ -532,21 +587,19 @@ def fraction_of_total(
     if threshold is None:
         msg = "No threshold found"
         raise InvalidIcclimArgumentError(msg)
-    if bootstrap_capability.uses_optimized_bootstrap:
-        optimized_fraction = _compute_fast_tiled_bootstrap_fraction_of_total(
-            climate_vars[0],
-            threshold,
-            resample_freq,
-            _get_fast_bootstrap_max_cells(study),
+
+    optimized_fraction = _compute_optimized_fraction_of_total(
+        climate_var=climate_vars[0],
+        threshold=threshold,
+        study=study,
+        resample_freq=resample_freq,
+        bootstrap_capability=bootstrap_capability,
+    )
+    if optimized_fraction is not None:
+        return _format_fraction_of_total_result(
+            optimized_fraction,
+            to_percent=to_percent,
         )
-        if optimized_fraction is not None:
-            res = optimized_fraction
-            if to_percent:
-                res = res * 100
-                res.attrs[UNITS_KEY] = "%"
-            else:
-                res.attrs[UNITS_KEY] = PART_OF_A_WHOLE_UNIT
-            return res
     if threshold.threshold_min_value is not None:
         min_val = threshold.threshold_min_value
         from xclim.core.units import convert_units_to  # noqa: PLC0415
@@ -564,11 +617,10 @@ def fraction_of_total(
         )
     else:
         total = study.resample(time=resample_freq.pandas_freq).sum(dim="time")
-    exceedance_mask = _compute_exceedance_mask(
-        study=study,
+    exceedance_mask = _compute_threshold_exceedance_mask(
+        climate_var=climate_vars[0],
         threshold=threshold,
-        freq=resample_freq.pandas_freq,
-        bootstrap=must_run_bootstrap(study, threshold, climate_vars[0].bootstrap),
+        resample_freq=resample_freq,
     ).squeeze()
     over = (
         study.where(exceedance_mask, 0)
@@ -576,12 +628,7 @@ def fraction_of_total(
         .sum(dim="time")
     )
     res = over / total
-    if to_percent:
-        res = res * 100
-        res.attrs[UNITS_KEY] = "%"
-    else:
-        res.attrs[UNITS_KEY] = PART_OF_A_WHOLE_UNIT
-    return res
+    return _format_fraction_of_total_result(res, to_percent=to_percent)
 
 
 def maximum(
@@ -735,7 +782,34 @@ def average(
         resample_freq=resample_freq,
     )
     study, threshold = get_single_var(climate_vars)
-    if threshold is not None and bootstrap_capability.uses_optimized_bootstrap:
+    from icclim._core.generic.threshold.percentile import (  # noqa: PLC0415
+        PercentileThreshold,
+    )
+
+    bounded_spec = _get_scalar_bounded_bootstrap_spec(threshold)
+    if (
+        threshold is not None
+        and bounded_spec is not None
+        and bootstrap_capability.uses_optimized_bootstrap
+    ):
+        percentile_threshold, scalar_bound, scalar_op_code = bounded_spec
+        optimized_average = (
+            _compute_fast_tiled_scalar_bounded_bootstrap_exceedance_average(
+                climate_vars[0],
+                percentile_threshold,
+                resample_freq,
+                scalar_bound,
+                scalar_op_code,
+                _get_fast_bootstrap_max_cells(study),
+            )
+        )
+        if optimized_average is not None:
+            return optimized_average
+    if (
+        threshold is not None
+        and bootstrap_capability.uses_optimized_bootstrap
+        and isinstance(threshold, PercentileThreshold)
+    ):
         optimized_average = _compute_fast_tiled_bootstrap_exceedance_average(
             climate_vars[0],
             threshold,
@@ -799,9 +873,32 @@ def generic_sum(
         resample_freq=resample_freq,
     )
     study, threshold = get_single_var(climate_vars)
+    from icclim._core.generic.threshold.percentile import (  # noqa: PLC0415
+        PercentileThreshold,
+    )
+
+    bounded_spec = _get_scalar_bounded_bootstrap_spec(threshold)
+    if (
+        threshold is not None
+        and bounded_spec is not None
+        and bootstrap_capability.uses_optimized_bootstrap
+        and not _is_rate(study)
+    ):
+        percentile_threshold, scalar_bound, scalar_op_code = bounded_spec
+        optimized_sum = _compute_fast_tiled_scalar_bounded_bootstrap_exceedance_sum(
+            climate_vars[0],
+            percentile_threshold,
+            resample_freq,
+            scalar_bound,
+            scalar_op_code,
+            _get_fast_bootstrap_max_cells(study),
+        )
+        if optimized_sum is not None:
+            return optimized_sum
     if (
         threshold is not None
         and bootstrap_capability.uses_optimized_bootstrap
+        and isinstance(threshold, PercentileThreshold)
         and not _is_rate(study)
     ):
         optimized_sum = _compute_fast_tiled_bootstrap_exceedance_sum(
@@ -819,6 +916,54 @@ def generic_sum(
         date_event=False,
         must_convert_rate=True,
     )
+
+
+def _compute_optimized_fraction_of_total(
+    *,
+    climate_var: ClimateVariable,
+    threshold: Threshold,
+    study: DataArray,
+    resample_freq: Frequency,
+    bootstrap_capability: BootstrapCapability,
+) -> DataArray | None:
+    if not bootstrap_capability.uses_optimized_bootstrap:
+        return None
+    bounded_spec = _get_scalar_bounded_bootstrap_spec(threshold)
+    if bounded_spec is not None:
+        percentile_threshold, scalar_bound, scalar_op_code = bounded_spec
+        return _compute_fast_tiled_scalar_bounded_bootstrap_fraction_of_total(
+            climate_var,
+            percentile_threshold,
+            resample_freq,
+            scalar_bound,
+            scalar_op_code,
+            _get_fast_bootstrap_max_cells(study),
+        )
+    from icclim._core.generic.threshold.percentile import (  # noqa: PLC0415
+        PercentileThreshold,
+    )
+
+    if not isinstance(threshold, PercentileThreshold):
+        return None
+    return _compute_fast_tiled_bootstrap_fraction_of_total(
+        climate_var,
+        threshold,
+        resample_freq,
+        _get_fast_bootstrap_max_cells(study),
+    )
+
+
+def _format_fraction_of_total_result(
+    result: DataArray,
+    *,
+    to_percent: bool,
+) -> DataArray:
+    if to_percent:
+        result = result * 100
+        result.attrs[UNITS_KEY] = "%"
+    else:
+        result.attrs[UNITS_KEY] = PART_OF_A_WHOLE_UNIT
+    return result
 
 
 def standard_deviation(
@@ -1612,6 +1757,29 @@ def _compute_fast_tiled_bootstrap_exceedance_sum(
     )
 
 
+def _compute_fast_tiled_scalar_bounded_bootstrap_count(
+    climate_var: ClimateVariable,
+    threshold: PercentileThreshold,
+    resample_freq: Frequency,
+    scalar_bound: float,
+    scalar_op_code: int,
+    max_cells: int,
+) -> DataArray | None:
+    from icclim._core.generic.bootstrap import (  # noqa: PLC0415
+        compute_doy_percentile_scalar_bounded_bootstrap_count,
+    )
+
+    return _compute_fast_tiled_scalar_bounded_bootstrap_reducer(
+        climate_var,
+        reducer=compute_doy_percentile_scalar_bounded_bootstrap_count,
+        threshold=threshold,
+        resample_freq=resample_freq,
+        scalar_bound=scalar_bound,
+        scalar_op_code=scalar_op_code,
+        max_cells=max_cells,
+    )
+
+
 def _compute_fast_tiled_bootstrap_exceedance_average(
     climate_var: ClimateVariable,
     threshold: PercentileThreshold,
@@ -1627,6 +1795,29 @@ def _compute_fast_tiled_bootstrap_exceedance_average(
         reducer=compute_doy_percentile_bootstrap_exceedance_average,
         threshold=threshold,
         resample_freq=resample_freq,
+        max_cells=max_cells,
+    )
+
+
+def _compute_fast_tiled_scalar_bounded_bootstrap_exceedance_average(
+    climate_var: ClimateVariable,
+    threshold: PercentileThreshold,
+    resample_freq: Frequency,
+    scalar_bound: float,
+    scalar_op_code: int,
+    max_cells: int,
+) -> DataArray | None:
+    from icclim._core.generic.bootstrap import (  # noqa: PLC0415
+        compute_doy_percentile_scalar_bounded_bootstrap_exceedance_average,
+    )
+
+    return _compute_fast_tiled_scalar_bounded_bootstrap_reducer(
+        climate_var,
+        reducer=compute_doy_percentile_scalar_bounded_bootstrap_exceedance_average,
+        threshold=threshold,
+        resample_freq=resample_freq,
+        scalar_bound=scalar_bound,
+        scalar_op_code=scalar_op_code,
         max_cells=max_cells,
     )
 
@@ -1650,6 +1841,52 @@ def _compute_fast_tiled_bootstrap_fraction_of_total(
     )
 
 
+def _compute_fast_tiled_scalar_bounded_bootstrap_exceedance_sum(
+    climate_var: ClimateVariable,
+    threshold: PercentileThreshold,
+    resample_freq: Frequency,
+    scalar_bound: float,
+    scalar_op_code: int,
+    max_cells: int,
+) -> DataArray | None:
+    from icclim._core.generic.bootstrap import (  # noqa: PLC0415
+        compute_doy_percentile_scalar_bounded_bootstrap_exceedance_sum,
+    )
+
+    return _compute_fast_tiled_scalar_bounded_bootstrap_reducer(
+        climate_var,
+        reducer=compute_doy_percentile_scalar_bounded_bootstrap_exceedance_sum,
+        threshold=threshold,
+        resample_freq=resample_freq,
+        scalar_bound=scalar_bound,
+        scalar_op_code=scalar_op_code,
+        max_cells=max_cells,
+    )
+
+
+def _compute_fast_tiled_scalar_bounded_bootstrap_fraction_of_total(
+    climate_var: ClimateVariable,
+    threshold: PercentileThreshold,
+    resample_freq: Frequency,
+    scalar_bound: float,
+    scalar_op_code: int,
+    max_cells: int,
+) -> DataArray | None:
+    from icclim._core.generic.bootstrap import (  # noqa: PLC0415
+        compute_doy_percentile_scalar_bounded_bootstrap_fraction_of_total,
+    )
+
+    return _compute_fast_tiled_scalar_bounded_bootstrap_reducer(
+        climate_var,
+        reducer=compute_doy_percentile_scalar_bounded_bootstrap_fraction_of_total,
+        threshold=threshold,
+        resample_freq=resample_freq,
+        scalar_bound=scalar_bound,
+        scalar_op_code=scalar_op_code,
+        max_cells=max_cells,
+    )
+
+
 def _compute_fast_tiled_bootstrap_reducer(
     climate_var: ClimateVariable,
     reducer: Callable[[DataArray, PercentileThreshold, str], DataArray | None],
@@ -1666,6 +1903,48 @@ def _compute_fast_tiled_bootstrap_reducer(
             tile_study,
             tile_threshold,
             resample_freq.pandas_freq,
+        )
+        if tile_result is None:
+            return None
+        tile_results.append(tile_result)
+        _profile_bootstrap_inc("bootstrap_optimized_tile_count")
+    if len(tile_results) == 1:
+        result = tile_results[0]
+    else:
+        result = xr.combine_by_coords(
+            [tile.to_dataset(name="__icclim_bootstrap_tile") for tile in tile_results],
+            combine_attrs="override",
+        )["__icclim_bootstrap_tile"]
+    result.attrs.update(tile_results[-1].attrs)
+    _profile_bootstrap_add(
+        "bootstrap_optimized_total_seconds",
+        perf_counter() - optimized_start,
+    )
+    return result
+
+
+def _compute_fast_tiled_scalar_bounded_bootstrap_reducer(
+    climate_var: ClimateVariable,
+    reducer: Callable[
+        [DataArray, PercentileThreshold, str, float, int], DataArray | None
+    ],
+    threshold: PercentileThreshold,
+    resample_freq: Frequency,
+    scalar_bound: float,
+    scalar_op_code: int,
+    max_cells: int,
+) -> DataArray | None:
+    optimized_start = perf_counter()
+    tile_results: list[DataArray] = []
+    for tile_indexers in _iter_spatial_tiles(climate_var.studied_data, max_cells):
+        tile_study = climate_var.studied_data.isel(tile_indexers)
+        tile_threshold = _slice_threshold_for_tile(threshold, tile_indexers)
+        tile_result = reducer(
+            tile_study,
+            tile_threshold,
+            resample_freq.pandas_freq,
+            scalar_bound,
+            scalar_op_code,
         )
         if tile_result is None:
             return None
@@ -1775,7 +2054,10 @@ def _compute_exact_tiled_bootstrap_spell_mask(
     ):
         return None
 
-    spell_capability = classify_doy_percentile_spell_bootstrap(climate_var)
+    spell_capability = classify_doy_percentile_spell_bootstrap(
+        climate_var,
+        resample_freq,
+    )
     if (
         not spell_capability.bootstrap_required
         or spell_capability.execution_kind
@@ -2160,11 +2442,10 @@ def _run_simple_reducer(
     """
     study, threshold = get_single_var(climate_vars)
     if threshold is not None:
-        exceedance_mask = _compute_exceedance_mask(
-            study=study,
-            freq=resample_freq.pandas_freq,
+        exceedance_mask = _compute_threshold_exceedance_mask(
+            climate_var=climate_vars[0],
             threshold=threshold,
-            bootstrap=must_run_bootstrap(study, threshold, climate_vars[0].bootstrap),
+            resample_freq=resample_freq,
         ).squeeze()
         filtered_study = study.where(exceedance_mask)
     else:

--- a/tests/test_bootstrap_capability.py
+++ b/tests/test_bootstrap_capability.py
@@ -270,7 +270,7 @@ def test_generic_spell_routes_to_optimized_bootstrap() -> None:
     assert decision.reason_code == "optimized_bootstrap_supported"
 
 
-def test_bounded_threshold_bootstrap_routes_to_reference_path() -> None:
+def test_bounded_count_bootstrap_routes_to_optimized_path() -> None:
     tas = stub_tas(27 + K2C).chunk({"time": 365, "lat": 1, "lon": 1})
     climate_var = _build_climate_variable(
         tas,
@@ -288,8 +288,30 @@ def test_bounded_threshold_bootstrap_routes_to_reference_path() -> None:
     )
 
     assert decision.family == BootstrapComputationFamily.DAY_OF_YEAR_PERCENTILE_COMPOUND
-    assert decision.execution_kind == BootstrapExecutionKind.REFERENCE_BOOTSTRAP
-    assert decision.reason_code == "bounded_threshold_uses_reference_bootstrap_path"
+    assert decision.execution_kind == BootstrapExecutionKind.OPTIMIZED_BOOTSTRAP
+    assert decision.reason_code == "optimized_scalar_bounded_bootstrap_supported"
+
+
+def test_bounded_value_aggregate_bootstrap_routes_to_optimized_path() -> None:
+    tas = stub_tas(27 + K2C).chunk({"time": 365, "lat": 1, "lon": 1})
+    climate_var = _build_climate_variable(
+        tas,
+        {
+            "thresholds": ["> 90 doy_per", "<= 30 degC"],
+            "logical_link": "and",
+            "reference_period": ("2042-01-01", "2043-12-31"),
+        },
+    )
+
+    decision = classify_generic_indicator_bootstrap(
+        indicator_name="average",
+        climate_vars=[climate_var],
+        resample_frequency=FrequencyRegistry.YEAR,
+    )
+
+    assert decision.family == BootstrapComputationFamily.DAY_OF_YEAR_PERCENTILE_COMPOUND
+    assert decision.execution_kind == BootstrapExecutionKind.OPTIMIZED_BOOTSTRAP
+    assert decision.reason_code == "optimized_scalar_bounded_bootstrap_supported"
 
 
 def test_multi_variable_percentile_count_routes_to_exact_tiled_compound_path() -> None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1090,7 +1090,7 @@ class TestIntegration:
             reference.average,
         )
 
-    def test_count_occurrences__bounded_percentile_bootstrap_uses_reference_path(
+    def test_count_occurrences__bounded_percentile_bootstrap_uses_optimized_path(
         self,
         monkeypatch,
     ) -> None:
@@ -1120,14 +1120,127 @@ class TestIntegration:
         default = icclim.count_occurrences(**common_kwargs)
         profile = generic_functions.get_bootstrap_profile()
 
-        assert profile["bootstrap_execution_kind"] == "reference_bootstrap"
+        assert profile["bootstrap_execution_kind"] == "optimized_bootstrap"
         assert (
             profile["bootstrap_reason_code"]
-            == "bounded_threshold_uses_reference_bootstrap_path"
+            == "optimized_scalar_bounded_bootstrap_supported"
         )
         assert profile["bootstrap_family"] == "day_of_year_percentile_compound"
         xr.testing.assert_allclose(
             default.count_occurrences.load(), eager.count_occurrences
+        )
+
+    def test_average__bounded_percentile_bootstrap_uses_optimized_path(
+        self,
+        monkeypatch,
+    ) -> None:
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS", "1")
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_FAST_TILE_CELLS", "1")
+        tas = stub_tas(tas_value=27 + K2C, lat_length=2, lon_length=2)
+        tas[5:10] = 0
+        tas = tas.chunk({"time": 365, "lat": 1, "lon": 1})
+        common_kwargs = {
+            "in_files": tas,
+            "var_name": "tas",
+            "threshold": build_threshold(
+                thresholds=["> 90 doy_per", "<= 30 degC"],
+                logical_link="and",
+                reference_period=("2042-01-01", "2043-12-31"),
+            ),
+            "time_range": ("2042-01-01", "2045-12-31"),
+            "out_file": self.OUTPUT_FILE,
+            "slice_mode": "year",
+        }
+
+        eager = icclim.average(**{**common_kwargs, "in_files": tas.compute()}).compute()
+        generic_functions.reset_bootstrap_profile()
+
+        default = icclim.average(**common_kwargs)
+        profile = generic_functions.get_bootstrap_profile()
+
+        assert profile["bootstrap_execution_kind"] == "optimized_bootstrap"
+        assert (
+            profile["bootstrap_reason_code"]
+            == "optimized_scalar_bounded_bootstrap_supported"
+        )
+        assert profile["bootstrap_family"] == "day_of_year_percentile_compound"
+        xr.testing.assert_allclose(default.average.load(), eager.average)
+
+    def test_sum__bounded_percentile_bootstrap_uses_optimized_path(
+        self,
+        monkeypatch,
+    ) -> None:
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS", "1")
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_FAST_TILE_CELLS", "1")
+        tas = stub_tas(tas_value=27 + K2C, lat_length=2, lon_length=2)
+        tas[5:10] = 0
+        tas = tas.chunk({"time": 365, "lat": 1, "lon": 1})
+        common_kwargs = {
+            "in_files": tas,
+            "var_name": "tas",
+            "threshold": build_threshold(
+                thresholds=["> 90 doy_per", "<= 30 degC"],
+                logical_link="and",
+                reference_period=("2042-01-01", "2043-12-31"),
+            ),
+            "time_range": ("2042-01-01", "2045-12-31"),
+            "out_file": self.OUTPUT_FILE,
+            "slice_mode": "year",
+        }
+
+        eager = icclim.sum(**{**common_kwargs, "in_files": tas.compute()}).compute()
+        generic_functions.reset_bootstrap_profile()
+
+        default = icclim.sum(**common_kwargs)
+        profile = generic_functions.get_bootstrap_profile()
+
+        assert profile["bootstrap_execution_kind"] == "optimized_bootstrap"
+        assert (
+            profile["bootstrap_reason_code"]
+            == "optimized_scalar_bounded_bootstrap_supported"
+        )
+        assert profile["bootstrap_family"] == "day_of_year_percentile_compound"
+        xr.testing.assert_allclose(default["sum"].load(), eager["sum"])
+
+    def test_fraction_of_total__bounded_percentile_bootstrap_uses_optimized_path(
+        self,
+        monkeypatch,
+    ) -> None:
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS", "1")
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_FAST_TILE_CELLS", "1")
+        tas = stub_tas(tas_value=27 + K2C, lat_length=2, lon_length=2)
+        tas[5:10] = 0
+        tas = tas.chunk({"time": 365, "lat": 1, "lon": 1})
+        common_kwargs = {
+            "in_files": tas,
+            "var_name": "tas",
+            "threshold": build_threshold(
+                thresholds=["> 90 doy_per", "<= 30 degC"],
+                logical_link="and",
+                reference_period=("2042-01-01", "2043-12-31"),
+            ),
+            "time_range": ("2042-01-01", "2045-12-31"),
+            "out_file": self.OUTPUT_FILE,
+            "slice_mode": "year",
+        }
+
+        eager = icclim.fraction_of_total(
+            **{**common_kwargs, "in_files": tas.compute()}
+        ).compute()
+        generic_functions.reset_bootstrap_profile()
+
+        default = icclim.fraction_of_total(**common_kwargs)
+        profile = generic_functions.get_bootstrap_profile()
+
+        assert profile["bootstrap_execution_kind"] == "optimized_bootstrap"
+        assert (
+            profile["bootstrap_reason_code"]
+            == "optimized_scalar_bounded_bootstrap_supported"
+        )
+        assert profile["bootstrap_family"] == "day_of_year_percentile_compound"
+        xr.testing.assert_allclose(
+            default.fraction_of_total.load(),
+            eager.fraction_of_total,
         )
 
     def test_count_occurrences__optimized_bootstrap_defers_threshold_materialization(

--- a/tools/run_real_data_validation.py
+++ b/tools/run_real_data_validation.py
@@ -158,6 +158,54 @@ def _build_workload(icclim, workload: str) -> xr.Dataset:
             time_range=TIME_RANGE,
             slice_mode="year",
         )
+    if workload == "generic_tas_bounded_average_yearly":
+        tas = _open_var(TAS_GLOB, "tas")
+        percentile_threshold = icclim.build_threshold(
+            "> 90 doy_per",
+            reference_period=BASE_PERIOD,
+        )
+        return icclim.average(
+            in_files=tas,
+            var_name="tas",
+            threshold=icclim.build_threshold(
+                thresholds=[percentile_threshold, "<= 30 degC"],
+                logical_link="and",
+            ),
+            time_range=TIME_RANGE,
+            slice_mode="year",
+        )
+    if workload == "generic_tas_bounded_sum_yearly":
+        tas = _open_var(TAS_GLOB, "tas")
+        percentile_threshold = icclim.build_threshold(
+            "> 90 doy_per",
+            reference_period=BASE_PERIOD,
+        )
+        return icclim.sum(
+            in_files=tas,
+            var_name="tas",
+            threshold=icclim.build_threshold(
+                thresholds=[percentile_threshold, "<= 30 degC"],
+                logical_link="and",
+            ),
+            time_range=TIME_RANGE,
+            slice_mode="year",
+        )
+    if workload == "generic_tas_bounded_fraction_yearly":
+        tas = _open_var(TAS_GLOB, "tas")
+        percentile_threshold = icclim.build_threshold(
+            "> 90 doy_per",
+            reference_period=BASE_PERIOD,
+        )
+        return icclim.fraction_of_total(
+            in_files=tas,
+            var_name="tas",
+            threshold=icclim.build_threshold(
+                thresholds=[percentile_threshold, "<= 30 degC"],
+                logical_link="and",
+            ),
+            time_range=TIME_RANGE,
+            slice_mode="year",
+        )
     if workload == "generic_pr_fraction_bootstrap_yearly":
         pr = _open_var(PR_GLOB, "pr")
         return icclim.fraction_of_total(

--- a/tools/summarize_real_data_validation.py
+++ b/tools/summarize_real_data_validation.py
@@ -161,8 +161,20 @@ def _format_validation_status(
 def _workload_notes(workload: str) -> str:
     notes = {
         "generic_tas_bounded_count_yearly": (
-            "bounded percentile count; raw older baselines need recursive-threshold"
-            " hotfix, and v7.1.7 also needs logical-link hotfix"
+            "bounded scalar-guard count; dedicated compiled path validated"
+            " on Kraken real data"
+        ),
+        "generic_tas_bounded_average_yearly": (
+            "bounded scalar-guard average; dedicated compiled path validated"
+            " on Kraken real data"
+        ),
+        "generic_tas_bounded_sum_yearly": (
+            "bounded scalar-guard sum; dedicated compiled path validated"
+            " on Kraken real data"
+        ),
+        "generic_tas_bounded_fraction_yearly": (
+            "bounded scalar-guard fraction_of_total; dedicated compiled path"
+            " validated on Kraken real data"
         ),
         "generic_pr_fraction_bootstrap_yearly": (
             "filtered value aggregate; wet-day style threshold_min_value"


### PR DESCRIPTION
## Summary
- add a dedicated compiled bootstrap path for single-variable bounded scalar guards such as `> 90 doy_per AND <= 30 degC`
- use that path for `count_occurrences`, `average`, `sum`, and `fraction_of_total`
- keep the routing explicit in `bootstrap_capability.py`, with a narrow validated shape instead of broad compound assumptions
- update maintainer documentation and real-data validation notes for the new bounded scalar boundary

## Local validation
- `pre-commit run --files src/icclim/_core/generic/bootstrap.py src/icclim/_core/generic/bootstrap_capability.py src/icclim/_core/generic/functions.py tests/test_bootstrap_capability.py tests/test_main.py tools/run_real_data_validation.py tools/summarize_real_data_validation.py`
- `pytest -q tests/test_bootstrap_capability.py tests/test_main.py tests/test_generic_functions.py -k 'bounded and (average or sum or fraction_of_total or count_occurrences)'`
  - `4 passed`
- `pytest -q tests/test_bootstrap_capability.py tests/test_main.py tests/test_generic_functions.py -k 'bounded or bootstrap or fraction_of_total or average or sum or count_occurrences'`
  - `56 passed`

## Kraken real-data validation
Trusted baseline: fresh `master`
Workload shape: `tas`, yearly, bounded scalar guard `> 90 doy_per AND <= 30 degC`

Exactness:
- bounded `count`: exact, `changed_cells = 0`, `max_abs_diff = 0.0`
- bounded `average`: exact, `changed_cells = 0`, `max_abs_diff = 0.0`
- bounded `sum`: exact, `changed_cells = 0`, `max_abs_diff = 0.0`
- bounded `fraction_of_total`: exact, `changed_cells = 0`, `max_abs_diff = 0.0`

Performance:
- bounded `count`
  - current `87.66s`
  - trusted `master` `122.81s`
  - about `1.40x` faster
- bounded `average`
  - current `87.91s`
  - trusted `master` `104.91s`
  - about `1.19x` faster
- bounded `sum`
  - current `85.69s`
  - trusted `master` `108.09s`
  - about `1.26x` faster
- bounded `fraction_of_total`
  - current `82.54s`
  - trusted `master` `109.36s`
  - about `1.32x` faster

## Notes
- only the narrow bounded scalar shape is routed to the new compiled path:
  - one climate variable
  - one day-of-year percentile leaf
  - one scalar threshold leaf
  - logical `AND`
- broader compound shapes still keep their existing routing
