### PR TITLE
Expand bootstrap real-data validation coverage

### DIFF
--- a/doc/source/dev/bootstrap_architecture.rst
+++ b/doc/source/dev/bootstrap_architecture.rst
@@ -330,6 +330,13 @@ in the compound family, but they reuse the same bootstrap leaf-mask
 combination strategy as the already validated percentile-interval
 workloads.
 
+For broader regression coverage, the real-data validation harness should
+also be able to rerun the same workload under a materially different
+chunk layout. As of Sunday, August 2, 2026, that means validation is no
+longer only about trusted-baseline equality; it also needs chunk-profile
+checks for representative spell, compound, and value-aggregate
+workloads.
+
 Daily exceedance mask construction
 ----------------------------------
 

--- a/tests/test_real_data_validation_tools.py
+++ b/tests/test_real_data_validation_tools.py
@@ -1,0 +1,476 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from typing import ClassVar
+
+import numpy as np
+import pytest
+import xarray as xr
+
+
+def _load_tool_module(path: Path) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(path.stem, path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_build_workload_uses_requested_chunks_for_chunk_sensitive_paths(
+    monkeypatch,
+) -> None:
+    module = _load_tool_module(Path("tools/run_real_data_validation.py"))
+    recorded_chunks: list[dict[str, int]] = []
+
+    def fake_open_var(*_args, chunks, **_kwargs):
+        recorded_chunks.append(chunks)
+        time = xr.date_range("2000-01-01", periods=4, freq="D")
+        return xr.DataArray(
+            np.ones((4, 1, 1), dtype=np.float32),
+            dims=("time", "lat", "lon"),
+            coords={"time": time, "lat": [45.0], "lon": [2.0]},
+            attrs={"units": "K"},
+            name="tas",
+        )
+
+    monkeypatch.setattr(module, "_open_var", fake_open_var)
+
+    class FakeIcclim:
+        @staticmethod
+        def build_threshold(*args, **kwargs):
+            return {"args": args, **kwargs}
+
+        @staticmethod
+        def average(**_kwargs):
+            return xr.Dataset({"average": xr.DataArray([1.0], dims=("time",))})
+
+        @staticmethod
+        def sum_of_spell_lengths(**_kwargs):
+            return xr.Dataset(
+                {"sum_of_spell_lengths": xr.DataArray([1.0], dims=("time",))}
+            )
+
+        @staticmethod
+        def index(**_kwargs):
+            return xr.Dataset({"CSDI": xr.DataArray([1.0], dims=("time",))})
+
+    module._build_workload(
+        FakeIcclim,
+        "generic_tas_compound_percentile_or_average_yearly",
+        chunks=module.ALT_CHUNKS,
+    )
+    module._build_workload(
+        FakeIcclim,
+        "generic_tas_spell_bootstrap_yearly",
+        chunks=module.ALT_CHUNKS,
+    )
+    module._build_workload(
+        FakeIcclim,
+        "csdi_yearly",
+        chunks=module.ALT_CHUNKS,
+    )
+
+    assert recorded_chunks == [
+        module.ALT_CHUNKS,
+        module.ALT_CHUNKS,
+        module.ALT_CHUNKS,
+    ]
+
+
+@pytest.mark.parametrize(
+    ("workload", "method_name"),
+    [
+        ("generic_tas_compound_percentile_or_count_yearly", "count_occurrences"),
+        ("generic_tas_compound_percentile_or_sum_yearly", "sum"),
+        ("generic_tas_compound_percentile_or_fraction_yearly", "fraction_of_total"),
+        ("wsdi_yearly", "index"),
+    ],
+)
+def test_build_workload_routes_new_workloads(
+    monkeypatch,
+    workload: str,
+    method_name: str,
+) -> None:
+    module = _load_tool_module(Path("tools/run_real_data_validation.py"))
+    called: dict[str, object] = {}
+
+    def fake_open_var(*_args, chunks=module.DEFAULT_CHUNKS, **_kwargs):
+        time = xr.date_range("2000-01-01", periods=4, freq="D")
+        return xr.DataArray(
+            np.ones((4, 1, 1), dtype=np.float32),
+            dims=("time", "lat", "lon"),
+            coords={"time": time, "lat": [45.0], "lon": [2.0]},
+            attrs={"units": "K"},
+            name="tas",
+        )
+
+    monkeypatch.setattr(module, "_open_var", fake_open_var)
+
+    class FakeIcclim:
+        @staticmethod
+        def build_threshold(*args, **kwargs):
+            return {"args": args, **kwargs}
+
+        @staticmethod
+        def count_occurrences(**kwargs):
+            called["method"] = "count_occurrences"
+            called["kwargs"] = kwargs
+            return xr.Dataset(
+                {"count_occurrences": xr.DataArray([1.0], dims=("time",))}
+            )
+
+        @staticmethod
+        def sum(**kwargs):
+            called["method"] = "sum"
+            called["kwargs"] = kwargs
+            return xr.Dataset({"sum": xr.DataArray([1.0], dims=("time",))})
+
+        @staticmethod
+        def fraction_of_total(**kwargs):
+            called["method"] = "fraction_of_total"
+            called["kwargs"] = kwargs
+            return xr.Dataset(
+                {"fraction_of_total": xr.DataArray([1.0], dims=("time",))}
+            )
+
+        @staticmethod
+        def index(**kwargs):
+            called["method"] = "index"
+            called["kwargs"] = kwargs
+            return xr.Dataset({"WSDI": xr.DataArray([1.0], dims=("time",))})
+
+    module._build_workload(FakeIcclim, workload, chunks=module.DEFAULT_CHUNKS)
+
+    assert called["method"] == method_name
+
+
+def test_main_writes_chunk_profile_to_summary(monkeypatch, tmp_path: Path) -> None:
+    module = _load_tool_module(Path("tools/run_real_data_validation.py"))
+    output = xr.Dataset({"value": xr.DataArray([1.0], dims=("time",))})
+
+    monkeypatch.setattr(module, "_warmup", lambda _icclim: None)
+    monkeypatch.setattr(module, "_build_workload", lambda *_args, **_kwargs: output)
+    monkeypatch.setattr(module, "_git_rev_parse", lambda *_args, **_kwargs: "deadbeef")
+    monkeypatch.setattr(
+        sys,
+        "path",
+        [str(tmp_path / "src"), *sys.path],
+    )
+
+    fake_icclim = SimpleNamespace(__version__="test-version")
+    monkeypatch.setitem(sys.modules, "icclim", fake_icclim)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "run_real_data_validation.py",
+            "--repo",
+            str(tmp_path),
+            "--workload",
+            "generic_tas_spell_bootstrap_yearly",
+            "--label",
+            "current",
+            "--chunk-profile",
+            "alt",
+            "--out-dir",
+            str(tmp_path / "out"),
+        ],
+    )
+
+    module.main()
+
+    summary_path = (
+        tmp_path / "out/current-generic_tas_spell_bootstrap_yearly.summary.json"
+    )
+    payload = json.loads(summary_path.read_text())
+    assert payload["chunk_profile"] == "alt"
+
+
+def test_main_defaults_to_default_chunk_profile(monkeypatch, tmp_path: Path) -> None:
+    module = _load_tool_module(Path("tools/run_real_data_validation.py"))
+    output = xr.Dataset({"value": xr.DataArray([1.0], dims=("time",))})
+    observed: dict[str, object] = {}
+
+    def fake_build_workload(*_args, **kwargs):
+        observed["chunks"] = kwargs["chunks"]
+        return output
+
+    monkeypatch.setattr(module, "_warmup", lambda _icclim: None)
+    monkeypatch.setattr(module, "_build_workload", fake_build_workload)
+    monkeypatch.setattr(module, "_git_rev_parse", lambda *_args, **_kwargs: "deadbeef")
+    monkeypatch.setitem(
+        sys.modules, "icclim", SimpleNamespace(__version__="test-version")
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "run_real_data_validation.py",
+            "--repo",
+            str(tmp_path),
+            "--workload",
+            "wsdi_yearly",
+            "--label",
+            "default",
+            "--out-dir",
+            str(tmp_path / "out"),
+        ],
+    )
+
+    module.main()
+
+    assert observed["chunks"] == module.DEFAULT_CHUNKS
+
+
+def test_git_rev_parse_reads_commit_from_subprocess(
+    monkeypatch, tmp_path: Path
+) -> None:
+    module = _load_tool_module(Path("tools/run_real_data_validation.py"))
+    monkeypatch.setattr(
+        module.subprocess,
+        "check_output",
+        lambda *args, **kwargs: "0123456789abcdef0123456789abcdef01234567\n",
+    )
+
+    rev = module._git_rev_parse(tmp_path, "HEAD")
+
+    assert rev == "0123456789abcdef0123456789abcdef01234567"
+
+
+def test_open_var_and_combined_dataset_use_requested_chunks(monkeypatch) -> None:
+    module = _load_tool_module(Path("tools/run_real_data_validation.py"))
+    observed: dict[str, object] = {}
+
+    monkeypatch.setattr(module.glob, "glob", lambda _pattern: ["a.nc", "b.nc"])
+
+    def fake_open_mfdataset(files, combine, chunks):
+        observed["files"] = files
+        observed["combine"] = combine
+        observed["chunks"] = chunks
+        time = xr.date_range("2000-01-01", periods=2, freq="D")
+        return xr.Dataset(
+            {
+                "tas": xr.DataArray(
+                    np.ones((2, 1, 1), dtype=np.float32),
+                    dims=("time", "lat", "lon"),
+                    coords={"time": time, "lat": [45.0], "lon": [2.0]},
+                ),
+                "pr": xr.DataArray(
+                    np.ones((2, 1, 1), dtype=np.float32),
+                    dims=("time", "lat", "lon"),
+                    coords={"time": time, "lat": [45.0], "lon": [2.0]},
+                ),
+            }
+        )
+
+    monkeypatch.setattr(module.xr, "open_mfdataset", fake_open_mfdataset)
+
+    tas = module._open_var(module.TAS_GLOB, "tas", chunks=module.ALT_CHUNKS)
+    combined = module._open_combined_dataset(chunks=module.ALT_CHUNKS)
+
+    assert observed["combine"] == "by_coords"
+    assert observed["chunks"] == module.ALT_CHUNKS
+    assert tas.name == "tas"
+    assert set(combined.data_vars) == {"tas", "pr"}
+
+
+def test_warmup_swallows_validation_exceptions() -> None:
+    module = _load_tool_module(Path("tools/run_real_data_validation.py"))
+    msg = "expected test failure"
+
+    class FakeIcclim:
+        @staticmethod
+        def index(**_kwargs):
+            raise RuntimeError(msg)
+
+    module._warmup(FakeIcclim)
+
+
+def test_workload_notes_cover_new_chunk_matrix_workloads() -> None:
+    module = _load_tool_module(Path("tools/summarize_real_data_validation.py"))
+
+    assert "OR average" in module._workload_notes(
+        "generic_tas_compound_percentile_or_average_yearly"
+    )
+    assert "OR sum" in module._workload_notes(
+        "generic_tas_compound_percentile_or_sum_yearly"
+    )
+    assert module._workload_notes("csdi_yearly") == "standard cold-spell duration index"
+
+
+def test_summarizer_parses_default_vs_alt_compare_filenames(tmp_path: Path) -> None:
+    module = _load_tool_module(Path("tools/summarize_real_data_validation.py"))
+    compare_path = tmp_path / "default-vs-alt-csdi_yearly.compare.json"
+    compare_path.write_text(
+        json.dumps(
+            {
+                "data_var_comparison": {
+                    "CSDI": {
+                        "equal": True,
+                        "changed_cells": 0,
+                        "max_abs_diff": 0.0,
+                    }
+                }
+            }
+        )
+    )
+
+    summary = module._parse_compare_file(compare_path)
+
+    assert summary.current_label == "default"
+    assert summary.baseline_label == "alt"
+    assert summary.workload == "csdi_yearly"
+    assert summary.all_data_vars_equal is True
+
+
+def test_summarizer_builds_chunk_profile_table(tmp_path: Path) -> None:
+    module = _load_tool_module(Path("tools/summarize_real_data_validation.py"))
+    result_dir = tmp_path
+    (result_dir / "default-csdi_yearly.summary.json").write_text(
+        json.dumps(
+            {
+                "label": "default",
+                "workload": "csdi_yearly",
+                "duration_seconds": 10.0,
+            }
+        )
+    )
+    (result_dir / "alt-csdi_yearly.summary.json").write_text(
+        json.dumps(
+            {
+                "label": "alt",
+                "workload": "csdi_yearly",
+                "duration_seconds": 25.0,
+            }
+        )
+    )
+    (result_dir / "default-vs-alt-csdi_yearly.compare.json").write_text(
+        json.dumps(
+            {
+                "data_var_comparison": {
+                    "CSDI": {
+                        "equal": True,
+                        "changed_cells": 0,
+                        "max_abs_diff": 0.0,
+                    }
+                }
+            }
+        )
+    )
+
+    summary = module._build_summary_document(result_dir, ["csdi_yearly"])
+
+    assert "## Chunk-profile invariance" in summary
+    assert "| csdi_yearly | exact | 0 | 0.0 | 10.00 | 25.00 | +150.0%" in summary
+
+
+def test_summarizer_historical_note_detects_known_difference() -> None:
+    module = _load_tool_module(Path("tools/summarize_real_data_validation.py"))
+    comparisons = {
+        (
+            "current",
+            "master",
+            "generic_tas_spell_bootstrap_yearly",
+        ): module.ComparisonSummary(
+            current_label="current",
+            baseline_label="master",
+            workload="generic_tas_spell_bootstrap_yearly",
+            path=Path("a"),
+            all_data_vars_equal=True,
+            total_changed_cells=0,
+            max_abs_diff=0.0,
+        ),
+        (
+            "current",
+            "v717",
+            "generic_tas_spell_bootstrap_yearly",
+        ): module.ComparisonSummary(
+            current_label="current",
+            baseline_label="v717",
+            workload="generic_tas_spell_bootstrap_yearly",
+            path=Path("b"),
+            all_data_vars_equal=False,
+            total_changed_cells=1,
+            max_abs_diff=1.0,
+        ),
+        (
+            "master",
+            "v717",
+            "generic_tas_spell_bootstrap_yearly",
+        ): module.ComparisonSummary(
+            current_label="master",
+            baseline_label="v717",
+            workload="generic_tas_spell_bootstrap_yearly",
+            path=Path("c"),
+            all_data_vars_equal=False,
+            total_changed_cells=1,
+            max_abs_diff=1.0,
+        ),
+    }
+
+    note = module._historical_validation_note(
+        "generic_tas_spell_bootstrap_yearly",
+        comparisons,
+    )
+
+    assert note == "historical master/v7.1.7 difference confirmed"
+
+
+def test_debug_real_data_validation_uses_default_chunks(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    module = _load_tool_module(Path("tools/debug_real_data_validation.py"))
+    observed: dict[str, object] = {}
+
+    class FakeValidationModule:
+        DEFAULT_CHUNKS: ClassVar[dict[str, int]] = {
+            "time": 365,
+            "lat": 24,
+            "lon": 32,
+        }
+
+        @staticmethod
+        def _warmup(_icclim) -> None:
+            return None
+
+        @staticmethod
+        def _build_workload(_icclim, workload, *, chunks):
+            observed["workload"] = workload
+            observed["chunks"] = chunks
+            return xr.Dataset({"value": xr.DataArray([1.0], dims=("time",))})
+
+    monkeypatch.setattr(module, "_load_validation_module", lambda: FakeValidationModule)
+    fake_icclim = SimpleNamespace(__version__="test-version")
+    monkeypatch.setitem(sys.modules, "icclim", fake_icclim)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "debug_real_data_validation.py",
+            "--repo",
+            str(tmp_path),
+            "--workload",
+            "csdi_yearly",
+        ],
+    )
+
+    module.main()
+
+    assert observed["workload"] == "csdi_yearly"
+    assert observed["chunks"] == FakeValidationModule.DEFAULT_CHUNKS
+
+
+def test_load_validation_module_reads_neighbor_script() -> None:
+    module = _load_tool_module(Path("tools/debug_real_data_validation.py"))
+
+    loaded = module._load_validation_module()
+
+    assert hasattr(loaded, "_build_workload")
+    assert hasattr(loaded, "DEFAULT_CHUNKS")

--- a/tools/debug_real_data_validation.py
+++ b/tools/debug_real_data_validation.py
@@ -42,7 +42,11 @@ def main() -> None:
         validation_module = _load_validation_module()
 
         validation_module._warmup(icclim)
-        ds = validation_module._build_workload(icclim, args.workload)
+        ds = validation_module._build_workload(
+            icclim,
+            args.workload,
+            chunks=validation_module.DEFAULT_CHUNKS,
+        )
         payload["data_vars"] = list(ds.data_vars)
         payload["coords"] = list(ds.coords)
         payload["sizes"] = {name: int(size) for name, size in ds.sizes.items()}

--- a/tools/run_real_data_validation.py
+++ b/tools/run_real_data_validation.py
@@ -22,7 +22,8 @@ BASE_PERIOD = ("1961-01-01", "1990-12-31")
 TIME_RANGE = ("1950-01-01", "2014-12-31")
 TASMAX_TIME_RANGE = ("1986-01-01", "1999-12-31")
 DATE_EVENT_TIME_RANGE = ("1980-01-01", "2014-12-31")
-CHUNKS = {"time": 365, "lat": 24, "lon": 32}
+DEFAULT_CHUNKS = {"time": 365, "lat": 24, "lon": 32}
+ALT_CHUNKS = {"time": 730, "lat": 7, "lon": 9}
 
 
 def _git_rev_parse(repo: Path, ref: str) -> str | None:
@@ -41,17 +42,22 @@ def _open_var(
     *,
     lat_slice: slice = LAT_SLICE,
     lon_slice: slice = LON_SLICE,
+    chunks: dict[str, int] = DEFAULT_CHUNKS,
 ) -> xr.DataArray:
     files = sorted(glob.glob(file_glob))
     if not files:
         raise FileNotFoundError(file_glob)
-    ds = xr.open_mfdataset(files, combine="by_coords", chunks=CHUNKS)
+    ds = xr.open_mfdataset(files, combine="by_coords", chunks=chunks)
     return ds[var_name].sel(lat=lat_slice, lon=lon_slice)
 
 
-def _open_combined_dataset(*, eager: bool = False) -> xr.Dataset:
-    tas = _open_var(TAS_GLOB, "tas")
-    pr = _open_var(PR_GLOB, "pr")
+def _open_combined_dataset(
+    *,
+    eager: bool = False,
+    chunks: dict[str, int] = DEFAULT_CHUNKS,
+) -> xr.Dataset:
+    tas = _open_var(TAS_GLOB, "tas", chunks=chunks)
+    pr = _open_var(PR_GLOB, "pr", chunks=chunks)
     ds = xr.Dataset({"tas": tas, "pr": pr})
     if eager:
         ds = ds.load()
@@ -78,7 +84,12 @@ def _warmup(icclim) -> None:
         pass
 
 
-def _build_workload(icclim, workload: str) -> xr.Dataset:
+def _build_workload(
+    icclim,
+    workload: str,
+    *,
+    chunks: dict[str, int],
+) -> xr.Dataset:
     if workload == "tg_monthly":
         tas = _open_var(TAS_GLOB, "tas")
         return icclim.index(
@@ -299,7 +310,7 @@ def _build_workload(icclim, workload: str) -> xr.Dataset:
             slice_mode="year",
         )
     if workload == "generic_tas_compound_percentile_or_count_yearly":
-        tas = _open_var(TAS_GLOB, "tas")
+        tas = _open_var(TAS_GLOB, "tas", chunks=chunks)
         return icclim.count_occurrences(
             in_files=tas,
             var_name="tas",
@@ -311,8 +322,34 @@ def _build_workload(icclim, workload: str) -> xr.Dataset:
             time_range=TIME_RANGE,
             slice_mode="year",
         )
+    if workload == "generic_tas_compound_percentile_or_average_yearly":
+        tas = _open_var(TAS_GLOB, "tas", chunks=chunks)
+        return icclim.average(
+            in_files=tas,
+            var_name="tas",
+            threshold=icclim.build_threshold(
+                thresholds=["> 95 doy_per", "<= 10 doy_per"],
+                logical_link="or",
+                reference_period=BASE_PERIOD,
+            ),
+            time_range=TIME_RANGE,
+            slice_mode="year",
+        )
+    if workload == "generic_tas_compound_percentile_or_sum_yearly":
+        tas = _open_var(TAS_GLOB, "tas", chunks=chunks)
+        return icclim.sum(
+            in_files=tas,
+            var_name="tas",
+            threshold=icclim.build_threshold(
+                thresholds=["> 95 doy_per", "<= 10 doy_per"],
+                logical_link="or",
+                reference_period=BASE_PERIOD,
+            ),
+            time_range=TIME_RANGE,
+            slice_mode="year",
+        )
     if workload == "generic_tas_compound_percentile_or_fraction_yearly":
-        tas = _open_var(TAS_GLOB, "tas")
+        tas = _open_var(TAS_GLOB, "tas", chunks=chunks)
         return icclim.fraction_of_total(
             in_files=tas,
             var_name="tas",
@@ -413,7 +450,7 @@ def _build_workload(icclim, workload: str) -> xr.Dataset:
             slice_mode="year",
         )
     if workload == "generic_tas_spell_bootstrap_yearly":
-        tas = _open_var(TAS_GLOB, "tas")
+        tas = _open_var(TAS_GLOB, "tas", chunks=chunks)
         return icclim.sum_of_spell_lengths(
             in_files=tas,
             var_name="tas",
@@ -426,9 +463,19 @@ def _build_workload(icclim, workload: str) -> xr.Dataset:
             min_spell_length=6,
         )
     if workload == "wsdi_yearly":
-        tas = _open_var(TAS_GLOB, "tas")
+        tas = _open_var(TAS_GLOB, "tas", chunks=chunks)
         return icclim.index(
             index_name="WSDI",
+            in_files=tas,
+            var_name="tas",
+            base_period_time_range=BASE_PERIOD,
+            time_range=TIME_RANGE,
+            slice_mode="year",
+        )
+    if workload == "csdi_yearly":
+        tas = _open_var(TAS_GLOB, "tas", chunks=chunks)
+        return icclim.index(
+            index_name="CSDI",
             in_files=tas,
             var_name="tas",
             base_period_time_range=BASE_PERIOD,
@@ -508,6 +555,11 @@ def main() -> None:
     parser.add_argument("--workload", required=True)
     parser.add_argument("--label", required=True)
     parser.add_argument("--out-dir", required=True)
+    parser.add_argument(
+        "--chunk-profile",
+        choices=("default", "alt"),
+        default="default",
+    )
     args = parser.parse_args()
 
     repo = Path(args.repo).resolve()
@@ -517,9 +569,14 @@ def main() -> None:
     out_dir = Path(args.out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
 
+    chunk_profile = DEFAULT_CHUNKS if args.chunk_profile == "default" else ALT_CHUNKS
     _warmup(icclim)
     start = time.perf_counter()
-    ds = _build_workload(icclim, args.workload).load()
+    ds = _build_workload(
+        icclim,
+        args.workload,
+        chunks=chunk_profile,
+    ).load()
     duration = time.perf_counter() - start
 
     result_nc = out_dir / f"{args.label}-{args.workload}.result.nc"
@@ -533,6 +590,7 @@ def main() -> None:
         "head_commit": _git_rev_parse(repo, "HEAD"),
         "icclim_version": icclim.__version__,
         "duration_seconds": duration,
+        "chunk_profile": args.chunk_profile,
         "output_path": str(result_nc),
         "dataset": _dataset_summary(ds),
     }

--- a/tools/summarize_real_data_validation.py
+++ b/tools/summarize_real_data_validation.py
@@ -80,6 +80,10 @@ def _parse_compare_file(path: Path) -> ComparisonSummary:
         current_label = "master"
         baseline_label = "v717"
         workload = filename.removeprefix("master-vs-v717-")
+    elif filename.startswith("default-vs-alt-"):
+        current_label = "default"
+        baseline_label = "alt"
+        workload = filename.removeprefix("default-vs-alt-")
     else:
         msg = f"Unsupported compare filename: {path.name}"
         raise ValueError(msg)
@@ -212,6 +216,14 @@ def _workload_notes(workload: str) -> str:
             "same-variable compound percentile OR count; composed from"
             " bootstrap leaf masks on Kraken real data"
         ),
+        "generic_tas_compound_percentile_or_average_yearly": (
+            "same-variable compound percentile OR average; composed from"
+            " bootstrap leaf masks on Kraken real data"
+        ),
+        "generic_tas_compound_percentile_or_sum_yearly": (
+            "same-variable compound percentile OR sum; composed from"
+            " bootstrap leaf masks on Kraken real data"
+        ),
         "generic_tas_compound_percentile_or_fraction_yearly": (
             "same-variable compound percentile OR fraction_of_total;"
             " composed from bootstrap leaf masks on Kraken real data"
@@ -241,6 +253,7 @@ def _workload_notes(workload: str) -> str:
             "spell reducer; raw v7.1.7 differs from current and master"
         ),
         "wsdi_yearly": "standard warm-spell duration index",
+        "csdi_yearly": "standard cold-spell duration index",
         "generic_tas_count_date_event_monthly": "date_event count control path",
         "combined_cd_yearly": (
             "compound tas+pr count; combines specialized leaf masks through"
@@ -348,18 +361,58 @@ def _build_performance_table(
     return "\n".join(lines)
 
 
+def _build_chunk_profile_table(
+    workloads: list[str],
+    comparisons: dict[tuple[str, str, str], ComparisonSummary],
+    runs: dict[tuple[str, str], RunSummary],
+) -> str:
+    lines = [
+        "| Workload | Default vs alt | Changed cells | Max abs diff | Default (s) | Alt (s) | Delta alt vs default | Notes |",
+        "| --- | --- | ---: | ---: | ---: | ---: | ---: | --- |",
+    ]
+    for workload in workloads:
+        comparison = comparisons.get(("default", "alt", workload))
+        if comparison is None:
+            continue
+        default_run = runs.get(("default", workload))
+        alt_run = runs.get(("alt", workload))
+        status = _format_validation_status(comparison)
+        default_s = default_run.duration_seconds if default_run is not None else None
+        alt_s = alt_run.duration_seconds if alt_run is not None else None
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    workload,
+                    status[0],
+                    status[1],
+                    status[2],
+                    _format_seconds(default_s),
+                    _format_seconds(alt_s),
+                    _format_percent_change(alt_s, default_s),
+                    _workload_notes(workload),
+                ]
+            )
+            + " |"
+        )
+    return "\n".join(lines)
+
+
 def _build_summary_document(result_dir: Path, expected_workloads: list[str]) -> str:
     runs = _load_run_summaries(result_dir)
     comparisons = _load_compare_summaries(result_dir)
     workloads = sorted({workload for _, workload in runs} | set(expected_workloads))
     validation_table = _build_validation_table(workloads, comparisons)
     performance_table = _build_performance_table(workloads, runs)
+    chunk_profile_table = _build_chunk_profile_table(workloads, comparisons, runs)
     return (
         "# Real-data bootstrap validation summary\n\n"
         "## Validation\n\n"
         f"{validation_table}\n\n"
         "## Performance\n\n"
-        f"{performance_table}"
+        f"{performance_table}\n\n"
+        "## Chunk-profile invariance\n\n"
+        f"{chunk_profile_table}"
     )
 
 


### PR DESCRIPTION
## Summary
- expand the Kraken real-data validation harness with chunk-profile coverage for compound percentile OR, generic spell, WSDI, and CSDI workloads
- add direct tests for the validation scripts and align the debug helper with the chunk-aware workload builder
- document chunk-profile validation as part of the bootstrap architecture guidance

## Local validation
- `pytest -q tests/test_real_data_validation_tools.py`
- `pytest -q tests/test_real_data_validation_tools.py tests/test_bootstrap_capability.py tests/test_bootstrap_primitives.py -k 'bootstrap or validation'`
- `pre-commit run --files tools/debug_real_data_validation.py tools/run_real_data_validation.py tools/summarize_real_data_validation.py tests/test_real_data_validation_tools.py doc/source/dev/bootstrap_architecture.rst`
- `python -m compileall tools/run_real_data_validation.py tools/summarize_real_data_validation.py tools/debug_real_data_validation.py`

## Kraken real-data validation
Chunk-profile invariance was validated on Sunday, August 2, 2026, with `default` vs `alt` chunk layouts on the same current branch tree.

Exact field equality (`changed_cells = 0`, `max_abs_diff = 0.0`) was confirmed for:
- `generic_tas_compound_percentile_or_count_yearly`
- `generic_tas_compound_percentile_or_average_yearly`
- `generic_tas_compound_percentile_or_sum_yearly`
- `generic_tas_compound_percentile_or_fraction_yearly`
- `generic_tas_spell_bootstrap_yearly`
- `wsdi_yearly`
- `csdi_yearly`

Representative timings from Kraken show that alternate chunking remains exact but can be substantially slower on these workloads, which is the expected outcome of this coverage pass rather than a correctness issue.
