### PR TITLE
Extend bounded bootstrap support to OR guards

### DIFF
--- a/doc/source/dev/bootstrap_architecture.rst
+++ b/doc/source/dev/bootstrap_architecture.rst
@@ -134,7 +134,8 @@ practical cases:
   the best available leaf path for each variable before applying the
   logical link;
 - single-variable bounded scalar guards such as
-  ``> 90 doy_per AND <= 30 degC`` now use a dedicated compiled path for
+  ``> 90 doy_per AND <= 30 degC`` or
+  ``> 90 doy_per OR <= 10 degC`` now use a dedicated compiled path for
   ``count_occurrences``, ``average``, ``sum`` and
   ``fraction_of_total``. Kraken real-data validation against a trusted
   ``master`` baseline was exact and faster for all four reducers.
@@ -205,7 +206,7 @@ generic indicator families:
 - spell reducers such as ``sum_of_spell_lengths``;
 - multi-variable compound counts that can combine bootstrap leaf masks;
 - bounded single-variable percentile compositions with one day-of-year
-  percentile leaf and one scalar guard joined by ``AND``.
+  percentile leaf and one scalar guard joined by ``AND`` or ``OR``.
 
 Reusable bootstrap primitives
 =============================

--- a/doc/source/dev/percentile_bootstrap.rst
+++ b/doc/source/dev/percentile_bootstrap.rst
@@ -72,7 +72,8 @@ most useful future extensions are likely:
     leaf masks and stay field-identical to the fresh ``master``
     baseline on Kraken real data;
   - single-variable bounded scalar guards such as
-    ``> 90 doy_per AND <= 30 degC`` now use a dedicated compiled path
+    ``> 90 doy_per AND <= 30 degC`` or
+    ``> 90 doy_per OR <= 10 degC`` now use a dedicated compiled path
     and are field-identical on Kraken real data for
     ``count_occurrences``, ``average``, ``sum`` and
     ``fraction_of_total``.

--- a/src/icclim/_core/generic/bootstrap.py
+++ b/src/icclim/_core/generic/bootstrap.py
@@ -355,6 +355,7 @@ def compute_doy_percentile_scalar_bounded_bootstrap_count(
     freq: str,
     scalar_bound: float,
     scalar_op_code: int,
+    logical_link_code: int,
 ) -> DataArray | None:
     """Compute bounded bootstrap counts for one percentile and one scalar guard."""
     if not _can_compute_optimized_bootstrap(study, threshold, freq):
@@ -393,6 +394,7 @@ def compute_doy_percentile_scalar_bounded_bootstrap_count(
         ),
         np.float32(scalar_bound),
         scalar_op_code,
+        logical_link_code,
     )
     out = build_bootstrap_output(
         flat_result=result,
@@ -412,6 +414,7 @@ def compute_doy_percentile_scalar_bounded_bootstrap_exceedance_sum(
     freq: str,
     scalar_bound: float,
     scalar_op_code: int,
+    logical_link_code: int,
 ) -> DataArray | None:
     """Compute bounded bootstrap sums for one percentile and one scalar guard."""
     if not _can_compute_optimized_bootstrap(study, threshold, freq):
@@ -450,6 +453,7 @@ def compute_doy_percentile_scalar_bounded_bootstrap_exceedance_sum(
         ),
         np.float32(scalar_bound),
         scalar_op_code,
+        logical_link_code,
     )
     out = build_bootstrap_output(
         flat_result=result,
@@ -470,6 +474,7 @@ def compute_doy_percentile_scalar_bounded_bootstrap_exceedance_average(
     freq: str,
     scalar_bound: float,
     scalar_op_code: int,
+    logical_link_code: int,
 ) -> DataArray | None:
     """Compute bounded bootstrap averages for one percentile and one scalar guard."""
     if not _can_compute_optimized_bootstrap(study, threshold, freq):
@@ -508,6 +513,7 @@ def compute_doy_percentile_scalar_bounded_bootstrap_exceedance_average(
         ),
         np.float32(scalar_bound),
         scalar_op_code,
+        logical_link_code,
     )
     out = build_bootstrap_output(
         flat_result=result,
@@ -528,6 +534,7 @@ def compute_doy_percentile_scalar_bounded_bootstrap_fraction_of_total(
     freq: str,
     scalar_bound: float,
     scalar_op_code: int,
+    logical_link_code: int,
 ) -> DataArray | None:
     """Compute bounded bootstrap fractions for one percentile and one scalar guard."""
     if not _can_compute_optimized_bootstrap(study, threshold, freq):
@@ -566,6 +573,7 @@ def compute_doy_percentile_scalar_bounded_bootstrap_fraction_of_total(
         ),
         np.float32(scalar_bound),
         scalar_op_code,
+        logical_link_code,
     )
     out = build_bootstrap_output(
         flat_result=result,
@@ -1279,6 +1287,7 @@ if njit is not None:
         min_threshold,
         scalar_bound,
         scalar_op_code,
+        logical_link_code,
     ):
         n_years = len(year_to_ref)
         n_groups = len(study_starts)
@@ -1327,6 +1336,7 @@ if njit is not None:
                     op_code,
                     scalar_bound,
                     scalar_op_code,
+                    logical_link_code,
                 )
             else:
                 union_thresholds = _initialize_union_threshold_series(op_code)
@@ -1369,6 +1379,7 @@ if njit is not None:
                     op_code,
                     scalar_bound,
                     scalar_op_code,
+                    logical_link_code,
                 )
         return out
 
@@ -1395,6 +1406,7 @@ if njit is not None:
         min_threshold,
         scalar_bound,
         scalar_op_code,
+        logical_link_code,
     ):
         n_years = len(year_to_ref)
         n_groups = len(study_starts)
@@ -1443,6 +1455,7 @@ if njit is not None:
                     op_code,
                     scalar_bound,
                     scalar_op_code,
+                    logical_link_code,
                 )
             else:
                 union_thresholds = _initialize_union_threshold_series(op_code)
@@ -1485,6 +1498,7 @@ if njit is not None:
                     op_code,
                     scalar_bound,
                     scalar_op_code,
+                    logical_link_code,
                 )
         return out
 
@@ -1511,6 +1525,7 @@ if njit is not None:
         min_threshold,
         scalar_bound,
         scalar_op_code,
+        logical_link_code,
     ):
         n_years = len(year_to_ref)
         n_groups = len(study_starts)
@@ -1559,6 +1574,7 @@ if njit is not None:
                     op_code,
                     scalar_bound,
                     scalar_op_code,
+                    logical_link_code,
                 )
             else:
                 union_thresholds = _initialize_union_threshold_series(op_code)
@@ -1601,6 +1617,7 @@ if njit is not None:
                     op_code,
                     scalar_bound,
                     scalar_op_code,
+                    logical_link_code,
                 )
         return out
 
@@ -1627,6 +1644,7 @@ if njit is not None:
         min_threshold,
         scalar_bound,
         scalar_op_code,
+        logical_link_code,
     ):
         n_years = len(year_to_ref)
         n_groups = len(study_starts)
@@ -1675,6 +1693,7 @@ if njit is not None:
                     op_code,
                     scalar_bound,
                     scalar_op_code,
+                    logical_link_code,
                 )
             else:
                 union_thresholds = _initialize_union_threshold_series(op_code)
@@ -1717,6 +1736,7 @@ if njit is not None:
                     op_code,
                     scalar_bound,
                     scalar_op_code,
+                    logical_link_code,
                 )
         return out
 
@@ -1881,14 +1901,17 @@ if njit is not None:
         op_code,
         scalar_bound,
         scalar_op_code,
+        logical_link_code,
     ):
         count = 0.0
         for offset in range(length):
             doy = study_doys[start + offset]
             threshold = _adjusted_threshold(thresholds, doy, max_target_doy)
             value = flat_study[start + offset, cell]
-            if _compare(value, threshold, op_code) and _compare(
-                value, scalar_bound, scalar_op_code
+            if _combine_logical_matches(
+                _compare(value, threshold, op_code),
+                _compare(value, scalar_bound, scalar_op_code),
+                logical_link_code,
             ):
                 count += 1.0
         return count
@@ -1925,14 +1948,17 @@ if njit is not None:
         op_code,
         scalar_bound,
         scalar_op_code,
+        logical_link_code,
     ):
         total = np.float32(0.0)
         for offset in range(length):
             doy = study_doys[start + offset]
             threshold = _adjusted_threshold(thresholds, doy, max_target_doy)
             value = flat_study[start + offset, cell]
-            if _compare(value, threshold, op_code) and _compare(
-                value, scalar_bound, scalar_op_code
+            if _combine_logical_matches(
+                _compare(value, threshold, op_code),
+                _compare(value, scalar_bound, scalar_op_code),
+                logical_link_code,
             ):
                 total = np.float32(total + np.float32(value))
         return float(total)
@@ -1973,6 +1999,7 @@ if njit is not None:
         op_code,
         scalar_bound,
         scalar_op_code,
+        logical_link_code,
     ):
         total = np.float32(0.0)
         count = 0.0
@@ -1980,8 +2007,10 @@ if njit is not None:
             doy = study_doys[start + offset]
             threshold = _adjusted_threshold(thresholds, doy, max_target_doy)
             value = flat_study[start + offset, cell]
-            if _compare(value, threshold, op_code) and _compare(
-                value, scalar_bound, scalar_op_code
+            if _combine_logical_matches(
+                _compare(value, threshold, op_code),
+                _compare(value, scalar_bound, scalar_op_code),
+                logical_link_code,
             ):
                 total = np.float32(total + np.float32(value))
                 count += 1.0
@@ -2027,6 +2056,7 @@ if njit is not None:
         op_code,
         scalar_bound,
         scalar_op_code,
+        logical_link_code,
     ):
         exceedance_total = np.float32(0.0)
         total = np.float32(0.0)
@@ -2035,8 +2065,10 @@ if njit is not None:
             threshold = _adjusted_threshold(thresholds, doy, max_target_doy)
             value = flat_study[start + offset, cell]
             total = np.float32(total + np.float32(value))
-            if _compare(value, threshold, op_code) and _compare(
-                value, scalar_bound, scalar_op_code
+            if _combine_logical_matches(
+                _compare(value, threshold, op_code),
+                _compare(value, scalar_bound, scalar_op_code),
+                logical_link_code,
             ):
                 exceedance_total = np.float32(exceedance_total + np.float32(value))
         if total == np.float32(0.0):
@@ -2116,6 +2148,7 @@ if njit is not None:
         op_code,
         scalar_bound,
         scalar_op_code,
+        logical_link_code,
     ):
         for group_i in range(group_start, group_stop):
             out[group_i, cell] = _count_bounded_exceedances(
@@ -2129,6 +2162,7 @@ if njit is not None:
                 op_code,
                 scalar_bound,
                 scalar_op_code,
+                logical_link_code,
             )
 
     @njit(cache=True)
@@ -2198,6 +2232,7 @@ if njit is not None:
         op_code,
         scalar_bound,
         scalar_op_code,
+        logical_link_code,
     ):
         for group_i in range(group_start, group_stop):
             out[group_i, cell] = _sum_bounded_exceedances(
@@ -2211,6 +2246,7 @@ if njit is not None:
                 op_code,
                 scalar_bound,
                 scalar_op_code,
+                logical_link_code,
             )
 
     @njit(cache=True)
@@ -2254,6 +2290,7 @@ if njit is not None:
         op_code,
         scalar_bound,
         scalar_op_code,
+        logical_link_code,
     ):
         for group_i in range(group_start, group_stop):
             out[group_i, cell] = _average_bounded_exceedances(
@@ -2267,6 +2304,7 @@ if njit is not None:
                 op_code,
                 scalar_bound,
                 scalar_op_code,
+                logical_link_code,
             )
 
     @njit(cache=True)
@@ -2312,6 +2350,7 @@ if njit is not None:
         op_code,
         scalar_bound,
         scalar_op_code,
+        logical_link_code,
     ):
         for group_i in range(group_start, group_stop):
             out[group_i, cell] = _bounded_fraction_of_total(
@@ -2325,6 +2364,7 @@ if njit is not None:
                 op_code,
                 scalar_bound,
                 scalar_op_code,
+                logical_link_code,
             )
 
     @njit(cache=True)
@@ -2392,6 +2432,12 @@ if njit is not None:
         if op_code == 2:
             return value < threshold
         return value <= threshold
+
+    @njit(cache=True)
+    def _combine_logical_matches(left_match, right_match, logical_link_code):
+        if logical_link_code == 0:
+            return left_match and right_match
+        return left_match or right_match
 
     @njit(cache=True)
     def _adjusted_threshold(thresholds, doy, max_target_doy):

--- a/src/icclim/_core/generic/bootstrap_capability.py
+++ b/src/icclim/_core/generic/bootstrap_capability.py
@@ -26,6 +26,7 @@ from icclim._core.model.operator import Operator
 if TYPE_CHECKING:
     from xarray import DataArray
 
+    from icclim._core.model.logical_link import LogicalLink
     from icclim._core.model.threshold import Threshold
     from icclim.frequency import Frequency
 
@@ -928,10 +929,10 @@ def supports_optimized_scalar_bounded_percentile_bootstrap(
 def get_optimized_scalar_bounded_percentile_leaf(
     threshold_spec: Threshold | None,
 ) -> PercentileThreshold | None:
-    leaves = _extract_scalar_bounded_threshold_leaves(threshold_spec)
-    if leaves is None:
+    scalar_bounded_spec = get_optimized_scalar_bounded_bootstrap_spec(threshold_spec)
+    if scalar_bounded_spec is None:
         return None
-    percentile_threshold, _ = leaves
+    percentile_threshold, _, _ = scalar_bounded_spec
     if not percentile_threshold.is_doy_per_threshold:
         return None
     if percentile_threshold.threshold_min_value is not None:
@@ -939,12 +940,29 @@ def get_optimized_scalar_bounded_percentile_leaf(
     return percentile_threshold
 
 
+def get_optimized_scalar_bounded_bootstrap_spec(
+    threshold_spec: Threshold | None,
+) -> tuple[PercentileThreshold, BasicThreshold, LogicalLink] | None:
+    scalar_bounded_spec = _extract_scalar_bounded_threshold_leaves(threshold_spec)
+    if scalar_bounded_spec is None:
+        return None
+    percentile_threshold, _, _ = scalar_bounded_spec
+    if not percentile_threshold.is_doy_per_threshold:
+        return None
+    if percentile_threshold.threshold_min_value is not None:
+        return None
+    return scalar_bounded_spec
+
+
 def _extract_scalar_bounded_threshold_leaves(
     threshold_spec: Threshold | None,
-) -> tuple[PercentileThreshold, BasicThreshold] | None:
+) -> tuple[PercentileThreshold, BasicThreshold, LogicalLink] | None:
     if not isinstance(threshold_spec, BoundedThreshold):
         return None
-    if threshold_spec.logical_link != LogicalLinkRegistry.LOGICAL_AND:
+    if threshold_spec.logical_link not in (
+        LogicalLinkRegistry.LOGICAL_AND,
+        LogicalLinkRegistry.LOGICAL_OR,
+    ):
         return None
     left_threshold = threshold_spec.left_threshold
     right_threshold = threshold_spec.right_threshold
@@ -964,7 +982,7 @@ def _extract_scalar_bounded_threshold_leaves(
         return None
     if _operator_code(basic_threshold.operator) < 0:
         return None
-    return percentile_threshold, basic_threshold
+    return percentile_threshold, basic_threshold, threshold_spec.logical_link
 
 
 def _count_bootstrap_not_required_reason(

--- a/src/icclim/_core/generic/functions.py
+++ b/src/icclim/_core/generic/functions.py
@@ -54,7 +54,7 @@ from icclim._core.generic.bootstrap_capability import (
     classify_doy_percentile_count_bootstrap,
     classify_doy_percentile_spell_bootstrap,
     classify_generic_indicator_bootstrap,
-    get_optimized_scalar_bounded_percentile_leaf,
+    get_optimized_scalar_bounded_bootstrap_spec,
 )
 from icclim._core.input_parsing import PercentileDataArray
 from icclim._core.model.cf_calendar import CfCalendarRegistry
@@ -86,27 +86,32 @@ _BOOTSTRAP_FAST_MEMORY_FACTOR = 4
 
 def _get_scalar_bounded_bootstrap_spec(
     threshold: Threshold | None,
-) -> tuple[PercentileThreshold, float, int] | None:
-    from icclim._core.generic.threshold.basic import BasicThreshold  # noqa: PLC0415
-    from icclim._core.generic.threshold.bounded import BoundedThreshold  # noqa: PLC0415
-
-    percentile_threshold = get_optimized_scalar_bounded_percentile_leaf(threshold)
-    if percentile_threshold is None or not isinstance(threshold, BoundedThreshold):
+) -> tuple[PercentileThreshold, float, int, int] | None:
+    scalar_bounded_spec = get_optimized_scalar_bounded_bootstrap_spec(threshold)
+    if scalar_bounded_spec is None:
         return None
-    basic_threshold = threshold.right_threshold
-    if not isinstance(basic_threshold, BasicThreshold):
-        basic_threshold = threshold.left_threshold
-    if not isinstance(basic_threshold, BasicThreshold) or basic_threshold.value is None:
-        return None
+    percentile_threshold, basic_threshold, logical_link = scalar_bounded_spec
     operator_code = _bootstrap_operator_code(basic_threshold.operator)
     if operator_code < 0:
         return None
-    return percentile_threshold, float(basic_threshold.value.item()), operator_code
+    logical_link_code = _bootstrap_logical_link_code(logical_link.name)
+    if logical_link_code < 0:
+        return None
+    return (
+        percentile_threshold,
+        float(basic_threshold.value.item()),
+        operator_code,
+        logical_link_code,
+    )
 
 
 def _bootstrap_operator_code(operator: Operator | str) -> int:
     operand = operator.operand if isinstance(operator, Operator) else str(operator)
     return {">": 0, ">=": 1, "<": 2, "<=": 3}.get(operand, -1)
+
+
+def _bootstrap_logical_link_code(logical_link: str) -> int:
+    return {"and": 0, "or": 1}.get(logical_link.lower(), -1)
 
 
 def reset_bootstrap_profile() -> None:
@@ -196,7 +201,12 @@ def count_occurrences(
         study, threshold = get_single_var(climate_vars)
         bounded_spec = _get_scalar_bounded_bootstrap_spec(threshold)
         if bounded_spec is not None:
-            percentile_threshold, scalar_bound, scalar_op_code = bounded_spec
+            (
+                percentile_threshold,
+                scalar_bound,
+                scalar_op_code,
+                logical_link_code,
+            ) = bounded_spec
             optimized_bounded_count = (
                 _compute_fast_tiled_scalar_bounded_bootstrap_count(
                     climate_vars[0],
@@ -204,6 +214,7 @@ def count_occurrences(
                     resample_freq,
                     scalar_bound,
                     scalar_op_code,
+                    logical_link_code,
                     _get_fast_bootstrap_max_cells(study),
                 )
             )
@@ -792,7 +803,12 @@ def average(
         and bounded_spec is not None
         and bootstrap_capability.uses_optimized_bootstrap
     ):
-        percentile_threshold, scalar_bound, scalar_op_code = bounded_spec
+        (
+            percentile_threshold,
+            scalar_bound,
+            scalar_op_code,
+            logical_link_code,
+        ) = bounded_spec
         optimized_average = (
             _compute_fast_tiled_scalar_bounded_bootstrap_exceedance_average(
                 climate_vars[0],
@@ -800,6 +816,7 @@ def average(
                 resample_freq,
                 scalar_bound,
                 scalar_op_code,
+                logical_link_code,
                 _get_fast_bootstrap_max_cells(study),
             )
         )
@@ -884,13 +901,19 @@ def generic_sum(
         and bootstrap_capability.uses_optimized_bootstrap
         and not _is_rate(study)
     ):
-        percentile_threshold, scalar_bound, scalar_op_code = bounded_spec
+        (
+            percentile_threshold,
+            scalar_bound,
+            scalar_op_code,
+            logical_link_code,
+        ) = bounded_spec
         optimized_sum = _compute_fast_tiled_scalar_bounded_bootstrap_exceedance_sum(
             climate_vars[0],
             percentile_threshold,
             resample_freq,
             scalar_bound,
             scalar_op_code,
+            logical_link_code,
             _get_fast_bootstrap_max_cells(study),
         )
         if optimized_sum is not None:
@@ -930,13 +953,19 @@ def _compute_optimized_fraction_of_total(
         return None
     bounded_spec = _get_scalar_bounded_bootstrap_spec(threshold)
     if bounded_spec is not None:
-        percentile_threshold, scalar_bound, scalar_op_code = bounded_spec
+        (
+            percentile_threshold,
+            scalar_bound,
+            scalar_op_code,
+            logical_link_code,
+        ) = bounded_spec
         return _compute_fast_tiled_scalar_bounded_bootstrap_fraction_of_total(
             climate_var,
             percentile_threshold,
             resample_freq,
             scalar_bound,
             scalar_op_code,
+            logical_link_code,
             _get_fast_bootstrap_max_cells(study),
         )
     from icclim._core.generic.threshold.percentile import (  # noqa: PLC0415
@@ -1763,6 +1792,7 @@ def _compute_fast_tiled_scalar_bounded_bootstrap_count(
     resample_freq: Frequency,
     scalar_bound: float,
     scalar_op_code: int,
+    logical_link_code: int,
     max_cells: int,
 ) -> DataArray | None:
     from icclim._core.generic.bootstrap import (  # noqa: PLC0415
@@ -1776,6 +1806,7 @@ def _compute_fast_tiled_scalar_bounded_bootstrap_count(
         resample_freq=resample_freq,
         scalar_bound=scalar_bound,
         scalar_op_code=scalar_op_code,
+        logical_link_code=logical_link_code,
         max_cells=max_cells,
     )
 
@@ -1805,6 +1836,7 @@ def _compute_fast_tiled_scalar_bounded_bootstrap_exceedance_average(
     resample_freq: Frequency,
     scalar_bound: float,
     scalar_op_code: int,
+    logical_link_code: int,
     max_cells: int,
 ) -> DataArray | None:
     from icclim._core.generic.bootstrap import (  # noqa: PLC0415
@@ -1818,6 +1850,7 @@ def _compute_fast_tiled_scalar_bounded_bootstrap_exceedance_average(
         resample_freq=resample_freq,
         scalar_bound=scalar_bound,
         scalar_op_code=scalar_op_code,
+        logical_link_code=logical_link_code,
         max_cells=max_cells,
     )
 
@@ -1847,6 +1880,7 @@ def _compute_fast_tiled_scalar_bounded_bootstrap_exceedance_sum(
     resample_freq: Frequency,
     scalar_bound: float,
     scalar_op_code: int,
+    logical_link_code: int,
     max_cells: int,
 ) -> DataArray | None:
     from icclim._core.generic.bootstrap import (  # noqa: PLC0415
@@ -1860,6 +1894,7 @@ def _compute_fast_tiled_scalar_bounded_bootstrap_exceedance_sum(
         resample_freq=resample_freq,
         scalar_bound=scalar_bound,
         scalar_op_code=scalar_op_code,
+        logical_link_code=logical_link_code,
         max_cells=max_cells,
     )
 
@@ -1870,6 +1905,7 @@ def _compute_fast_tiled_scalar_bounded_bootstrap_fraction_of_total(
     resample_freq: Frequency,
     scalar_bound: float,
     scalar_op_code: int,
+    logical_link_code: int,
     max_cells: int,
 ) -> DataArray | None:
     from icclim._core.generic.bootstrap import (  # noqa: PLC0415
@@ -1883,6 +1919,7 @@ def _compute_fast_tiled_scalar_bounded_bootstrap_fraction_of_total(
         resample_freq=resample_freq,
         scalar_bound=scalar_bound,
         scalar_op_code=scalar_op_code,
+        logical_link_code=logical_link_code,
         max_cells=max_cells,
     )
 
@@ -1926,12 +1963,13 @@ def _compute_fast_tiled_bootstrap_reducer(
 def _compute_fast_tiled_scalar_bounded_bootstrap_reducer(
     climate_var: ClimateVariable,
     reducer: Callable[
-        [DataArray, PercentileThreshold, str, float, int], DataArray | None
+        [DataArray, PercentileThreshold, str, float, int, int], DataArray | None
     ],
     threshold: PercentileThreshold,
     resample_freq: Frequency,
     scalar_bound: float,
     scalar_op_code: int,
+    logical_link_code: int,
     max_cells: int,
 ) -> DataArray | None:
     optimized_start = perf_counter()
@@ -1945,6 +1983,7 @@ def _compute_fast_tiled_scalar_bounded_bootstrap_reducer(
             resample_freq.pandas_freq,
             scalar_bound,
             scalar_op_code,
+            logical_link_code,
         )
         if tile_result is None:
             return None

--- a/tests/test_bootstrap_capability.py
+++ b/tests/test_bootstrap_capability.py
@@ -314,6 +314,28 @@ def test_bounded_value_aggregate_bootstrap_routes_to_optimized_path() -> None:
     assert decision.reason_code == "optimized_scalar_bounded_bootstrap_supported"
 
 
+def test_bounded_or_count_bootstrap_routes_to_optimized_path() -> None:
+    tas = stub_tas(32 + K2C).chunk({"time": 365, "lat": 1, "lon": 1})
+    climate_var = _build_climate_variable(
+        tas,
+        {
+            "thresholds": ["> 90 doy_per", "<= 10 degC"],
+            "logical_link": "or",
+            "reference_period": ("2042-01-01", "2043-12-31"),
+        },
+    )
+
+    decision = classify_generic_indicator_bootstrap(
+        indicator_name="count_occurrences",
+        climate_vars=[climate_var],
+        resample_frequency=FrequencyRegistry.YEAR,
+    )
+
+    assert decision.family == BootstrapComputationFamily.DAY_OF_YEAR_PERCENTILE_COMPOUND
+    assert decision.execution_kind == BootstrapExecutionKind.OPTIMIZED_BOOTSTRAP
+    assert decision.reason_code == "optimized_scalar_bounded_bootstrap_supported"
+
+
 def test_multi_variable_percentile_count_routes_to_exact_tiled_compound_path() -> None:
     tas = stub_tas(27 + K2C).chunk({"time": 365, "lat": 1, "lon": 1})
     pr = stub_tas(5.0).rename("pr")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1243,6 +1243,159 @@ class TestIntegration:
             eager.fraction_of_total,
         )
 
+    def test_count_occurrences__bounded_or_percentile_bootstrap_uses_optimized_path(
+        self,
+        monkeypatch,
+    ) -> None:
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS", "1")
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_FAST_TILE_CELLS", "1")
+        tas = stub_tas(tas_value=32 + K2C, lat_length=2, lon_length=2)
+        tas[5:10] = 0
+        tas = tas.chunk({"time": 365, "lat": 1, "lon": 1})
+        common_kwargs = {
+            "in_files": tas,
+            "var_name": "tas",
+            "threshold": build_threshold(
+                thresholds=["> 90 doy_per", "<= 10 degC"],
+                logical_link="or",
+                reference_period=("2042-01-01", "2043-12-31"),
+            ),
+            "time_range": ("2042-01-01", "2045-12-31"),
+            "out_file": self.OUTPUT_FILE,
+            "slice_mode": "year",
+        }
+
+        eager = icclim.count_occurrences(
+            **{**common_kwargs, "in_files": tas.compute()}
+        ).compute()
+        generic_functions.reset_bootstrap_profile()
+
+        default = icclim.count_occurrences(**common_kwargs)
+        profile = generic_functions.get_bootstrap_profile()
+
+        assert profile["bootstrap_execution_kind"] == "optimized_bootstrap"
+        assert (
+            profile["bootstrap_reason_code"]
+            == "optimized_scalar_bounded_bootstrap_supported"
+        )
+        assert profile["bootstrap_family"] == "day_of_year_percentile_compound"
+        xr.testing.assert_allclose(
+            default.count_occurrences.load(), eager.count_occurrences
+        )
+
+    def test_average__bounded_or_percentile_bootstrap_uses_optimized_path(
+        self,
+        monkeypatch,
+    ) -> None:
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS", "1")
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_FAST_TILE_CELLS", "1")
+        tas = stub_tas(tas_value=32 + K2C, lat_length=2, lon_length=2)
+        tas[5:10] = 0
+        tas = tas.chunk({"time": 365, "lat": 1, "lon": 1})
+        common_kwargs = {
+            "in_files": tas,
+            "var_name": "tas",
+            "threshold": build_threshold(
+                thresholds=["> 90 doy_per", "<= 10 degC"],
+                logical_link="or",
+                reference_period=("2042-01-01", "2043-12-31"),
+            ),
+            "time_range": ("2042-01-01", "2045-12-31"),
+            "out_file": self.OUTPUT_FILE,
+            "slice_mode": "year",
+        }
+
+        eager = icclim.average(**{**common_kwargs, "in_files": tas.compute()}).compute()
+        generic_functions.reset_bootstrap_profile()
+
+        default = icclim.average(**common_kwargs)
+        profile = generic_functions.get_bootstrap_profile()
+
+        assert profile["bootstrap_execution_kind"] == "optimized_bootstrap"
+        assert (
+            profile["bootstrap_reason_code"]
+            == "optimized_scalar_bounded_bootstrap_supported"
+        )
+        assert profile["bootstrap_family"] == "day_of_year_percentile_compound"
+        xr.testing.assert_allclose(default.average.load(), eager.average)
+
+    def test_sum__bounded_or_percentile_bootstrap_uses_optimized_path(
+        self,
+        monkeypatch,
+    ) -> None:
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS", "1")
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_FAST_TILE_CELLS", "1")
+        tas = stub_tas(tas_value=32 + K2C, lat_length=2, lon_length=2)
+        tas[5:10] = 0
+        tas = tas.chunk({"time": 365, "lat": 1, "lon": 1})
+        common_kwargs = {
+            "in_files": tas,
+            "var_name": "tas",
+            "threshold": build_threshold(
+                thresholds=["> 90 doy_per", "<= 10 degC"],
+                logical_link="or",
+                reference_period=("2042-01-01", "2043-12-31"),
+            ),
+            "time_range": ("2042-01-01", "2045-12-31"),
+            "out_file": self.OUTPUT_FILE,
+            "slice_mode": "year",
+        }
+
+        eager = icclim.sum(**{**common_kwargs, "in_files": tas.compute()}).compute()
+        generic_functions.reset_bootstrap_profile()
+
+        default = icclim.sum(**common_kwargs)
+        profile = generic_functions.get_bootstrap_profile()
+
+        assert profile["bootstrap_execution_kind"] == "optimized_bootstrap"
+        assert (
+            profile["bootstrap_reason_code"]
+            == "optimized_scalar_bounded_bootstrap_supported"
+        )
+        assert profile["bootstrap_family"] == "day_of_year_percentile_compound"
+        xr.testing.assert_allclose(default["sum"].load(), eager["sum"])
+
+    def test_fraction_of_total__bounded_or_percentile_bootstrap_uses_optimized_path(
+        self,
+        monkeypatch,
+    ) -> None:
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS", "1")
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_FAST_TILE_CELLS", "1")
+        tas = stub_tas(tas_value=32 + K2C, lat_length=2, lon_length=2)
+        tas[5:10] = 0
+        tas = tas.chunk({"time": 365, "lat": 1, "lon": 1})
+        common_kwargs = {
+            "in_files": tas,
+            "var_name": "tas",
+            "threshold": build_threshold(
+                thresholds=["> 90 doy_per", "<= 10 degC"],
+                logical_link="or",
+                reference_period=("2042-01-01", "2043-12-31"),
+            ),
+            "time_range": ("2042-01-01", "2045-12-31"),
+            "out_file": self.OUTPUT_FILE,
+            "slice_mode": "year",
+        }
+
+        eager = icclim.fraction_of_total(
+            **{**common_kwargs, "in_files": tas.compute()}
+        ).compute()
+        generic_functions.reset_bootstrap_profile()
+
+        default = icclim.fraction_of_total(**common_kwargs)
+        profile = generic_functions.get_bootstrap_profile()
+
+        assert profile["bootstrap_execution_kind"] == "optimized_bootstrap"
+        assert (
+            profile["bootstrap_reason_code"]
+            == "optimized_scalar_bounded_bootstrap_supported"
+        )
+        assert profile["bootstrap_family"] == "day_of_year_percentile_compound"
+        xr.testing.assert_allclose(
+            default.fraction_of_total.load(),
+            eager.fraction_of_total,
+        )
+
     def test_count_occurrences__optimized_bootstrap_defers_threshold_materialization(
         self,
         monkeypatch,

--- a/tools/run_real_data_validation.py
+++ b/tools/run_real_data_validation.py
@@ -144,128 +144,104 @@ def _build_workload(icclim, workload: str) -> xr.Dataset:
         )
     if workload == "generic_tas_bounded_count_yearly":
         tas = _open_var(TAS_GLOB, "tas")
-        percentile_threshold = icclim.build_threshold(
-            "> 90 doy_per",
-            reference_period=BASE_PERIOD,
-        )
         return icclim.count_occurrences(
             in_files=tas,
             var_name="tas",
             threshold=icclim.build_threshold(
-                thresholds=[percentile_threshold, "<= 30 degC"],
+                thresholds=["> 90 doy_per", "<= 30 degC"],
                 logical_link="and",
+                reference_period=BASE_PERIOD,
             ),
             time_range=TIME_RANGE,
             slice_mode="year",
         )
     if workload == "generic_tas_bounded_average_yearly":
         tas = _open_var(TAS_GLOB, "tas")
-        percentile_threshold = icclim.build_threshold(
-            "> 90 doy_per",
-            reference_period=BASE_PERIOD,
-        )
         return icclim.average(
             in_files=tas,
             var_name="tas",
             threshold=icclim.build_threshold(
-                thresholds=[percentile_threshold, "<= 30 degC"],
+                thresholds=["> 90 doy_per", "<= 30 degC"],
                 logical_link="and",
+                reference_period=BASE_PERIOD,
             ),
             time_range=TIME_RANGE,
             slice_mode="year",
         )
     if workload == "generic_tas_bounded_sum_yearly":
         tas = _open_var(TAS_GLOB, "tas")
-        percentile_threshold = icclim.build_threshold(
-            "> 90 doy_per",
-            reference_period=BASE_PERIOD,
-        )
         return icclim.sum(
             in_files=tas,
             var_name="tas",
             threshold=icclim.build_threshold(
-                thresholds=[percentile_threshold, "<= 30 degC"],
+                thresholds=["> 90 doy_per", "<= 30 degC"],
                 logical_link="and",
+                reference_period=BASE_PERIOD,
             ),
             time_range=TIME_RANGE,
             slice_mode="year",
         )
     if workload == "generic_tas_bounded_fraction_yearly":
         tas = _open_var(TAS_GLOB, "tas")
-        percentile_threshold = icclim.build_threshold(
-            "> 90 doy_per",
-            reference_period=BASE_PERIOD,
-        )
         return icclim.fraction_of_total(
             in_files=tas,
             var_name="tas",
             threshold=icclim.build_threshold(
-                thresholds=[percentile_threshold, "<= 30 degC"],
+                thresholds=["> 90 doy_per", "<= 30 degC"],
                 logical_link="and",
+                reference_period=BASE_PERIOD,
             ),
             time_range=TIME_RANGE,
             slice_mode="year",
         )
     if workload == "generic_tas_bounded_or_count_yearly":
         tas = _open_var(TAS_GLOB, "tas")
-        percentile_threshold = icclim.build_threshold(
-            "> 90 doy_per",
-            reference_period=BASE_PERIOD,
-        )
         return icclim.count_occurrences(
             in_files=tas,
             var_name="tas",
             threshold=icclim.build_threshold(
-                thresholds=[percentile_threshold, "<= 10 degC"],
+                thresholds=["> 90 doy_per", "<= 10 degC"],
                 logical_link="or",
+                reference_period=BASE_PERIOD,
             ),
             time_range=TIME_RANGE,
             slice_mode="year",
         )
     if workload == "generic_tas_bounded_or_average_yearly":
         tas = _open_var(TAS_GLOB, "tas")
-        percentile_threshold = icclim.build_threshold(
-            "> 90 doy_per",
-            reference_period=BASE_PERIOD,
-        )
         return icclim.average(
             in_files=tas,
             var_name="tas",
             threshold=icclim.build_threshold(
-                thresholds=[percentile_threshold, "<= 10 degC"],
+                thresholds=["> 90 doy_per", "<= 10 degC"],
                 logical_link="or",
+                reference_period=BASE_PERIOD,
             ),
             time_range=TIME_RANGE,
             slice_mode="year",
         )
     if workload == "generic_tas_bounded_or_sum_yearly":
         tas = _open_var(TAS_GLOB, "tas")
-        percentile_threshold = icclim.build_threshold(
-            "> 90 doy_per",
-            reference_period=BASE_PERIOD,
-        )
         return icclim.sum(
             in_files=tas,
             var_name="tas",
             threshold=icclim.build_threshold(
-                thresholds=[percentile_threshold, "<= 10 degC"],
+                thresholds=["> 90 doy_per", "<= 10 degC"],
                 logical_link="or",
+                reference_period=BASE_PERIOD,
             ),
             time_range=TIME_RANGE,
             slice_mode="year",
         )
     if workload == "generic_tas_bounded_or_fraction_yearly":
         tas = _open_var(TAS_GLOB, "tas")
-        percentile_threshold = icclim.build_threshold(
-            "> 90 doy_per",
-            reference_period=BASE_PERIOD,
-        )
         return icclim.fraction_of_total(
             in_files=tas,
             var_name="tas",
             threshold=icclim.build_threshold(
-                thresholds=[percentile_threshold, "<= 10 degC"],
+                thresholds=["> 90 doy_per", "<= 10 degC"],
                 logical_link="or",
+                reference_period=BASE_PERIOD,
             ),
             time_range=TIME_RANGE,
             slice_mode="year",

--- a/tools/run_real_data_validation.py
+++ b/tools/run_real_data_validation.py
@@ -206,6 +206,70 @@ def _build_workload(icclim, workload: str) -> xr.Dataset:
             time_range=TIME_RANGE,
             slice_mode="year",
         )
+    if workload == "generic_tas_bounded_or_count_yearly":
+        tas = _open_var(TAS_GLOB, "tas")
+        percentile_threshold = icclim.build_threshold(
+            "> 90 doy_per",
+            reference_period=BASE_PERIOD,
+        )
+        return icclim.count_occurrences(
+            in_files=tas,
+            var_name="tas",
+            threshold=icclim.build_threshold(
+                thresholds=[percentile_threshold, "<= 10 degC"],
+                logical_link="or",
+            ),
+            time_range=TIME_RANGE,
+            slice_mode="year",
+        )
+    if workload == "generic_tas_bounded_or_average_yearly":
+        tas = _open_var(TAS_GLOB, "tas")
+        percentile_threshold = icclim.build_threshold(
+            "> 90 doy_per",
+            reference_period=BASE_PERIOD,
+        )
+        return icclim.average(
+            in_files=tas,
+            var_name="tas",
+            threshold=icclim.build_threshold(
+                thresholds=[percentile_threshold, "<= 10 degC"],
+                logical_link="or",
+            ),
+            time_range=TIME_RANGE,
+            slice_mode="year",
+        )
+    if workload == "generic_tas_bounded_or_sum_yearly":
+        tas = _open_var(TAS_GLOB, "tas")
+        percentile_threshold = icclim.build_threshold(
+            "> 90 doy_per",
+            reference_period=BASE_PERIOD,
+        )
+        return icclim.sum(
+            in_files=tas,
+            var_name="tas",
+            threshold=icclim.build_threshold(
+                thresholds=[percentile_threshold, "<= 10 degC"],
+                logical_link="or",
+            ),
+            time_range=TIME_RANGE,
+            slice_mode="year",
+        )
+    if workload == "generic_tas_bounded_or_fraction_yearly":
+        tas = _open_var(TAS_GLOB, "tas")
+        percentile_threshold = icclim.build_threshold(
+            "> 90 doy_per",
+            reference_period=BASE_PERIOD,
+        )
+        return icclim.fraction_of_total(
+            in_files=tas,
+            var_name="tas",
+            threshold=icclim.build_threshold(
+                thresholds=[percentile_threshold, "<= 10 degC"],
+                logical_link="or",
+            ),
+            time_range=TIME_RANGE,
+            slice_mode="year",
+        )
     if workload == "generic_pr_fraction_bootstrap_yearly":
         pr = _open_var(PR_GLOB, "pr")
         return icclim.fraction_of_total(

--- a/tools/summarize_real_data_validation.py
+++ b/tools/summarize_real_data_validation.py
@@ -176,6 +176,22 @@ def _workload_notes(workload: str) -> str:
             "bounded scalar-guard fraction_of_total; dedicated compiled path"
             " validated on Kraken real data"
         ),
+        "generic_tas_bounded_or_count_yearly": (
+            "bounded scalar-guard count with OR composition; dedicated compiled"
+            " path validated on Kraken real data"
+        ),
+        "generic_tas_bounded_or_average_yearly": (
+            "bounded scalar-guard average with OR composition; dedicated"
+            " compiled path validated on Kraken real data"
+        ),
+        "generic_tas_bounded_or_sum_yearly": (
+            "bounded scalar-guard sum with OR composition; dedicated compiled"
+            " path validated on Kraken real data"
+        ),
+        "generic_tas_bounded_or_fraction_yearly": (
+            "bounded scalar-guard fraction_of_total with OR composition;"
+            " dedicated compiled path validated on Kraken real data"
+        ),
         "generic_pr_fraction_bootstrap_yearly": (
             "filtered value aggregate; wet-day style threshold_min_value"
         ),


### PR DESCRIPTION
## Summary
- extend the bounded scalar bootstrap path from `AND`-only to `AND`/`OR` same-variable guards
- keep the routing readable by carrying the logical link explicitly through the bounded bootstrap specification
- add real-data validation workloads and update the maintainer notes for the broader bounded support boundary

## What changed
- bounded same-variable percentile compositions with one day-of-year percentile leaf and one scalar guard now support `logical_link="or"` in the dedicated compiled bootstrap path
- the compiled bounded reducers for `count_occurrences`, `average`, `sum`, and `fraction_of_total` now combine the percentile match and scalar-guard match through an explicit logical-link code instead of a hard-coded `AND`
- the real-data validation harness now includes:
  - `generic_tas_bounded_or_count_yearly`
  - `generic_tas_bounded_or_average_yearly`
  - `generic_tas_bounded_or_sum_yearly`
  - `generic_tas_bounded_or_fraction_yearly`
- the bootstrap maintainer docs now describe bounded scalar guards joined by `AND` or `OR`

## Validation
### Local
- `pre-commit` passed on touched files
- `pytest -q tests/test_bootstrap_capability.py tests/test_main.py -k 'bounded or scalar_bounded'`
  - `14 passed`

### Kraken real data
Reference implementation: fresh `master` (`83fdc23`) on Sunday, August 2, 2026.

Exactness vs fresh `master`:
- `generic_tas_bounded_or_count_yearly`: exact, `changed_cells = 0`, `max_abs_diff = 0.0`
- `generic_tas_bounded_or_average_yearly`: exact, `changed_cells = 0`, `max_abs_diff = 0.0`
- `generic_tas_bounded_or_sum_yearly`: exact, `changed_cells = 0`, `max_abs_diff = 0.0`
- `generic_tas_bounded_or_fraction_yearly`: exact, `changed_cells = 0`, `max_abs_diff = 0.0`

Performance vs fresh `master`:
- bounded `count`: current `85.22s`, `master` `123.88s`, about `1.45x` faster
- bounded `average`: current `84.62s`, `master` `128.49s`, about `1.52x` faster
- bounded `sum`: current `87.10s`, `master` `128.40s`, about `1.47x` faster
- bounded `fraction_of_total`: current `84.44s`, `master` `126.17s`, about `1.49x` faster

## Historical note
`v7.1.7` is not a usable trusted baseline for this bounded `OR` validation. Its run fails before the computation starts because bounded percentile metadata formatting still raises:

`RuntimeError: PercentileThreshold cannot infer climatology bounds without source data.`

That is an older bounded-threshold limitation in `v7.1.7`, not a regression introduced by this branch.
