### PR TITLE
Validate compound percentile OR bootstrap routing

### DIFF
--- a/doc/source/dev/bootstrap_architecture.rst
+++ b/doc/source/dev/bootstrap_architecture.rst
@@ -324,6 +324,12 @@ validated optimized implementation instead uses:
 - optimized union exceedance-day counts;
 - final output casting aligned with the trusted baseline dtype.
 
+The same compound leaf-mask architecture also supports percentile-tail
+unions such as ``> 95 doy_per OR <= 10 doy_per``. Those OR shapes stay
+in the compound family, but they reuse the same bootstrap leaf-mask
+combination strategy as the already validated percentile-interval
+workloads.
+
 Daily exceedance mask construction
 ----------------------------------
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1130,6 +1130,45 @@ class TestIntegration:
             default.count_occurrences.load(), eager.count_occurrences
         )
 
+    def test_count_occurrences__compound_percentile_or_bootstrap_uses_optimized_path(
+        self,
+        monkeypatch,
+    ) -> None:
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS", "1")
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_FAST_TILE_CELLS", "1")
+        tas = stub_tas(tas_value=27 + K2C, lat_length=2, lon_length=2)
+        tas[5:10] = 0
+        tas = tas.chunk({"time": 365, "lat": 1, "lon": 1})
+        common_kwargs = {
+            "in_files": tas,
+            "var_name": "tas",
+            "threshold": build_threshold(
+                thresholds=["> 95 doy_per", "<= 10 doy_per"],
+                logical_link="or",
+                reference_period=("2042-01-01", "2043-12-31"),
+            ),
+            "time_range": ("2042-01-01", "2045-12-31"),
+            "out_file": self.OUTPUT_FILE,
+            "slice_mode": "year",
+        }
+
+        eager = icclim.count_occurrences(
+            **{**common_kwargs, "in_files": tas.compute()}
+        ).compute()
+        generic_functions.reset_bootstrap_profile()
+
+        default = icclim.count_occurrences(**common_kwargs)
+        profile = generic_functions.get_bootstrap_profile()
+
+        assert profile["bootstrap_execution_kind"] == "optimized_bootstrap"
+        assert (
+            profile["bootstrap_reason_code"] == "optimized_compound_bootstrap_supported"
+        )
+        assert profile["bootstrap_family"] == "day_of_year_percentile_compound"
+        xr.testing.assert_allclose(
+            default.count_occurrences.load(), eager.count_occurrences
+        )
+
     def test_average__bounded_percentile_bootstrap_uses_optimized_path(
         self,
         monkeypatch,
@@ -2045,6 +2084,46 @@ class TestIntegration:
         xr.testing.assert_allclose(
             optimized.fraction_of_total,
             reference.fraction_of_total,
+        )
+
+    def test_fraction_of_total__compound_percentile_or_bootstrap_uses_optimized_path(
+        self,
+        monkeypatch,
+    ) -> None:
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_SAFE_TILE_CELLS", "1")
+        monkeypatch.setenv("ICCLIM_BOOTSTRAP_FAST_TILE_CELLS", "1")
+        tas = stub_tas(tas_value=27 + K2C, lat_length=2, lon_length=2).rename("tas")
+        tas[5:10] = 0
+        tas = tas.chunk({"time": 365, "lat": 1, "lon": 1})
+        common_kwargs = {
+            "in_files": tas,
+            "var_name": "tas",
+            "index_name": "fraction_of_total",
+            "threshold": build_threshold(
+                thresholds=["> 95 doy_per", "<= 10 doy_per"],
+                logical_link="or",
+                reference_period=("2042-01-01", "2043-12-31"),
+            ),
+            "time_range": ("2042-01-01", "2045-12-31"),
+            "out_file": self.OUTPUT_FILE,
+            "slice_mode": "year",
+        }
+
+        eager = icclim.index(**{**common_kwargs, "in_files": tas.compute()}).compute()
+        generic_functions.reset_bootstrap_profile()
+
+        optimized = icclim.index(**common_kwargs).compute()
+        profile = generic_functions.get_bootstrap_profile()
+
+        assert profile["bootstrap_execution_kind"] == "optimized_bootstrap"
+        assert (
+            profile["bootstrap_reason_code"]
+            == "optimized_compound_value_aggregate_bootstrap_supported"
+        )
+        assert profile["bootstrap_family"] == "day_of_year_percentile_compound"
+        xr.testing.assert_allclose(
+            optimized.fraction_of_total,
+            eager.fraction_of_total,
         )
 
     def test_sum__dask_percentile_bootstrap_uses_optimized_path(

--- a/tools/run_real_data_validation.py
+++ b/tools/run_real_data_validation.py
@@ -298,6 +298,32 @@ def _build_workload(icclim, workload: str) -> xr.Dataset:
             time_range=TIME_RANGE,
             slice_mode="year",
         )
+    if workload == "generic_tas_compound_percentile_or_count_yearly":
+        tas = _open_var(TAS_GLOB, "tas")
+        return icclim.count_occurrences(
+            in_files=tas,
+            var_name="tas",
+            threshold=icclim.build_threshold(
+                thresholds=["> 95 doy_per", "<= 10 doy_per"],
+                logical_link="or",
+                reference_period=BASE_PERIOD,
+            ),
+            time_range=TIME_RANGE,
+            slice_mode="year",
+        )
+    if workload == "generic_tas_compound_percentile_or_fraction_yearly":
+        tas = _open_var(TAS_GLOB, "tas")
+        return icclim.fraction_of_total(
+            in_files=tas,
+            var_name="tas",
+            threshold=icclim.build_threshold(
+                thresholds=["> 95 doy_per", "<= 10 doy_per"],
+                logical_link="or",
+                reference_period=BASE_PERIOD,
+            ),
+            time_range=TIME_RANGE,
+            slice_mode="year",
+        )
     if workload == "generic_pr_fraction_bootstrap_yearly":
         pr = _open_var(PR_GLOB, "pr")
         return icclim.fraction_of_total(

--- a/tools/summarize_real_data_validation.py
+++ b/tools/summarize_real_data_validation.py
@@ -208,6 +208,14 @@ def _workload_notes(workload: str) -> str:
             "same-variable compound percentile fraction_of_total; composed"
             " from bootstrap leaf masks on Kraken real data"
         ),
+        "generic_tas_compound_percentile_or_count_yearly": (
+            "same-variable compound percentile OR count; composed from"
+            " bootstrap leaf masks on Kraken real data"
+        ),
+        "generic_tas_compound_percentile_or_fraction_yearly": (
+            "same-variable compound percentile OR fraction_of_total;"
+            " composed from bootstrap leaf masks on Kraken real data"
+        ),
         "generic_pr_fraction_bootstrap_yearly": (
             "filtered value aggregate; wet-day style threshold_min_value"
         ),


### PR DESCRIPTION
## Summary
- validate same-variable compound percentile `OR` routing for `count_occurrences` and `fraction_of_total`
- extend the Kraken real-data validation matrix with `> 95 doy_per OR <= 10 doy_per`
- document that percentile-tail unions reuse the same compound leaf-mask architecture as the validated interval cases

## Local validation
- `pre-commit run --files tests/test_main.py tools/run_real_data_validation.py tools/summarize_real_data_validation.py doc/source/dev/bootstrap_architecture.rst`
- `pytest -q tests/test_main.py -k "compound_percentile_or_bootstrap_uses_optimized_path"`

## Kraken real-data validation
Trusted baseline: current `master`

### `generic_tas_compound_percentile_or_count_yearly`
- exact vs trusted `master`
- `changed_cells = 0`
- `max_abs_diff = 0.0`
- current: `157.83s`
- trusted `master`: `165.56s`
- speedup: about `1.05x`

### `generic_tas_compound_percentile_or_fraction_yearly`
- exact vs trusted `master`
- `changed_cells = 0`
- `max_abs_diff = 0.0`
- current: `199.02s`
- trusted `master`: `200.62s`
- performance: effectively identical

## Notes
- filtered `average` with `threshold_min_value` was investigated during this phase but remains off this PR because it is still not field-identical on Kraken real data.
- this PR keeps the branch focused on one clean, validated compound-percentile support extension.