### PR TITLE
Align compound percentile bootstrap routing

### DIFF
--- a/src/icclim/_core/generic/bootstrap_capability.py
+++ b/src/icclim/_core/generic/bootstrap_capability.py
@@ -666,7 +666,7 @@ def _uses_specialized_compound_count_routing(
 ) -> bool:
     if reducer_kind != BootstrapReducerKind.COUNT or date_event:
         return False
-    if len(climate_vars) <= 1:
+    if len(climate_vars) == 0:
         return False
     return inventory.bootstrap_required and (
         inventory.has_bounded_threshold or inventory.threshold_count > 1

--- a/tests/test_bootstrap_capability.py
+++ b/tests/test_bootstrap_capability.py
@@ -336,6 +336,28 @@ def test_bounded_or_count_bootstrap_routes_to_optimized_path() -> None:
     assert decision.reason_code == "optimized_scalar_bounded_bootstrap_supported"
 
 
+def test_single_variable_compound_percentile_count_routes_to_optimized_path() -> None:
+    tas = stub_tas(32 + K2C).chunk({"time": 365, "lat": 1, "lon": 1})
+    climate_var = _build_climate_variable(
+        tas,
+        {
+            "thresholds": ["> 90 doy_per", "<= 95 doy_per"],
+            "logical_link": "and",
+            "reference_period": ("2042-01-01", "2043-12-31"),
+        },
+    )
+
+    decision = classify_generic_indicator_bootstrap(
+        indicator_name="count_occurrences",
+        climate_vars=[climate_var],
+        resample_frequency=FrequencyRegistry.YEAR,
+    )
+
+    assert decision.family == BootstrapComputationFamily.DAY_OF_YEAR_PERCENTILE_COMPOUND
+    assert decision.execution_kind == BootstrapExecutionKind.OPTIMIZED_BOOTSTRAP
+    assert decision.reason_code == "optimized_compound_bootstrap_supported"
+
+
 def test_multi_variable_percentile_count_routes_to_exact_tiled_compound_path() -> None:
     tas = stub_tas(27 + K2C).chunk({"time": 365, "lat": 1, "lon": 1})
     pr = stub_tas(5.0).rename("pr")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1396,6 +1396,159 @@ class TestIntegration:
             eager.fraction_of_total,
         )
 
+    def test_count_occurrences__compound_percentile_bootstrap_uses_optimized_path(
+        self,
+        monkeypatch,
+    ) -> None:
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS", "1")
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_FAST_TILE_CELLS", "1")
+        tas = stub_tas(tas_value=32 + K2C, lat_length=2, lon_length=2)
+        tas[5:10] = 290.15
+        tas = tas.chunk({"time": 365, "lat": 1, "lon": 1})
+        common_kwargs = {
+            "in_files": tas,
+            "var_name": "tas",
+            "threshold": build_threshold(
+                thresholds=["> 90 doy_per", "<= 95 doy_per"],
+                logical_link="and",
+                reference_period=("2042-01-01", "2043-12-31"),
+            ),
+            "time_range": ("2042-01-01", "2045-12-31"),
+            "out_file": self.OUTPUT_FILE,
+            "slice_mode": "year",
+        }
+
+        eager = icclim.count_occurrences(
+            **{**common_kwargs, "in_files": tas.compute()}
+        ).compute()
+        generic_functions.reset_bootstrap_profile()
+
+        default = icclim.count_occurrences(**common_kwargs)
+        profile = generic_functions.get_bootstrap_profile()
+
+        assert profile["bootstrap_execution_kind"] == "optimized_bootstrap"
+        assert (
+            profile["bootstrap_reason_code"] == "optimized_compound_bootstrap_supported"
+        )
+        assert profile["bootstrap_family"] == "day_of_year_percentile_compound"
+        xr.testing.assert_allclose(
+            default.count_occurrences.load(),
+            eager.count_occurrences,
+        )
+
+    def test_average__compound_percentile_bootstrap_uses_optimized_path(
+        self,
+        monkeypatch,
+    ) -> None:
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS", "1")
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_FAST_TILE_CELLS", "1")
+        tas = stub_tas(tas_value=32 + K2C, lat_length=2, lon_length=2)
+        tas[5:10] = 290.15
+        tas = tas.chunk({"time": 365, "lat": 1, "lon": 1})
+        common_kwargs = {
+            "in_files": tas,
+            "var_name": "tas",
+            "threshold": build_threshold(
+                thresholds=["> 90 doy_per", "<= 95 doy_per"],
+                logical_link="and",
+                reference_period=("2042-01-01", "2043-12-31"),
+            ),
+            "time_range": ("2042-01-01", "2045-12-31"),
+            "out_file": self.OUTPUT_FILE,
+            "slice_mode": "year",
+        }
+
+        eager = icclim.average(**{**common_kwargs, "in_files": tas.compute()}).compute()
+        generic_functions.reset_bootstrap_profile()
+
+        default = icclim.average(**common_kwargs)
+        profile = generic_functions.get_bootstrap_profile()
+
+        assert profile["bootstrap_execution_kind"] == "optimized_bootstrap"
+        assert (
+            profile["bootstrap_reason_code"]
+            == "optimized_compound_value_aggregate_bootstrap_supported"
+        )
+        assert profile["bootstrap_family"] == "day_of_year_percentile_compound"
+        xr.testing.assert_allclose(default.average.load(), eager.average)
+
+    def test_sum__compound_percentile_bootstrap_uses_optimized_path(
+        self,
+        monkeypatch,
+    ) -> None:
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS", "1")
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_FAST_TILE_CELLS", "1")
+        tas = stub_tas(tas_value=32 + K2C, lat_length=2, lon_length=2)
+        tas[5:10] = 290.15
+        tas = tas.chunk({"time": 365, "lat": 1, "lon": 1})
+        common_kwargs = {
+            "in_files": tas,
+            "var_name": "tas",
+            "threshold": build_threshold(
+                thresholds=["> 90 doy_per", "<= 95 doy_per"],
+                logical_link="and",
+                reference_period=("2042-01-01", "2043-12-31"),
+            ),
+            "time_range": ("2042-01-01", "2045-12-31"),
+            "out_file": self.OUTPUT_FILE,
+            "slice_mode": "year",
+        }
+
+        eager = icclim.sum(**{**common_kwargs, "in_files": tas.compute()}).compute()
+        generic_functions.reset_bootstrap_profile()
+
+        default = icclim.sum(**common_kwargs)
+        profile = generic_functions.get_bootstrap_profile()
+
+        assert profile["bootstrap_execution_kind"] == "optimized_bootstrap"
+        assert (
+            profile["bootstrap_reason_code"]
+            == "optimized_compound_value_aggregate_bootstrap_supported"
+        )
+        assert profile["bootstrap_family"] == "day_of_year_percentile_compound"
+        xr.testing.assert_allclose(default["sum"].load(), eager["sum"])
+
+    def test_fraction_of_total__compound_percentile_bootstrap_uses_optimized_path(
+        self,
+        monkeypatch,
+    ) -> None:
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS", "1")
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_FAST_TILE_CELLS", "1")
+        tas = stub_tas(tas_value=32 + K2C, lat_length=2, lon_length=2)
+        tas[5:10] = 290.15
+        tas = tas.chunk({"time": 365, "lat": 1, "lon": 1})
+        common_kwargs = {
+            "in_files": tas,
+            "var_name": "tas",
+            "threshold": build_threshold(
+                thresholds=["> 90 doy_per", "<= 95 doy_per"],
+                logical_link="and",
+                reference_period=("2042-01-01", "2043-12-31"),
+            ),
+            "time_range": ("2042-01-01", "2045-12-31"),
+            "out_file": self.OUTPUT_FILE,
+            "slice_mode": "year",
+        }
+
+        eager = icclim.fraction_of_total(
+            **{**common_kwargs, "in_files": tas.compute()}
+        ).compute()
+        generic_functions.reset_bootstrap_profile()
+
+        default = icclim.fraction_of_total(**common_kwargs)
+        profile = generic_functions.get_bootstrap_profile()
+
+        assert profile["bootstrap_execution_kind"] == "optimized_bootstrap"
+        assert (
+            profile["bootstrap_reason_code"]
+            == "optimized_compound_value_aggregate_bootstrap_supported"
+        )
+        assert profile["bootstrap_family"] == "day_of_year_percentile_compound"
+        xr.testing.assert_allclose(
+            default.fraction_of_total.load(),
+            eager.fraction_of_total,
+        )
+
     def test_count_occurrences__optimized_bootstrap_defers_threshold_materialization(
         self,
         monkeypatch,

--- a/tools/run_real_data_validation.py
+++ b/tools/run_real_data_validation.py
@@ -246,6 +246,58 @@ def _build_workload(icclim, workload: str) -> xr.Dataset:
             time_range=TIME_RANGE,
             slice_mode="year",
         )
+    if workload == "generic_tas_compound_percentile_count_yearly":
+        tas = _open_var(TAS_GLOB, "tas")
+        return icclim.count_occurrences(
+            in_files=tas,
+            var_name="tas",
+            threshold=icclim.build_threshold(
+                thresholds=["> 90 doy_per", "<= 95 doy_per"],
+                logical_link="and",
+                reference_period=BASE_PERIOD,
+            ),
+            time_range=TIME_RANGE,
+            slice_mode="year",
+        )
+    if workload == "generic_tas_compound_percentile_average_yearly":
+        tas = _open_var(TAS_GLOB, "tas")
+        return icclim.average(
+            in_files=tas,
+            var_name="tas",
+            threshold=icclim.build_threshold(
+                thresholds=["> 90 doy_per", "<= 95 doy_per"],
+                logical_link="and",
+                reference_period=BASE_PERIOD,
+            ),
+            time_range=TIME_RANGE,
+            slice_mode="year",
+        )
+    if workload == "generic_tas_compound_percentile_sum_yearly":
+        tas = _open_var(TAS_GLOB, "tas")
+        return icclim.sum(
+            in_files=tas,
+            var_name="tas",
+            threshold=icclim.build_threshold(
+                thresholds=["> 90 doy_per", "<= 95 doy_per"],
+                logical_link="and",
+                reference_period=BASE_PERIOD,
+            ),
+            time_range=TIME_RANGE,
+            slice_mode="year",
+        )
+    if workload == "generic_tas_compound_percentile_fraction_yearly":
+        tas = _open_var(TAS_GLOB, "tas")
+        return icclim.fraction_of_total(
+            in_files=tas,
+            var_name="tas",
+            threshold=icclim.build_threshold(
+                thresholds=["> 90 doy_per", "<= 95 doy_per"],
+                logical_link="and",
+                reference_period=BASE_PERIOD,
+            ),
+            time_range=TIME_RANGE,
+            slice_mode="year",
+        )
     if workload == "generic_pr_fraction_bootstrap_yearly":
         pr = _open_var(PR_GLOB, "pr")
         return icclim.fraction_of_total(

--- a/tools/summarize_real_data_validation.py
+++ b/tools/summarize_real_data_validation.py
@@ -192,6 +192,22 @@ def _workload_notes(workload: str) -> str:
             "bounded scalar-guard fraction_of_total with OR composition;"
             " dedicated compiled path validated on Kraken real data"
         ),
+        "generic_tas_compound_percentile_count_yearly": (
+            "same-variable compound percentile count; composed from bootstrap"
+            " leaf masks on Kraken real data"
+        ),
+        "generic_tas_compound_percentile_average_yearly": (
+            "same-variable compound percentile average; composed from bootstrap"
+            " leaf masks on Kraken real data"
+        ),
+        "generic_tas_compound_percentile_sum_yearly": (
+            "same-variable compound percentile sum; composed from bootstrap"
+            " leaf masks on Kraken real data"
+        ),
+        "generic_tas_compound_percentile_fraction_yearly": (
+            "same-variable compound percentile fraction_of_total; composed"
+            " from bootstrap leaf masks on Kraken real data"
+        ),
         "generic_pr_fraction_bootstrap_yearly": (
             "filtered value aggregate; wet-day style threshold_min_value"
         ),


### PR DESCRIPTION
## Summary
- align same-variable compound percentile count routing with the optimized leaf-mask path it already uses in practice
- add regression coverage for same-variable compound percentile count, average, sum, and fraction_of_total
- add Kraken validation workloads and summary rows for the same-variable compound percentile interval case

## What changed
- `count_occurrences` with a same-variable compound percentile threshold such as `> 90 doy_per AND <= 95 doy_per` now classifies as `optimized_bootstrap` instead of the older reference-bootstrap label
- added focused integration tests for the same-variable compound percentile interval case across:
  - `count_occurrences`
  - `average`
  - `sum`
  - `fraction_of_total`
- extended `tools/run_real_data_validation.py` and `tools/summarize_real_data_validation.py` with the corresponding real-data workloads

## Validation
### Local
- `pre-commit` passed on touched files
- `pytest -q tests/test_bootstrap_capability.py tests/test_main.py -k 'compound_percentile or single_variable_compound'`
  - `5 passed`

### Kraken real data
Trusted baseline: fresh `master` on Sunday, August 2, 2026.

Exactness vs trusted `master`:
- `generic_tas_compound_percentile_count_yearly`: exact, `changed_cells = 0`, `max_abs_diff = 0.0`
- `generic_tas_compound_percentile_average_yearly`: exact, `changed_cells = 0`, `max_abs_diff = 0.0`
- `generic_tas_compound_percentile_sum_yearly`: exact, `changed_cells = 0`, `max_abs_diff = 0.0`
- `generic_tas_compound_percentile_fraction_yearly`: exact, `changed_cells = 0`, `max_abs_diff = 0.0`

Performance vs trusted `master`:
- compound percentile `count`: current `160.54s`, `master` `154.85s`
- compound percentile `average`: current `196.96s`, `master` `205.17s`
- compound percentile `sum`: current `200.68s`, `master` `200.94s`
- compound percentile `fraction_of_total`: current `204.30s`, `master` `203.31s`

Interpretation:
- correctness is exact across the validated matrix
- performance is essentially neutral, with `average` modestly faster and the others effectively flat
