### PR TITLE
Stabilize bootstrap chunk performance

### DIFF
--- a/doc/source/dev/bootstrap_architecture.rst
+++ b/doc/source/dev/bootstrap_architecture.rst
@@ -140,6 +140,28 @@ practical cases:
   ``fraction_of_total``. Kraken real-data validation against a trusted
   ``master`` baseline was exact and faster for all four reducers.
 
+As of Monday, August 3, 2026, same-variable compound percentile
+``OR`` value aggregates such as
+``> 95 doy_per OR <= 10 doy_per`` are now also robust to materially
+different chunk layouts. Kraken validation showed exact outputs between
+the default and alternate chunk profiles for:
+
+- ``count_occurrences``;
+- ``average``;
+- ``sum``;
+- ``fraction_of_total``.
+
+The same chunk-robustness validation also remained exact for the simple
+optimized percentile spell family:
+
+- generic spell bootstrap;
+- ``WSDI``;
+- ``CSDI``.
+
+This matters for maintainability as much as for speed. Optimized
+bootstrap support is not complete until it stays both exact and
+performance-stable under different chunk layouts that users may provide.
+
 Non-bootstrap family
 --------------------
 
@@ -254,6 +276,15 @@ Those helpers keep the bootstrap preparation workflow readable in code:
 That is still only a first step. Threshold generation itself is not yet
 fully extracted into a reusable engine, but the preparation phases now
 have a stable home and direct unit tests.
+
+The same module now also contains the stable-study materialization
+helper used by the validated chunk-robust optimized paths. It is kept as
+an explicit bootstrap primitive so maintainers can reason separately
+about:
+
+- threshold-generation preparation;
+- study-data materialization;
+- reducer-specific aggregation.
 
 Bootstrap threshold generation
 ------------------------------

--- a/src/icclim/_core/generic/bootstrap.py
+++ b/src/icclim/_core/generic/bootstrap.py
@@ -12,8 +12,10 @@ from icclim._core.generic.bootstrap_capability import (
     is_optimized_doy_percentile_count_supported,
 )
 from icclim._core.generic.bootstrap_primitives import (
+    BootstrapPreparedInputs,
     build_bootstrap_array_inputs,
     build_bootstrap_output,
+    build_bootstrap_prepared_inputs,
     build_bootstrap_reference_sample,
     build_bootstrap_temporal_indexing,
 )
@@ -192,20 +194,24 @@ def compute_doy_percentile_bootstrap_union_exceedance_mask(
     study: DataArray,
     threshold: PercentileThreshold,
     freq: str,
+    *,
+    prepared_inputs: BootstrapPreparedInputs | None = None,
 ) -> DataArray | None:
     """Compute the daily union exceedance mask for spell-style bootstrap reducers."""
     if not _can_compute_optimized_bootstrap(study, threshold, freq):
         return None
     import xarray as xr  # noqa: PLC0415
 
-    reference_sample = build_bootstrap_reference_sample(study, threshold)
-    temporal_indexing = build_bootstrap_temporal_indexing(
-        reference_sample.study,
-        reference_sample.reference_sample,
-        freq,
-        doy_window_width=threshold.doy_window_width,
-    )
-    array_inputs = build_bootstrap_array_inputs(reference_sample, dtype=np.float32)
+    if prepared_inputs is None:
+        prepared_inputs = build_bootstrap_prepared_inputs(
+            study,
+            threshold,
+            freq,
+            dtype=np.float32,
+        )
+    reference_sample = prepared_inputs.reference_sample
+    temporal_indexing = prepared_inputs.temporal_indexing
+    array_inputs = prepared_inputs.array_inputs
     flat_result = _bootstrap_union_mask_kernel(
         array_inputs.flat_reference_raw,
         array_inputs.flat_reference_filtered,

--- a/src/icclim/_core/generic/bootstrap_primitives.py
+++ b/src/icclim/_core/generic/bootstrap_primitives.py
@@ -119,7 +119,7 @@ def build_bootstrap_reference_sample(
     threshold: PercentileThreshold,
 ) -> BootstrapReferenceSample:
     """Load and prepare the reference-period sample for bootstrap."""
-    loaded_study = _normalize_bootstrap_chunks(study).load()
+    loaded_study = _materialize_bootstrap_study(study)
     climatology_bounds = threshold.climatology_bounds(loaded_study)
     reference_sample = loaded_study.sel(time=slice(*climatology_bounds))
     threshold_floor = _threshold_min_value_in_reference_units(
@@ -165,6 +165,24 @@ def _normalize_bootstrap_chunks(study: DataArray) -> DataArray:
     if not target_chunks:
         return study
     return study.chunk(target_chunks)
+
+
+def _materialize_bootstrap_study(study: DataArray) -> DataArray:
+    """Load study data through stable time slabs instead of one large dask graph."""
+    if not hasattr(study.data, "chunks"):
+        return study.load()
+    normalized = _normalize_bootstrap_chunks(study).transpose("time", ...)
+    time_block = min(
+        normalized.sizes["time"],
+        PREFERRED_BOOTSTRAP_CHUNKS["time"],
+    )
+    blocks: list[np.ndarray] = []
+    for start in range(0, normalized.sizes["time"], time_block):
+        stop = min(normalized.sizes["time"], start + time_block)
+        block = normalized.isel(time=slice(start, stop)).load()
+        blocks.append(np.asarray(block.data))
+    loaded = np.concatenate(blocks, axis=0)
+    return normalized.copy(data=loaded)
 
 
 def build_bootstrap_array_inputs(

--- a/src/icclim/_core/generic/bootstrap_primitives.py
+++ b/src/icclim/_core/generic/bootstrap_primitives.py
@@ -22,11 +22,6 @@ if TYPE_CHECKING:
 
 
 LEAP_YEAR_DAY_COUNT = 366
-PREFERRED_BOOTSTRAP_CHUNKS = {
-    "time": 365,
-    "lat": 24,
-    "lon": 32,
-}
 
 
 @dataclass(frozen=True)
@@ -128,7 +123,7 @@ def build_bootstrap_reference_sample(
     threshold: PercentileThreshold,
 ) -> BootstrapReferenceSample:
     """Load and prepare the reference-period sample for bootstrap."""
-    loaded_study = _normalize_bootstrap_chunks(study).load()
+    loaded_study = study.load()
     climatology_bounds = threshold.climatology_bounds(loaded_study)
     reference_sample = loaded_study.sel(time=slice(*climatology_bounds))
     threshold_floor = _threshold_min_value_in_reference_units(
@@ -148,32 +143,6 @@ def build_bootstrap_reference_sample(
         filtered_reference_sample=filtered_reference_sample,
         threshold_floor_in_reference_units=threshold_floor,
     )
-
-
-def _normalize_bootstrap_chunks(study: DataArray) -> DataArray:
-    """Rechunk dask-backed study data to a stable bootstrap-friendly layout."""
-    if not hasattr(study.data, "chunks"):
-        return study
-    rechunk_spec = {
-        dim: min(size, PREFERRED_BOOTSTRAP_CHUNKS[dim])
-        for dim, size in study.sizes.items()
-        if dim in PREFERRED_BOOTSTRAP_CHUNKS
-    }
-    if not rechunk_spec:
-        return study
-    current_chunks = {
-        dim: tuple(chunks)
-        for dim, chunks in zip(study.dims, study.chunks, strict=False)
-    }
-    target_chunks = {
-        dim: chunk_size
-        for dim, chunk_size in rechunk_spec.items()
-        if current_chunks.get(dim) != (chunk_size,) * (study.sizes[dim] // chunk_size)
-        or study.sizes[dim] % chunk_size != 0
-    }
-    if not target_chunks:
-        return study
-    return study.chunk(target_chunks)
 
 
 def build_bootstrap_array_inputs(

--- a/src/icclim/_core/generic/bootstrap_primitives.py
+++ b/src/icclim/_core/generic/bootstrap_primitives.py
@@ -22,6 +22,11 @@ if TYPE_CHECKING:
 
 
 LEAP_YEAR_DAY_COUNT = 366
+PREFERRED_BOOTSTRAP_CHUNKS = {
+    "time": 365,
+    "lat": 24,
+    "lon": 32,
+}
 
 
 @dataclass(frozen=True)
@@ -114,7 +119,7 @@ def build_bootstrap_reference_sample(
     threshold: PercentileThreshold,
 ) -> BootstrapReferenceSample:
     """Load and prepare the reference-period sample for bootstrap."""
-    loaded_study = study.load()
+    loaded_study = _normalize_bootstrap_chunks(study).load()
     climatology_bounds = threshold.climatology_bounds(loaded_study)
     reference_sample = loaded_study.sel(time=slice(*climatology_bounds))
     threshold_floor = _threshold_min_value_in_reference_units(
@@ -134,6 +139,32 @@ def build_bootstrap_reference_sample(
         filtered_reference_sample=filtered_reference_sample,
         threshold_floor_in_reference_units=threshold_floor,
     )
+
+
+def _normalize_bootstrap_chunks(study: DataArray) -> DataArray:
+    """Rechunk dask-backed study data to a stable bootstrap-friendly layout."""
+    if not hasattr(study.data, "chunks"):
+        return study
+    rechunk_spec = {
+        dim: min(size, PREFERRED_BOOTSTRAP_CHUNKS[dim])
+        for dim, size in study.sizes.items()
+        if dim in PREFERRED_BOOTSTRAP_CHUNKS
+    }
+    if not rechunk_spec:
+        return study
+    current_chunks = {
+        dim: tuple(chunks)
+        for dim, chunks in zip(study.dims, study.chunks, strict=False)
+    }
+    target_chunks = {
+        dim: chunk_size
+        for dim, chunk_size in rechunk_spec.items()
+        if current_chunks.get(dim) != (chunk_size,) * (study.sizes[dim] // chunk_size)
+        or study.sizes[dim] % chunk_size != 0
+    }
+    if not target_chunks:
+        return study
+    return study.chunk(target_chunks)
 
 
 def build_bootstrap_array_inputs(

--- a/src/icclim/_core/generic/bootstrap_primitives.py
+++ b/src/icclim/_core/generic/bootstrap_primitives.py
@@ -128,7 +128,7 @@ def build_bootstrap_reference_sample(
     threshold: PercentileThreshold,
 ) -> BootstrapReferenceSample:
     """Load and prepare the reference-period sample for bootstrap."""
-    loaded_study = _materialize_bootstrap_study(study)
+    loaded_study = _normalize_bootstrap_chunks(study).load()
     climatology_bounds = threshold.climatology_bounds(loaded_study)
     reference_sample = loaded_study.sel(time=slice(*climatology_bounds))
     threshold_floor = _threshold_min_value_in_reference_units(
@@ -174,24 +174,6 @@ def _normalize_bootstrap_chunks(study: DataArray) -> DataArray:
     if not target_chunks:
         return study
     return study.chunk(target_chunks)
-
-
-def _materialize_bootstrap_study(study: DataArray) -> DataArray:
-    """Load study data through stable time slabs instead of one large dask graph."""
-    if not hasattr(study.data, "chunks"):
-        return study.load()
-    normalized = _normalize_bootstrap_chunks(study).transpose("time", ...)
-    time_block = min(
-        normalized.sizes["time"],
-        PREFERRED_BOOTSTRAP_CHUNKS["time"],
-    )
-    blocks: list[np.ndarray] = []
-    for start in range(0, normalized.sizes["time"], time_block):
-        stop = min(normalized.sizes["time"], start + time_block)
-        block = normalized.isel(time=slice(start, stop)).load()
-        blocks.append(np.asarray(block.data))
-    loaded = np.concatenate(blocks, axis=0)
-    return normalized.copy(data=loaded)
 
 
 def build_bootstrap_array_inputs(

--- a/src/icclim/_core/generic/bootstrap_primitives.py
+++ b/src/icclim/_core/generic/bootstrap_primitives.py
@@ -75,6 +75,15 @@ class BootstrapArrayInputs:
     spatial_shape: tuple[int, ...]
 
 
+@dataclass(frozen=True)
+class BootstrapPreparedInputs:
+    """Prepared bootstrap arrays and indexes shared across reducers."""
+
+    reference_sample: BootstrapReferenceSample
+    temporal_indexing: BootstrapTemporalIndexing
+    array_inputs: BootstrapArrayInputs
+
+
 def build_bootstrap_output(
     *,
     flat_result: np.ndarray,
@@ -213,6 +222,29 @@ def build_bootstrap_array_inputs(
             -1,
         ),
         spatial_shape=study.shape[1:],
+    )
+
+
+def build_bootstrap_prepared_inputs(
+    study: DataArray,
+    threshold: PercentileThreshold,
+    freq: str,
+    *,
+    dtype: np.dtype = np.float32,
+) -> BootstrapPreparedInputs:
+    """Build the reusable study arrays and indexes for optimized bootstrap."""
+    reference_sample = build_bootstrap_reference_sample(study, threshold)
+    temporal_indexing = build_bootstrap_temporal_indexing(
+        reference_sample.study,
+        reference_sample.reference_sample,
+        freq,
+        doy_window_width=threshold.doy_window_width,
+    )
+    array_inputs = build_bootstrap_array_inputs(reference_sample, dtype=dtype)
+    return BootstrapPreparedInputs(
+        reference_sample=reference_sample,
+        temporal_indexing=temporal_indexing,
+        array_inputs=array_inputs,
     )
 
 

--- a/src/icclim/_core/generic/bootstrap_primitives.py
+++ b/src/icclim/_core/generic/bootstrap_primitives.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
 
 
 LEAP_YEAR_DAY_COUNT = 366
+PREFERRED_BOOTSTRAP_TIME_LOAD_BLOCK = 365
 
 
 @dataclass(frozen=True)
@@ -121,9 +122,14 @@ def build_bootstrap_output(
 def build_bootstrap_reference_sample(
     study: DataArray,
     threshold: PercentileThreshold,
+    *,
+    prefer_file_reopen: bool = False,
 ) -> BootstrapReferenceSample:
     """Load and prepare the reference-period sample for bootstrap."""
-    loaded_study = study.load()
+    loaded_study = _materialize_bootstrap_study(
+        study,
+        prefer_file_reopen=prefer_file_reopen,
+    )
     climatology_bounds = threshold.climatology_bounds(loaded_study)
     reference_sample = loaded_study.sel(time=slice(*climatology_bounds))
     threshold_floor = _threshold_min_value_in_reference_units(
@@ -143,6 +149,124 @@ def build_bootstrap_reference_sample(
         filtered_reference_sample=filtered_reference_sample,
         threshold_floor_in_reference_units=threshold_floor,
     )
+
+
+def _materialize_bootstrap_study(
+    study: DataArray,
+    *,
+    prefer_file_reopen: bool = False,
+) -> DataArray:
+    """Load study data through a stable internal bootstrap layout."""
+    normalized = study.transpose("time", ...)
+    if not prefer_file_reopen or not hasattr(normalized.data, "chunks"):
+        return normalized.load()
+    reopened = _reopen_file_backed_study(normalized)
+    if reopened is not None:
+        return reopened.load()
+    return normalized.load()
+
+
+def _block_slices(
+    *,
+    size: int,
+    preferred_block_size: int,
+) -> list[slice]:
+    block_size = min(size, preferred_block_size)
+    return [
+        slice(start, min(size, start + block_size))
+        for start in range(0, size, block_size)
+    ]
+
+
+def _preferred_spatial_block_sizes(study: DataArray) -> dict[str, int]:
+    preferred_chunks = study.encoding.get("preferred_chunks")
+    if not isinstance(preferred_chunks, dict):
+        return {}
+    return {
+        dim: min(study.sizes[dim], int(preferred_chunks[dim]))
+        for dim in study.dims
+        if dim != "time" and dim in preferred_chunks
+    }
+
+
+def _reopen_file_backed_study(study: DataArray) -> DataArray | None:
+    source_files, variable_name = _file_backed_bootstrap_sources(study)
+    if not source_files or variable_name is None:
+        return None
+    import xarray as xr  # noqa: PLC0415
+
+    reopened = xr.open_mfdataset(
+        source_files,
+        combine="by_coords",
+        chunks=_bootstrap_reopen_chunks(study),
+    )[variable_name]
+    selection = _selection_for_reopened_study(reopened, study)
+    if selection:
+        reopened = reopened.sel(selection)
+    reopened = reopened.transpose(*study.dims)
+    reopened.attrs = dict(study.attrs)
+    return reopened
+
+
+def _bootstrap_reopen_chunks(study: DataArray) -> dict[str, int]:
+    chunks = {"time": min(study.sizes["time"], PREFERRED_BOOTSTRAP_TIME_LOAD_BLOCK)}
+    chunks.update(_preferred_spatial_block_sizes(study))
+    return chunks
+
+
+def _selection_for_reopened_study(
+    reopened: DataArray,
+    study: DataArray,
+) -> dict[str, object]:
+    selection: dict[str, object] = {}
+    for dim in study.dims:
+        if dim not in reopened.dims:
+            continue
+        if dim == "time":
+            if study.sizes["time"] == reopened.sizes["time"]:
+                continue
+            selection[dim] = slice(study[dim].values[0], study[dim].values[-1])
+            continue
+        selection[dim] = study.indexes[dim]
+    return selection
+
+
+def _file_backed_bootstrap_sources(
+    study: DataArray,
+) -> tuple[list[str], str | None]:
+    dask_graph = getattr(getattr(study, "data", None), "dask", None)
+    if dask_graph is None:
+        return [], None
+    source_files: list[str] = []
+    variable_name: str | None = None
+    for layer_name, layer in dask_graph.layers.items():
+        if not layer_name.startswith("original-open_dataset-"):
+            continue
+        _, layer_value = next(iter(layer.items()))
+        wrapper = _unwrap_file_backed_array_wrapper(layer_value)
+        if wrapper is None or not hasattr(wrapper, "datastore"):
+            return [], None
+        file_path = getattr(wrapper.datastore, "_filename", None)
+        current_variable_name = getattr(wrapper, "variable_name", None)
+        if file_path is None or current_variable_name is None:
+            return [], None
+        if variable_name is None:
+            variable_name = str(current_variable_name)
+        elif variable_name != str(current_variable_name):
+            return [], None
+        source_files.append(str(file_path))
+    return source_files, variable_name
+
+
+def _unwrap_file_backed_array_wrapper(obj: object) -> object | None:
+    current = obj
+    for _ in range(12):
+        if hasattr(current, "datastore") and hasattr(current, "variable_name"):
+            return current
+        if not hasattr(current, "array"):
+            break
+        current = current.array
+    return None
 
 
 def build_bootstrap_array_inputs(
@@ -182,9 +306,14 @@ def build_bootstrap_prepared_inputs(
     freq: str,
     *,
     dtype: np.dtype = np.float32,
+    prefer_file_reopen: bool = False,
 ) -> BootstrapPreparedInputs:
     """Build the reusable study arrays and indexes for optimized bootstrap."""
-    reference_sample = build_bootstrap_reference_sample(study, threshold)
+    reference_sample = build_bootstrap_reference_sample(
+        study,
+        threshold,
+        prefer_file_reopen=prefer_file_reopen,
+    )
     temporal_indexing = build_bootstrap_temporal_indexing(
         reference_sample.study,
         reference_sample.reference_sample,

--- a/src/icclim/_core/generic/functions.py
+++ b/src/icclim/_core/generic/functions.py
@@ -633,6 +633,7 @@ def fraction_of_total(
         climate_var=climate_vars[0],
         threshold=threshold,
         resample_freq=resample_freq,
+        prepared_inputs_cache={},
     ).squeeze()
     over = (
         study.where(exceedance_mask, 0)
@@ -2508,6 +2509,7 @@ def _run_simple_reducer(
             climate_var=climate_vars[0],
             threshold=threshold,
             resample_freq=resample_freq,
+            prepared_inputs_cache={},
         ).squeeze()
         filtered_study = study.where(exceedance_mask)
     else:

--- a/src/icclim/_core/generic/functions.py
+++ b/src/icclim/_core/generic/functions.py
@@ -612,6 +612,11 @@ def fraction_of_total(
             optimized_fraction,
             to_percent=to_percent,
         )
+    study = _materialize_study_for_optimized_compound_value_aggregate(
+        study=study,
+        threshold=threshold,
+        bootstrap_capability=bootstrap_capability,
+    )
     if threshold.threshold_min_value is not None:
         min_val = threshold.threshold_min_value
         from xclim.core.units import convert_units_to  # noqa: PLC0415
@@ -837,6 +842,24 @@ def average(
         )
         if optimized_average is not None:
             return optimized_average
+    stabilized_study = _materialize_study_for_optimized_compound_value_aggregate(
+        study=study,
+        threshold=threshold,
+        bootstrap_capability=bootstrap_capability,
+    )
+    if stabilized_study is not study and threshold is not None:
+        exceedance_mask = _compute_threshold_exceedance_mask(
+            climate_var=climate_vars[0],
+            threshold=threshold,
+            resample_freq=resample_freq,
+            prepared_inputs_cache={},
+        ).squeeze()
+        return DataArrayResample.mean(
+            stabilized_study.where(exceedance_mask).resample(
+                time=resample_freq.pandas_freq
+            ),
+            dim="time",
+        )
     return _run_simple_reducer(
         climate_vars=climate_vars,
         resample_freq=resample_freq,
@@ -934,6 +957,24 @@ def generic_sum(
         )
         if optimized_sum is not None:
             return optimized_sum
+    stabilized_study = _materialize_study_for_optimized_compound_value_aggregate(
+        study=study,
+        threshold=threshold,
+        bootstrap_capability=bootstrap_capability,
+    )
+    if stabilized_study is not study and threshold is not None and not _is_rate(study):
+        exceedance_mask = _compute_threshold_exceedance_mask(
+            climate_var=climate_vars[0],
+            threshold=threshold,
+            resample_freq=resample_freq,
+            prepared_inputs_cache={},
+        ).squeeze()
+        return DataArrayResample.sum(
+            stabilized_study.where(exceedance_mask).resample(
+                time=resample_freq.pandas_freq
+            ),
+            dim="time",
+        )
     return _run_simple_reducer(
         climate_vars=climate_vars,
         resample_freq=resample_freq,
@@ -982,6 +1023,28 @@ def _compute_optimized_fraction_of_total(
         resample_freq,
         _get_fast_bootstrap_max_cells(study),
     )
+
+
+def _materialize_study_for_optimized_compound_value_aggregate(
+    *,
+    study: DataArray,
+    threshold: Threshold | None,
+    bootstrap_capability: BootstrapCapability,
+) -> DataArray:
+    if (
+        not bootstrap_capability.uses_optimized_bootstrap
+        or bootstrap_capability.reason_code
+        != "optimized_compound_value_aggregate_bootstrap_supported"
+    ):
+        return study
+    from icclim._core.generic.bootstrap_primitives import (  # noqa: PLC0415
+        _materialize_bootstrap_study,
+    )
+    from icclim._core.generic.threshold.bounded import BoundedThreshold  # noqa: PLC0415
+
+    if not isinstance(threshold, BoundedThreshold):
+        return study
+    return _materialize_bootstrap_study(study, prefer_file_reopen=True)
 
 
 def _format_fraction_of_total_result(
@@ -2064,6 +2127,7 @@ def _compute_fast_tiled_bootstrap_spell_mask(
                     tile_threshold,
                     resample_freq.pandas_freq,
                     dtype=np.float32,
+                    prefer_file_reopen=True,
                 )
                 prepared_inputs_cache[cache_key] = prepared_inputs
         tile_result = compute_doy_percentile_bootstrap_union_exceedance_mask(

--- a/src/icclim/_core/generic/functions.py
+++ b/src/icclim/_core/generic/functions.py
@@ -28,6 +28,7 @@ from time import perf_counter
 from typing import TYPE_CHECKING, Any, cast
 from warnings import warn
 
+import numpy as np
 import xarray as xr
 from numpy import abs as np_abs
 from numpy import diff as np_diff
@@ -66,12 +67,12 @@ if TYPE_CHECKING:
     from collections.abc import Callable
     from datetime import timedelta
 
-    import numpy as np
     from pint import Quantity
     from xarray.computation.rolling import DataArrayRolling
     from xarray.core.groupby import DataArrayGroupBy
 
     from icclim._core.climate_variable import ClimateVariable
+    from icclim._core.generic.bootstrap_primitives import BootstrapPreparedInputs
     from icclim._core.generic.threshold.percentile import PercentileThreshold
     from icclim._core.model.logical_link import LogicalLink
     from icclim._core.model.threshold import Threshold
@@ -2030,9 +2031,14 @@ def _compute_fast_tiled_bootstrap_spell_mask(
     climate_var: ClimateVariable,
     resample_freq: Frequency,
     max_cells: int,
+    *,
+    prepared_inputs_cache: dict[tuple, BootstrapPreparedInputs] | None = None,
 ) -> DataArray | None:
     from icclim._core.generic.bootstrap import (  # noqa: PLC0415
         compute_doy_percentile_bootstrap_union_exceedance_mask,
+    )
+    from icclim._core.generic.bootstrap_primitives import (  # noqa: PLC0415
+        build_bootstrap_prepared_inputs,
     )
 
     optimized_start = perf_counter()
@@ -2043,10 +2049,27 @@ def _compute_fast_tiled_bootstrap_spell_mask(
     for tile_indexers in _iter_spatial_tiles(climate_var.studied_data, max_cells):
         tile_study = climate_var.studied_data.isel(tile_indexers)
         tile_threshold = _slice_threshold_for_tile(threshold, tile_indexers)
+        prepared_inputs = None
+        if prepared_inputs_cache is not None:
+            cache_key = _bootstrap_tile_preparation_cache_key(
+                tile_indexers,
+                tile_threshold,
+                resample_freq.pandas_freq,
+            )
+            prepared_inputs = prepared_inputs_cache.get(cache_key)
+            if prepared_inputs is None:
+                prepared_inputs = build_bootstrap_prepared_inputs(
+                    tile_study,
+                    tile_threshold,
+                    resample_freq.pandas_freq,
+                    dtype=np.float32,
+                )
+                prepared_inputs_cache[cache_key] = prepared_inputs
         tile_result = compute_doy_percentile_bootstrap_union_exceedance_mask(
             tile_study,
             tile_threshold,
             resample_freq.pandas_freq,
+            prepared_inputs=prepared_inputs,
         )
         if tile_result is None:
             return None
@@ -2574,6 +2597,7 @@ def _compute_combined_exceedance_mask(
                 climate_var=climate_var,
                 threshold=climate_var.threshold,
                 resample_freq=resample_freq,
+                prepared_inputs_cache={},
             ).squeeze()
         )
     return logical_link(exceedance_masks)
@@ -2584,6 +2608,7 @@ def _compute_threshold_exceedance_mask(
     climate_var: ClimateVariable,
     threshold: Threshold,
     resample_freq: Frequency,
+    prepared_inputs_cache: dict[tuple, BootstrapPreparedInputs] | None = None,
 ) -> DataArray:
     from icclim._core.generic.threshold.bounded import BoundedThreshold  # noqa: PLC0415
     from icclim._core.generic.threshold.percentile import (  # noqa: PLC0415
@@ -2595,11 +2620,13 @@ def _compute_threshold_exceedance_mask(
             climate_var=replace(climate_var, threshold=threshold.left_threshold),
             threshold=threshold.left_threshold,
             resample_freq=resample_freq,
+            prepared_inputs_cache=prepared_inputs_cache,
         )
         right_mask = _compute_threshold_exceedance_mask(
             climate_var=replace(climate_var, threshold=threshold.right_threshold),
             threshold=threshold.right_threshold,
             resample_freq=resample_freq,
+            prepared_inputs_cache=prepared_inputs_cache,
         )
         return _transpose_like_study(
             threshold.logical_link.compute([left_mask.squeeze(), right_mask.squeeze()]),
@@ -2622,6 +2649,7 @@ def _compute_threshold_exceedance_mask(
                 leaf_climate_var,
                 resample_freq,
                 _get_fast_bootstrap_max_cells(climate_var.studied_data),
+                prepared_inputs_cache=prepared_inputs_cache,
             )
             if optimized_mask is not None:
                 return optimized_mask
@@ -2637,6 +2665,38 @@ def _compute_threshold_exceedance_mask(
         threshold=threshold,
         freq=resample_freq.pandas_freq,
         bootstrap=bootstrap_required,
+    )
+
+
+def _bootstrap_tile_preparation_cache_key(
+    tile_indexers: dict[str, slice | int],
+    threshold: Threshold,
+    freq: str,
+) -> tuple:
+    from icclim._core.generic.threshold.percentile import (  # noqa: PLC0415
+        PercentileThreshold,
+    )
+
+    if not isinstance(threshold, PercentileThreshold):
+        return (freq, tuple(sorted(tile_indexers.items())))
+    normalized_indexers = tuple(
+        (
+            dim,
+            indexer
+            if isinstance(indexer, int)
+            else (indexer.start, indexer.stop, indexer.step),
+        )
+        for dim, indexer in sorted(tile_indexers.items())
+    )
+    return (
+        freq,
+        normalized_indexers,
+        threshold.reference_period,
+        threshold.doy_window_width,
+        None
+        if threshold.threshold_min_value is None
+        else str(threshold.threshold_min_value),
+        threshold.only_leap_years,
     )
 
 

--- a/tests/test_bootstrap_primitives.py
+++ b/tests/test_bootstrap_primitives.py
@@ -5,7 +5,6 @@ import pandas as pd
 import xarray as xr
 
 from icclim._core.generic.bootstrap_primitives import (
-    PREFERRED_BOOTSTRAP_CHUNKS,
     build_bootstrap_array_inputs,
     build_bootstrap_output,
     build_bootstrap_reference_sample,
@@ -118,24 +117,3 @@ def test_build_bootstrap_output_rebuilds_coordinates_and_attrs() -> None:
     assert output.shape == (5, 2, 1)
     assert output.attrs["units"] == "d"
     assert output.attrs["climatology_bounds"] == ["2042-01-01", "2046-12-31"]
-
-
-def test_build_bootstrap_reference_sample_rechunks_dask_inputs() -> None:
-    tas = stub_tas(27.0, lat_length=30, lon_length=40).chunk(
-        {"time": 730, "lat": 7, "lon": 9}
-    )
-    threshold = build_threshold("> 90 doy_per")
-
-    reference_sample = build_bootstrap_reference_sample(tas, threshold)
-
-    assert reference_sample.study.chunks is None
-    dask_view = tas.chunk(
-        {
-            "time": PREFERRED_BOOTSTRAP_CHUNKS["time"],
-            "lat": PREFERRED_BOOTSTRAP_CHUNKS["lat"],
-            "lon": PREFERRED_BOOTSTRAP_CHUNKS["lon"],
-        }
-    )
-    assert dask_view.chunks[0][0] == PREFERRED_BOOTSTRAP_CHUNKS["time"]
-    assert dask_view.chunks[1][0] == PREFERRED_BOOTSTRAP_CHUNKS["lat"]
-    assert dask_view.chunks[2][0] == PREFERRED_BOOTSTRAP_CHUNKS["lon"]

--- a/tests/test_bootstrap_primitives.py
+++ b/tests/test_bootstrap_primitives.py
@@ -5,6 +5,7 @@ import pandas as pd
 import xarray as xr
 
 from icclim._core.generic.bootstrap_primitives import (
+    PREFERRED_BOOTSTRAP_CHUNKS,
     build_bootstrap_array_inputs,
     build_bootstrap_output,
     build_bootstrap_reference_sample,
@@ -117,3 +118,24 @@ def test_build_bootstrap_output_rebuilds_coordinates_and_attrs() -> None:
     assert output.shape == (5, 2, 1)
     assert output.attrs["units"] == "d"
     assert output.attrs["climatology_bounds"] == ["2042-01-01", "2046-12-31"]
+
+
+def test_build_bootstrap_reference_sample_rechunks_dask_inputs() -> None:
+    tas = stub_tas(27.0, lat_length=30, lon_length=40).chunk(
+        {"time": 730, "lat": 7, "lon": 9}
+    )
+    threshold = build_threshold("> 90 doy_per")
+
+    reference_sample = build_bootstrap_reference_sample(tas, threshold)
+
+    assert reference_sample.study.chunks is None
+    dask_view = tas.chunk(
+        {
+            "time": PREFERRED_BOOTSTRAP_CHUNKS["time"],
+            "lat": PREFERRED_BOOTSTRAP_CHUNKS["lat"],
+            "lon": PREFERRED_BOOTSTRAP_CHUNKS["lon"],
+        }
+    )
+    assert dask_view.chunks[0][0] == PREFERRED_BOOTSTRAP_CHUNKS["time"]
+    assert dask_view.chunks[1][0] == PREFERRED_BOOTSTRAP_CHUNKS["lat"]
+    assert dask_view.chunks[2][0] == PREFERRED_BOOTSTRAP_CHUNKS["lon"]

--- a/tests/test_bootstrap_primitives.py
+++ b/tests/test_bootstrap_primitives.py
@@ -139,3 +139,12 @@ def test_build_bootstrap_reference_sample_rechunks_dask_inputs() -> None:
     assert dask_view.chunks[0][0] == PREFERRED_BOOTSTRAP_CHUNKS["time"]
     assert dask_view.chunks[1][0] == PREFERRED_BOOTSTRAP_CHUNKS["lat"]
     assert dask_view.chunks[2][0] == PREFERRED_BOOTSTRAP_CHUNKS["lon"]
+
+
+def test_build_bootstrap_reference_sample_preserves_data_when_loaded_by_slabs() -> None:
+    tas = stub_tas(lat_length=2, lon_length=2).chunk({"time": 730, "lat": 1, "lon": 1})
+    threshold = build_threshold("> 90 doy_per")
+
+    reference_sample = build_bootstrap_reference_sample(tas, threshold)
+
+    xr.testing.assert_equal(reference_sample.study, tas.transpose("time", ...).load())

--- a/tests/test_bootstrap_primitives.py
+++ b/tests/test_bootstrap_primitives.py
@@ -139,12 +139,3 @@ def test_build_bootstrap_reference_sample_rechunks_dask_inputs() -> None:
     assert dask_view.chunks[0][0] == PREFERRED_BOOTSTRAP_CHUNKS["time"]
     assert dask_view.chunks[1][0] == PREFERRED_BOOTSTRAP_CHUNKS["lat"]
     assert dask_view.chunks[2][0] == PREFERRED_BOOTSTRAP_CHUNKS["lon"]
-
-
-def test_build_bootstrap_reference_sample_preserves_data_when_loaded_by_slabs() -> None:
-    tas = stub_tas(lat_length=2, lon_length=2).chunk({"time": 730, "lat": 1, "lon": 1})
-    threshold = build_threshold("> 90 doy_per")
-
-    reference_sample = build_bootstrap_reference_sample(tas, threshold)
-
-    xr.testing.assert_equal(reference_sample.study, tas.transpose("time", ...).load())

--- a/tests/test_bootstrap_primitives.py
+++ b/tests/test_bootstrap_primitives.py
@@ -5,6 +5,9 @@ import pandas as pd
 import xarray as xr
 
 from icclim._core.generic.bootstrap_primitives import (
+    _block_slices,
+    _materialize_bootstrap_study,
+    _preferred_spatial_block_sizes,
     build_bootstrap_array_inputs,
     build_bootstrap_output,
     build_bootstrap_reference_sample,
@@ -117,3 +120,26 @@ def test_build_bootstrap_output_rebuilds_coordinates_and_attrs() -> None:
     assert output.shape == (5, 2, 1)
     assert output.attrs["units"] == "d"
     assert output.attrs["climatology_bounds"] == ["2042-01-01", "2046-12-31"]
+
+
+def test_materialize_bootstrap_study_loads_chunked_spatial_tiles_exactly() -> None:
+    tas = stub_tas(lat_length=3, lon_length=5).chunk({"time": 2, "lat": 1, "lon": 2})
+
+    materialized = _materialize_bootstrap_study(tas)
+
+    xr.testing.assert_identical(materialized, tas.transpose("time", ...).load())
+
+
+def test_block_slices_covers_full_axis() -> None:
+    block_slices = _block_slices(size=5, preferred_block_size=2)
+
+    assert block_slices == [slice(0, 2), slice(2, 4), slice(4, 5)]
+
+
+def test_preferred_spatial_block_sizes_uses_backend_hints() -> None:
+    tas = stub_tas(lat_length=3, lon_length=5)
+    tas.encoding["preferred_chunks"] = {"lat": 10, "lon": 2}
+
+    block_sizes = _preferred_spatial_block_sizes(tas)
+
+    assert block_sizes == {"lat": 3, "lon": 2}

--- a/tests/test_bootstrap_primitives.py
+++ b/tests/test_bootstrap_primitives.py
@@ -2,14 +2,38 @@ from __future__ import annotations
 
 import numpy as np
 import pandas as pd
+import pytest
 import xarray as xr
 
+from icclim._core.generic.bootstrap import (
+    _bootstrap_average_kernel,
+    _bootstrap_bounded_average_kernel,
+    _bootstrap_bounded_count_kernel,
+    _bootstrap_bounded_fraction_kernel,
+    _bootstrap_bounded_sum_kernel,
+    _bootstrap_count_kernel,
+    _bootstrap_fraction_kernel,
+    _bootstrap_sum_kernel,
+    _bootstrap_union_count_kernel,
+    _bootstrap_union_mask_kernel,
+    compute_doy_percentile_bootstrap_count,
+    compute_doy_percentile_bootstrap_exceedance_average,
+    compute_doy_percentile_bootstrap_exceedance_sum,
+    compute_doy_percentile_bootstrap_fraction_of_total,
+    compute_doy_percentile_bootstrap_union_exceedance_count,
+    compute_doy_percentile_bootstrap_union_exceedance_mask,
+    compute_doy_percentile_scalar_bounded_bootstrap_count,
+    compute_doy_percentile_scalar_bounded_bootstrap_exceedance_average,
+    compute_doy_percentile_scalar_bounded_bootstrap_exceedance_sum,
+    compute_doy_percentile_scalar_bounded_bootstrap_fraction_of_total,
+)
 from icclim._core.generic.bootstrap_primitives import (
     _block_slices,
     _materialize_bootstrap_study,
     _preferred_spatial_block_sizes,
     build_bootstrap_array_inputs,
     build_bootstrap_output,
+    build_bootstrap_prepared_inputs,
     build_bootstrap_reference_sample,
     build_bootstrap_temporal_indexing,
     substitute_indices_aligned_to_target,
@@ -143,3 +167,280 @@ def test_preferred_spatial_block_sizes_uses_backend_hints() -> None:
     block_sizes = _preferred_spatial_block_sizes(tas)
 
     assert block_sizes == {"lat": 3, "lon": 2}
+
+
+def test_compiled_bootstrap_count_wrappers_match_constant_expectations() -> None:
+    tas = stub_tas(300.0).chunk({"time": 365, "lat": 1, "lon": 1})
+    threshold = build_threshold(">= 90 doy_per")
+    expected_count = tas.resample(time="YS").count(dim="time")
+
+    count = compute_doy_percentile_bootstrap_count(tas, threshold, "YS")
+    union_count = compute_doy_percentile_bootstrap_union_exceedance_count(
+        tas, threshold, "YS"
+    )
+    union_mask = compute_doy_percentile_bootstrap_union_exceedance_mask(
+        tas, threshold, "YS"
+    )
+
+    assert count is not None
+    assert union_count is not None
+    assert union_mask is not None
+    xr.testing.assert_allclose(
+        count.reset_coords("percentiles", drop=True), expected_count
+    )
+    xr.testing.assert_allclose(
+        union_count.reset_coords("percentiles", drop=True), expected_count
+    )
+    xr.testing.assert_allclose(
+        union_mask.reset_coords("percentiles", drop=True),
+        xr.ones_like(tas, dtype=np.float32),
+    )
+
+
+def test_compiled_bootstrap_value_aggregate_wrappers_match_constant_expectations() -> (
+    None
+):
+    tas = stub_tas(300.0).chunk({"time": 365, "lat": 1, "lon": 1})
+    threshold = build_threshold(">= 90 doy_per")
+    expected_count = tas.resample(time="YS").count(dim="time").astype(np.float32)
+    expected_sum = (expected_count * np.float32(300.0)).astype(tas.dtype)
+    expected_average = xr.full_like(expected_sum, 300.0)
+    expected_fraction = xr.full_like(expected_sum, 1.0)
+
+    summed = compute_doy_percentile_bootstrap_exceedance_sum(tas, threshold, "YS")
+    averaged = compute_doy_percentile_bootstrap_exceedance_average(tas, threshold, "YS")
+    fraction = compute_doy_percentile_bootstrap_fraction_of_total(tas, threshold, "YS")
+
+    assert summed is not None
+    assert averaged is not None
+    assert fraction is not None
+    xr.testing.assert_allclose(
+        summed.reset_coords("percentiles", drop=True),
+        expected_sum,
+    )
+    xr.testing.assert_allclose(
+        averaged.reset_coords("percentiles", drop=True),
+        expected_average,
+    )
+    xr.testing.assert_allclose(
+        fraction.reset_coords("percentiles", drop=True),
+        expected_fraction,
+    )
+
+
+def test_compiled_scalar_bounded_wrappers_match_constant_expectations() -> None:
+    tas = stub_tas(300.0).chunk({"time": 365, "lat": 1, "lon": 1})
+    threshold = build_threshold(">= 90 doy_per")
+    expected_count = tas.resample(time="YS").count(dim="time")
+    expected_sum = (expected_count * 300.0).astype(tas.dtype)
+    expected_average = xr.full_like(expected_sum, 300.0)
+    expected_fraction = xr.full_like(expected_sum, 1.0)
+
+    count = compute_doy_percentile_scalar_bounded_bootstrap_count(
+        tas,
+        threshold,
+        "YS",
+        303.15,
+        3,
+        0,
+    )
+    summed = compute_doy_percentile_scalar_bounded_bootstrap_exceedance_sum(
+        tas,
+        threshold,
+        "YS",
+        303.15,
+        3,
+        0,
+    )
+    averaged = compute_doy_percentile_scalar_bounded_bootstrap_exceedance_average(
+        tas,
+        threshold,
+        "YS",
+        303.15,
+        3,
+        0,
+    )
+    fraction = compute_doy_percentile_scalar_bounded_bootstrap_fraction_of_total(
+        tas,
+        threshold,
+        "YS",
+        303.15,
+        3,
+        0,
+    )
+
+    assert count is not None
+    assert summed is not None
+    assert averaged is not None
+    assert fraction is not None
+    xr.testing.assert_allclose(
+        count.reset_coords("percentiles", drop=True), expected_count
+    )
+    xr.testing.assert_allclose(
+        summed.reset_coords("percentiles", drop=True), expected_sum
+    )
+    xr.testing.assert_allclose(
+        averaged.reset_coords("percentiles", drop=True),
+        expected_average,
+    )
+    xr.testing.assert_allclose(
+        fraction.reset_coords("percentiles", drop=True),
+        expected_fraction,
+    )
+
+
+def test_compiled_bootstrap_returns_none_when_not_optimized() -> None:
+    tas = stub_tas(300.0).chunk({"time": 365, "lat": 1, "lon": 1})
+    threshold = build_threshold(">= 90 doy_per")
+
+    assert compute_doy_percentile_bootstrap_count(tas, threshold, "D") is None
+
+
+def _kernel_common_args(
+    tas: xr.DataArray,
+    threshold,
+) -> tuple[tuple, xr.DataArray]:
+    prepared = build_bootstrap_prepared_inputs(tas, threshold, "YS", dtype=np.float32)
+    ref = prepared.reference_sample
+    idx = prepared.temporal_indexing
+    arr = prepared.array_inputs
+    min_threshold = (
+        np.nan
+        if ref.threshold_floor_in_reference_units is None
+        else float(ref.threshold_floor_in_reference_units)
+    )
+    args = (
+        arr.flat_reference_raw,
+        arr.flat_reference_filtered,
+        arr.flat_study,
+        idx.sample_indices_by_day_of_year,
+        idx.reference_index_year,
+        idx.reference_index_position,
+        idx.substitute_alignment,
+        idx.output_starts,
+        idx.output_lengths,
+        idx.year_group_starts,
+        idx.year_group_stops,
+        idx.year_max_day_of_years,
+        idx.year_to_reference_index,
+        idx.study_day_of_years,
+        float(threshold.percentile_coord().item()) / 100.0,
+        float(threshold.interpolation.alpha),
+        float(threshold.interpolation.beta),
+        1,
+        min_threshold,
+    )
+    return args, ref.study
+
+
+@pytest.mark.parametrize(
+    ("kernel", "wrapper"),
+    [
+        (_bootstrap_count_kernel, compute_doy_percentile_bootstrap_count),
+        (_bootstrap_sum_kernel, compute_doy_percentile_bootstrap_exceedance_sum),
+        (
+            _bootstrap_union_count_kernel,
+            compute_doy_percentile_bootstrap_union_exceedance_count,
+        ),
+        (
+            _bootstrap_average_kernel,
+            compute_doy_percentile_bootstrap_exceedance_average,
+        ),
+        (
+            _bootstrap_fraction_kernel,
+            compute_doy_percentile_bootstrap_fraction_of_total,
+        ),
+    ],
+)
+def test_numba_python_kernels_match_wrapper_outputs(kernel, wrapper) -> None:
+    tas = stub_tas(300.0).chunk({"time": 365, "lat": 1, "lon": 1})
+    threshold = build_threshold(">= 90 doy_per")
+    args, _study = _kernel_common_args(tas, threshold)
+
+    kernel_result = kernel.py_func(*args)
+    wrapper_result = wrapper(tas, threshold, "YS")
+
+    assert wrapper_result is not None
+    expected = wrapper_result.values.reshape(kernel_result.shape)
+    np.testing.assert_allclose(kernel_result, expected)
+
+
+def test_numba_python_union_mask_kernel_matches_wrapper_output() -> None:
+    tas = stub_tas(300.0).chunk({"time": 365, "lat": 1, "lon": 1})
+    threshold = build_threshold(">= 90 doy_per")
+    prepared = build_bootstrap_prepared_inputs(tas, threshold, "YS", dtype=np.float32)
+    ref = prepared.reference_sample
+    idx = prepared.temporal_indexing
+    arr = prepared.array_inputs
+    min_threshold = (
+        np.nan
+        if ref.threshold_floor_in_reference_units is None
+        else float(ref.threshold_floor_in_reference_units)
+    )
+
+    kernel_result = _bootstrap_union_mask_kernel.py_func(
+        arr.flat_reference_raw,
+        arr.flat_reference_filtered,
+        arr.flat_study,
+        idx.sample_indices_by_day_of_year,
+        idx.reference_index_year,
+        idx.reference_index_position,
+        idx.substitute_alignment,
+        idx.study_year_starts,
+        idx.study_year_lengths,
+        idx.year_max_day_of_years,
+        idx.year_to_reference_index,
+        idx.study_day_of_years,
+        float(threshold.percentile_coord().item()) / 100.0,
+        float(threshold.interpolation.alpha),
+        float(threshold.interpolation.beta),
+        1,
+        min_threshold,
+    )
+    wrapper_result = compute_doy_percentile_bootstrap_union_exceedance_mask(
+        tas,
+        threshold,
+        "YS",
+        prepared_inputs=prepared,
+    )
+
+    assert wrapper_result is not None
+    np.testing.assert_allclose(
+        kernel_result,
+        wrapper_result.values.reshape(kernel_result.shape),
+    )
+
+
+@pytest.mark.parametrize(
+    ("kernel", "wrapper"),
+    [
+        (
+            _bootstrap_bounded_count_kernel,
+            compute_doy_percentile_scalar_bounded_bootstrap_count,
+        ),
+        (
+            _bootstrap_bounded_sum_kernel,
+            compute_doy_percentile_scalar_bounded_bootstrap_exceedance_sum,
+        ),
+        (
+            _bootstrap_bounded_average_kernel,
+            compute_doy_percentile_scalar_bounded_bootstrap_exceedance_average,
+        ),
+        (
+            _bootstrap_bounded_fraction_kernel,
+            compute_doy_percentile_scalar_bounded_bootstrap_fraction_of_total,
+        ),
+    ],
+)
+def test_numba_python_bounded_kernels_match_wrapper_outputs(kernel, wrapper) -> None:
+    tas = stub_tas(300.0).chunk({"time": 365, "lat": 1, "lon": 1})
+    threshold = build_threshold(">= 90 doy_per")
+    args, _study = _kernel_common_args(tas, threshold)
+    bounded_args = (*args, np.float32(303.15), 3, 0)
+
+    kernel_result = kernel.py_func(*bounded_args)
+    wrapper_result = wrapper(tas, threshold, "YS", 303.15, 3, 0)
+
+    assert wrapper_result is not None
+    expected = wrapper_result.values.reshape(kernel_result.shape)
+    np.testing.assert_allclose(kernel_result, expected)

--- a/tests/test_generic_functions.py
+++ b/tests/test_generic_functions.py
@@ -4,7 +4,9 @@ import xarray as xr
 
 from icclim._core.climate_variable import ClimateVariable
 from icclim._core.constants import GROUP_BY_METHOD
+from icclim._core.generic import bootstrap_primitives
 from icclim._core.generic.functions import (
+    _compute_threshold_exceedance_mask,
     _safe_to_agg_units,
     average,
     count_occurrences,
@@ -194,3 +196,48 @@ def test_safe_to_agg_units_drops_unsupported_kwargs(
         "op": "count",
         "dim": "time",
     }
+
+
+def test_compound_percentile_threshold_reuses_prepared_bootstrap_inputs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tas = stub_tas(27.0, lat_length=2, lon_length=2).chunk(
+        {"time": 365, "lat": 1, "lon": 1}
+    )
+    threshold = build_threshold(
+        thresholds=["> 95 doy_per", "<= 10 doy_per"],
+        logical_link="or",
+        reference_period=("2042-01-01", "2043-12-31"),
+    )
+    climate_var = ClimateVariable(
+        name="tas",
+        standard_var=StandardVariableRegistry.TAS,
+        studied_data=tas,
+        threshold=threshold,
+        source_frequency=FrequencyRegistry.DAY,
+        global_metadata={},
+    )
+    build_calls = {"count": 0}
+
+    original_builder = bootstrap_primitives.build_bootstrap_prepared_inputs
+
+    def counted_builder(*args, **kwargs):
+        build_calls["count"] += 1
+        return original_builder(*args, **kwargs)
+
+    monkeypatch.setenv("ICCLIM_BOOTSTRAP_FAST_TILE_CELLS", "1")
+    monkeypatch.setattr(
+        bootstrap_primitives,
+        "build_bootstrap_prepared_inputs",
+        counted_builder,
+    )
+
+    mask = _compute_threshold_exceedance_mask(
+        climate_var=climate_var,
+        threshold=threshold,
+        resample_freq=FrequencyRegistry.YEAR,
+        prepared_inputs_cache={},
+    )
+
+    assert mask is not None
+    assert build_calls["count"] == 4

--- a/tests/test_generic_functions.py
+++ b/tests/test_generic_functions.py
@@ -10,6 +10,7 @@ from icclim._core.generic.functions import (
     _safe_to_agg_units,
     average,
     count_occurrences,
+    fraction_of_total,
     generic_sum,
     max_consecutive_occurrence,
     maximum,
@@ -240,4 +241,48 @@ def test_compound_percentile_threshold_reuses_prepared_bootstrap_inputs(
     )
 
     assert mask is not None
+    assert build_calls["count"] == 4
+
+
+def test_fraction_of_total_reuses_prepared_bootstrap_inputs_for_compound_threshold(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tas = stub_tas(27.0, lat_length=2, lon_length=2).chunk(
+        {"time": 365, "lat": 1, "lon": 1}
+    )
+    threshold = build_threshold(
+        thresholds=["> 95 doy_per", "<= 10 doy_per"],
+        logical_link="or",
+        reference_period=("2042-01-01", "2043-12-31"),
+    )
+    climate_var = ClimateVariable(
+        name="tas",
+        standard_var=StandardVariableRegistry.TAS,
+        studied_data=tas,
+        threshold=threshold,
+        source_frequency=FrequencyRegistry.DAY,
+        global_metadata={},
+    )
+    build_calls = {"count": 0}
+
+    original_builder = bootstrap_primitives.build_bootstrap_prepared_inputs
+
+    def counted_builder(*args, **kwargs):
+        build_calls["count"] += 1
+        return original_builder(*args, **kwargs)
+
+    monkeypatch.setenv("ICCLIM_BOOTSTRAP_FAST_TILE_CELLS", "1")
+    monkeypatch.setattr(
+        bootstrap_primitives,
+        "build_bootstrap_prepared_inputs",
+        counted_builder,
+    )
+
+    result = fraction_of_total(
+        climate_vars=[climate_var],
+        resample_freq=FrequencyRegistry.YEAR,
+        to_percent=False,
+    )
+
+    assert result is not None
     assert build_calls["count"] == 4

--- a/tests/test_generic_functions.py
+++ b/tests/test_generic_functions.py
@@ -286,3 +286,59 @@ def test_fraction_of_total_reuses_prepared_bootstrap_inputs_for_compound_thresho
 
     assert result is not None
     assert build_calls["count"] == 4
+
+
+@pytest.mark.parametrize(
+    ("reducer", "kwargs"),
+    [
+        (average, {}),
+        (generic_sum, {}),
+        (fraction_of_total, {"to_percent": False}),
+    ],
+)
+def test_compound_value_aggregate_materializes_stable_study(
+    monkeypatch: pytest.MonkeyPatch,
+    reducer,
+    kwargs: dict[str, object],
+) -> None:
+    tas = stub_tas(27.0, lat_length=2, lon_length=2).chunk(
+        {"time": 365, "lat": 1, "lon": 1}
+    )
+    threshold = build_threshold(
+        thresholds=["> 95 doy_per", "<= 10 doy_per"],
+        logical_link="or",
+        reference_period=("2042-01-01", "2043-12-31"),
+    )
+    climate_var = ClimateVariable(
+        name="tas",
+        standard_var=StandardVariableRegistry.TAS,
+        studied_data=tas,
+        threshold=threshold,
+        source_frequency=FrequencyRegistry.DAY,
+        global_metadata={},
+    )
+    materialize_calls = {"count": 0, "prefer_file_reopen": []}
+
+    original_materialize = bootstrap_primitives._materialize_bootstrap_study
+
+    def counted_materialize(study, *, prefer_file_reopen=False):
+        materialize_calls["count"] += 1
+        materialize_calls["prefer_file_reopen"].append(prefer_file_reopen)
+        return original_materialize(study, prefer_file_reopen=prefer_file_reopen)
+
+    monkeypatch.setenv("ICCLIM_BOOTSTRAP_FAST_TILE_CELLS", "1")
+    monkeypatch.setattr(
+        bootstrap_primitives,
+        "_materialize_bootstrap_study",
+        counted_materialize,
+    )
+
+    result = reducer(
+        climate_vars=[climate_var],
+        resample_freq=FrequencyRegistry.YEAR,
+        **kwargs,
+    )
+
+    assert result is not None
+    assert materialize_calls["count"] >= 1
+    assert True in materialize_calls["prefer_file_reopen"]

--- a/tests/test_real_data_validation_tools.py
+++ b/tests/test_real_data_validation_tools.py
@@ -1,0 +1,630 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+import xarray as xr
+
+from tools import (
+    profile_bootstrap_phases,
+    run_real_data_validation,
+    summarize_real_data_validation,
+)
+
+
+def test_run_real_data_validation_selected_chunks_switches_with_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("ICCLIM_REAL_DATA_CHUNK_PROFILE", raising=False)
+    assert (
+        run_real_data_validation._selected_chunks() == run_real_data_validation.CHUNKS
+    )
+
+    monkeypatch.setenv("ICCLIM_REAL_DATA_CHUNK_PROFILE", "alt")
+    assert (
+        run_real_data_validation._selected_chunks()
+        == run_real_data_validation.ALT_CHUNKS
+    )
+
+
+def test_resolve_import_root_supports_src_and_flat_layouts(tmp_path: Path) -> None:
+    src_repo = tmp_path / "src-repo"
+    (src_repo / "src" / "icclim").mkdir(parents=True)
+    (src_repo / "src" / "icclim" / "__init__.py").write_text("")
+    assert run_real_data_validation._resolve_import_root(src_repo) == src_repo / "src"
+    assert profile_bootstrap_phases._resolve_import_root(src_repo) == src_repo / "src"
+
+    flat_repo = tmp_path / "flat-repo"
+    (flat_repo / "icclim").mkdir(parents=True)
+    (flat_repo / "icclim" / "__init__.py").write_text("")
+    assert run_real_data_validation._resolve_import_root(flat_repo) == flat_repo
+    assert profile_bootstrap_phases._resolve_import_root(flat_repo) == flat_repo
+
+
+def test_resolve_import_root_raises_for_missing_package(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        run_real_data_validation._resolve_import_root(tmp_path)
+    with pytest.raises(FileNotFoundError):
+        profile_bootstrap_phases._resolve_import_root(tmp_path)
+
+
+def test_profile_timed_patch_if_present_records_calls() -> None:
+    class Dummy:
+        def ping(self):
+            return "pong"
+
+    stats: dict[str, dict[str, float]] = {}
+    dummy = Dummy()
+
+    with profile_bootstrap_phases._timed_patch_if_present(dummy, "ping", stats):
+        assert dummy.ping() == "pong"
+
+    assert stats["ping"]["calls"] == 1.0
+    assert stats["ping"]["seconds"] >= 0.0
+
+
+def test_profile_timed_patch_if_present_noops_when_missing() -> None:
+    class Dummy:
+        pass
+
+    stats: dict[str, dict[str, float]] = {}
+    dummy = Dummy()
+    with profile_bootstrap_phases._timed_patch_if_present(dummy, "missing", stats):
+        pass
+    assert stats == {}
+
+
+def test_profile_build_workload_rejects_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        profile_bootstrap_phases,
+        "_open_var",
+        lambda *args, **kwargs: None,
+    )
+    with pytest.raises(ValueError, match="Unsupported workload"):
+        profile_bootstrap_phases._build_workload(
+            object(),
+            "unknown_workload",
+            chunks=profile_bootstrap_phases.DEFAULT_CHUNKS,
+        )
+
+
+def test_run_real_data_validation_build_workload_rejects_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        run_real_data_validation,
+        "_open_var",
+        lambda *args, **kwargs: None,
+    )
+    with pytest.raises(ValueError, match="Unknown workload"):
+        run_real_data_validation._build_workload(object(), "unknown_workload")
+
+
+def test_summarize_parse_compare_file_supports_current_vs_master(
+    tmp_path: Path,
+) -> None:
+    compare_path = (
+        tmp_path / "current-vs-master-generic_tas_spell_bootstrap_yearly.compare.json"
+    )
+    compare_path.write_text(
+        json.dumps(
+            {
+                "data_var_comparison": {
+                    "sum_of_spell_lengths": {
+                        "equal": True,
+                        "changed_cells": 0,
+                        "max_abs_diff": 0.0,
+                    }
+                }
+            }
+        )
+    )
+
+    summary = summarize_real_data_validation._parse_compare_file(compare_path)
+
+    assert summary.current_label == "current"
+    assert summary.baseline_label == "master"
+    assert summary.workload == "generic_tas_spell_bootstrap_yearly"
+    assert summary.all_data_vars_equal is True
+    assert summary.total_changed_cells == 0
+    assert summary.max_abs_diff == 0.0
+
+
+def test_summarize_parse_compare_file_supports_master_vs_v717(tmp_path: Path) -> None:
+    compare_path = (
+        tmp_path / "master-vs-v717-generic_tas_spell_bootstrap_yearly.compare.json"
+    )
+    compare_path.write_text(
+        json.dumps(
+            {
+                "data_var_comparison": {
+                    "sum_of_spell_lengths": {
+                        "equal": False,
+                        "changed_cells": 1,
+                        "max_abs_diff": 1.0,
+                    }
+                }
+            }
+        )
+    )
+
+    summary = summarize_real_data_validation._parse_compare_file(compare_path)
+
+    assert summary.current_label == "master"
+    assert summary.baseline_label == "v717"
+    assert summary.workload == "generic_tas_spell_bootstrap_yearly"
+    assert summary.all_data_vars_equal is False
+    assert summary.total_changed_cells == 1
+    assert summary.max_abs_diff == 1.0
+
+
+def test_summarize_notes_cover_new_compound_workloads() -> None:
+    note = summarize_real_data_validation._workload_notes(
+        "generic_tas_compound_percentile_or_fraction_yearly"
+    )
+    assert "compound percentile OR" in note
+    assert "bootstrap leaf masks" in note
+
+
+class _FakeIcclim:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict]] = []
+
+    def build_threshold(self, *args, **kwargs):
+        return {"args": args, "kwargs": kwargs}
+
+    def index(self, **kwargs):
+        self.calls.append(("index", kwargs))
+        return {"method": "index", "kwargs": kwargs}
+
+    def indices(self, **kwargs):
+        self.calls.append(("indices", kwargs))
+        return {"method": "indices", "kwargs": kwargs}
+
+    def count_occurrences(self, **kwargs):
+        self.calls.append(("count_occurrences", kwargs))
+        return {"method": "count_occurrences", "kwargs": kwargs}
+
+    def average(self, **kwargs):
+        self.calls.append(("average", kwargs))
+        return {"method": "average", "kwargs": kwargs}
+
+    def sum(self, **kwargs):
+        self.calls.append(("sum", kwargs))
+        return {"method": "sum", "kwargs": kwargs}
+
+    def fraction_of_total(self, **kwargs):
+        self.calls.append(("fraction_of_total", kwargs))
+        return {"method": "fraction_of_total", "kwargs": kwargs}
+
+    def sum_of_spell_lengths(self, **kwargs):
+        self.calls.append(("sum_of_spell_lengths", kwargs))
+        return {"method": "sum_of_spell_lengths", "kwargs": kwargs}
+
+
+@pytest.mark.parametrize(
+    ("workload", "expected_method", "expected_key"),
+    [
+        ("tg_monthly", "index", "index_name"),
+        ("tg_djf_seasonal", "index", "slice_mode"),
+        ("rr1_yearly", "index", "var_name"),
+        ("su_tasmax_yearly", "index", "time_range"),
+        ("prcptot_yearly", "index", "slice_mode"),
+        ("generic_tas_count_date_event_monthly", "count_occurrences", "date_event"),
+        ("generic_tas_bounded_count_yearly", "count_occurrences", "threshold"),
+        ("generic_tas_bounded_average_yearly", "average", "threshold"),
+        ("generic_tas_bounded_sum_yearly", "sum", "threshold"),
+        ("generic_tas_bounded_fraction_yearly", "fraction_of_total", "threshold"),
+        ("generic_tas_bounded_or_count_yearly", "count_occurrences", "threshold"),
+        ("generic_tas_bounded_or_average_yearly", "average", "threshold"),
+        ("generic_tas_bounded_or_sum_yearly", "sum", "threshold"),
+        ("generic_tas_bounded_or_fraction_yearly", "fraction_of_total", "threshold"),
+        (
+            "generic_tas_compound_percentile_count_yearly",
+            "count_occurrences",
+            "threshold",
+        ),
+        ("generic_tas_compound_percentile_average_yearly", "average", "threshold"),
+        ("generic_tas_compound_percentile_sum_yearly", "sum", "threshold"),
+        (
+            "generic_tas_compound_percentile_fraction_yearly",
+            "fraction_of_total",
+            "threshold",
+        ),
+        (
+            "generic_tas_compound_percentile_or_count_yearly",
+            "count_occurrences",
+            "threshold",
+        ),
+        ("generic_tas_compound_percentile_or_average_yearly", "average", "threshold"),
+        ("generic_tas_compound_percentile_or_sum_yearly", "sum", "threshold"),
+        (
+            "generic_tas_compound_percentile_or_fraction_yearly",
+            "fraction_of_total",
+            "threshold",
+        ),
+        ("generic_pr_fraction_bootstrap_yearly", "fraction_of_total", "threshold"),
+        ("generic_pr_count_bootstrap_yearly", "count_occurrences", "threshold"),
+        ("generic_pr_sum_bootstrap_yearly", "sum", "threshold"),
+        ("generic_pr_average_bootstrap_yearly", "average", "threshold"),
+        ("generic_tas_fraction_bootstrap_yearly", "fraction_of_total", "threshold"),
+        ("generic_tas_sum_bootstrap_yearly", "sum", "threshold"),
+        ("generic_tas_average_bootstrap_yearly", "average", "threshold"),
+        (
+            "generic_tas_spell_bootstrap_yearly",
+            "sum_of_spell_lengths",
+            "min_spell_length",
+        ),
+        ("wsdi_yearly", "index", "index_name"),
+        ("csdi_yearly", "index", "index_name"),
+        ("tg90p_save_thresholds_monthly", "index", "save_thresholds"),
+        ("combined_cd_yearly", "index", "index_name"),
+        ("indices_mixed_yearly", "indices", "index_group"),
+        ("indices_mixed_with_cd_yearly", "indices", "index_group"),
+    ],
+)
+def test_run_real_data_validation_build_workload_routes_expected_call(
+    monkeypatch: pytest.MonkeyPatch,
+    workload: str,
+    expected_method: str,
+    expected_key: str,
+) -> None:
+    fake = _FakeIcclim()
+    monkeypatch.setattr(
+        run_real_data_validation,
+        "_open_var",
+        lambda *args, **kwargs: {"source": "var", "args": args, "kwargs": kwargs},
+    )
+    monkeypatch.setattr(
+        run_real_data_validation,
+        "_open_combined_dataset",
+        lambda *args, **kwargs: {"source": "combined", "kwargs": kwargs},
+    )
+
+    result = run_real_data_validation._build_workload(fake, workload)
+
+    assert result["method"] == expected_method
+    assert expected_key in result["kwargs"]
+
+
+def test_summarize_format_helpers_cover_pending_and_numeric_paths() -> None:
+    assert summarize_real_data_validation._format_seconds(None) == "pending"
+    assert summarize_real_data_validation._format_seconds(1.234) == "1.23"
+    assert summarize_real_data_validation._format_ratio(None, 1.0) == "pending"
+    assert summarize_real_data_validation._format_ratio(2.0, 4.0) == "2.00x"
+    assert summarize_real_data_validation._format_percent_change(None, 1.0) == "pending"
+    assert summarize_real_data_validation._format_percent_change(6.0, 4.0) == "+50.0%"
+
+
+def test_summarize_validation_and_history_notes_cover_main_branches() -> None:
+    exact = summarize_real_data_validation.ComparisonSummary(
+        current_label="current",
+        baseline_label="master",
+        workload="generic_tas_spell_bootstrap_yearly",
+        path=Path("dummy"),
+        all_data_vars_equal=True,
+        total_changed_cells=0,
+        max_abs_diff=0.0,
+    )
+    different = summarize_real_data_validation.ComparisonSummary(
+        current_label="current",
+        baseline_label="v717",
+        workload="generic_tas_spell_bootstrap_yearly",
+        path=Path("dummy"),
+        all_data_vars_equal=False,
+        total_changed_cells=1,
+        max_abs_diff=1.0,
+    )
+    master_v717 = summarize_real_data_validation.ComparisonSummary(
+        current_label="master",
+        baseline_label="v717",
+        workload="generic_tas_spell_bootstrap_yearly",
+        path=Path("dummy"),
+        all_data_vars_equal=False,
+        total_changed_cells=1,
+        max_abs_diff=1.0,
+    )
+
+    assert summarize_real_data_validation._format_validation_status(None) == (
+        "pending",
+        "pending",
+        "pending",
+    )
+    assert summarize_real_data_validation._format_validation_status(exact) == (
+        "exact",
+        "0",
+        "0.0",
+    )
+    assert summarize_real_data_validation._format_validation_status(different) == (
+        "differs",
+        "1",
+        "1",
+    )
+    assert (
+        summarize_real_data_validation._historical_validation_note(
+            "generic_tas_spell_bootstrap_yearly",
+            {
+                ("current", "master", "generic_tas_spell_bootstrap_yearly"): exact,
+                ("current", "v717", "generic_tas_spell_bootstrap_yearly"): different,
+                ("master", "v717", "generic_tas_spell_bootstrap_yearly"): master_v717,
+            },
+        )
+        == "historical master/v7.1.7 difference confirmed"
+    )
+
+
+def test_summarize_parse_summary_file_and_compare_filename_errors(
+    tmp_path: Path,
+) -> None:
+    summary_path = tmp_path / "current-wsdi_yearly.summary.json"
+    summary_path.write_text(
+        json.dumps(
+            {
+                "workload": "wsdi_yearly",
+                "label": "current",
+                "duration_seconds": 12.5,
+            }
+        )
+    )
+    summary = summarize_real_data_validation._parse_summary_file(summary_path)
+    assert summary.workload == "wsdi_yearly"
+    assert summary.label == "current"
+    assert summary.duration_seconds == 12.5
+    assert (
+        summarize_real_data_validation._remove_suffix(
+            "current.summary.json",
+            ".summary.json",
+        )
+        == "current"
+    )
+
+    unknown_compare = tmp_path / "unknown.compare.json"
+    unknown_compare.write_text(json.dumps({"data_var_comparison": {}}))
+    with pytest.raises(ValueError, match="Unsupported compare filename"):
+        summarize_real_data_validation._parse_compare_file(unknown_compare)
+
+
+def test_summarize_loaders_tables_and_main_cover_summary_paths(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    (tmp_path / "current-generic_tas_spell_bootstrap_yearly.summary.json").write_text(
+        json.dumps(
+            {
+                "workload": "generic_tas_spell_bootstrap_yearly",
+                "label": "current",
+                "duration_seconds": 80.0,
+            }
+        )
+    )
+    (
+        tmp_path / "baseline-master-generic_tas_spell_bootstrap_yearly.summary.json"
+    ).write_text(
+        json.dumps(
+            {
+                "workload": "generic_tas_spell_bootstrap_yearly",
+                "label": "baseline-master",
+                "duration_seconds": 100.0,
+            }
+        )
+    )
+    (
+        tmp_path / "baseline717-generic_tas_spell_bootstrap_yearly.summary.json"
+    ).write_text(
+        json.dumps(
+            {
+                "workload": "generic_tas_spell_bootstrap_yearly",
+                "label": "baseline717",
+                "duration_seconds": 110.0,
+            }
+        )
+    )
+    (
+        tmp_path / "current-vs-master-generic_tas_spell_bootstrap_yearly.compare.json"
+    ).write_text(
+        json.dumps(
+            {
+                "data_var_comparison": {
+                    "sum_of_spell_lengths": {
+                        "equal": True,
+                        "changed_cells": 0,
+                        "max_abs_diff": 0.0,
+                    }
+                }
+            }
+        )
+    )
+
+    runs = summarize_real_data_validation._load_run_summaries(tmp_path)
+    comparisons = summarize_real_data_validation._load_compare_summaries(tmp_path)
+    validation_table = summarize_real_data_validation._build_validation_table(
+        ["generic_tas_spell_bootstrap_yearly"],
+        comparisons,
+    )
+    performance_table = summarize_real_data_validation._build_performance_table(
+        ["generic_tas_spell_bootstrap_yearly"],
+        runs,
+    )
+    summary_document = summarize_real_data_validation._build_summary_document(
+        tmp_path,
+        ["generic_tas_spell_bootstrap_yearly"],
+    )
+
+    assert ("current", "generic_tas_spell_bootstrap_yearly") in runs
+    assert ("current", "master", "generic_tas_spell_bootstrap_yearly") in comparisons
+    assert "generic_tas_spell_bootstrap_yearly" in validation_table
+    assert "generic_tas_spell_bootstrap_yearly" in performance_table
+    assert "# Real-data bootstrap validation summary" in summary_document
+
+    out_path = tmp_path / "summary.md"
+    monkeypatch.setattr(
+        summarize_real_data_validation,
+        "_build_summary_document",
+        lambda result_dir, expected_workloads: "summary-body",
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "summarize_real_data_validation.py",
+            "--result-dir",
+            str(tmp_path),
+            "--out",
+            str(out_path),
+            "--expected-workload",
+            "wsdi_yearly",
+        ],
+    )
+    summarize_real_data_validation.main()
+    assert out_path.read_text() == "summary-body"
+
+
+@pytest.mark.parametrize(
+    ("workload", "expected_method"),
+    [
+        ("generic_tas_compound_percentile_or_count_yearly", "count_occurrences"),
+        ("generic_tas_compound_percentile_or_average_yearly", "average"),
+        ("generic_tas_compound_percentile_or_sum_yearly", "sum"),
+        ("generic_tas_compound_percentile_or_fraction_yearly", "fraction_of_total"),
+        ("generic_tas_spell_bootstrap_yearly", "sum_of_spell_lengths"),
+        ("wsdi_yearly", "index"),
+        ("csdi_yearly", "index"),
+    ],
+)
+def test_profile_build_workload_routes_expected_call(
+    monkeypatch: pytest.MonkeyPatch,
+    workload: str,
+    expected_method: str,
+) -> None:
+    fake = _FakeIcclim()
+    monkeypatch.setattr(
+        profile_bootstrap_phases,
+        "_open_var",
+        lambda *args, **kwargs: {"source": "var", "kwargs": kwargs},
+    )
+
+    result = profile_bootstrap_phases._build_workload(
+        fake,
+        workload,
+        chunks=profile_bootstrap_phases.DEFAULT_CHUNKS,
+    )
+
+    assert result["method"] == expected_method
+
+
+def test_run_real_data_validation_main_writes_summary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_icclim = ModuleType("icclim")
+    fake_icclim.__version__ = "9.9.9"
+    result_ds = xr.Dataset({"foo": xr.DataArray([1, 2], dims=["time"])})
+
+    monkeypatch.setitem(sys.modules, "icclim", fake_icclim)
+    monkeypatch.setattr(
+        run_real_data_validation,
+        "_resolve_import_root",
+        lambda repo: repo,
+    )
+    monkeypatch.setattr(run_real_data_validation, "_warmup", lambda icclim: None)
+    monkeypatch.setattr(
+        run_real_data_validation,
+        "_build_workload",
+        lambda icclim, workload: result_ds,
+    )
+    monkeypatch.setattr(
+        run_real_data_validation,
+        "_git_rev_parse",
+        lambda repo, ref: "deadbeef",
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "run_real_data_validation.py",
+            "--repo",
+            str(tmp_path),
+            "--workload",
+            "wsdi_yearly",
+            "--label",
+            "current",
+            "--out-dir",
+            str(tmp_path),
+        ],
+    )
+
+    run_real_data_validation.main()
+
+    payload = json.loads((tmp_path / "current-wsdi_yearly.summary.json").read_text())
+    assert payload["label"] == "current"
+    assert payload["workload"] == "wsdi_yearly"
+    assert payload["head_commit"] == "deadbeef"
+
+
+def test_profile_main_writes_profile_json(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_icclim = ModuleType("icclim")
+    fake_core = ModuleType("icclim._core")
+    fake_generic = ModuleType("icclim._core.generic")
+    fake_bootstrap = ModuleType("icclim._core.generic.bootstrap")
+    fake_primitives = ModuleType("icclim._core.generic.bootstrap_primitives")
+    fake_functions = ModuleType("icclim._core.generic.functions")
+    result_ds = xr.Dataset({"foo": xr.DataArray([1, 2], dims=["time"])})
+
+    fake_bootstrap.build_bootstrap_temporal_indexing = lambda *args, **kwargs: None
+    fake_bootstrap.build_bootstrap_array_inputs = lambda *args, **kwargs: None
+    fake_primitives.build_bootstrap_reference_sample = lambda *args, **kwargs: None
+    fake_primitives.build_bootstrap_prepared_inputs = lambda *args, **kwargs: None
+    fake_functions.reset_bootstrap_profile = lambda: None
+    fake_functions.get_bootstrap_profile = lambda: {"bootstrap_family": "test"}
+    monkeypatch.setitem(sys.modules, "icclim", fake_icclim)
+    monkeypatch.setitem(sys.modules, "icclim._core", fake_core)
+    monkeypatch.setitem(sys.modules, "icclim._core.generic", fake_generic)
+    monkeypatch.setitem(sys.modules, "icclim._core.generic.bootstrap", fake_bootstrap)
+    monkeypatch.setitem(
+        sys.modules,
+        "icclim._core.generic.bootstrap_primitives",
+        fake_primitives,
+    )
+    monkeypatch.setitem(sys.modules, "icclim._core.generic.functions", fake_functions)
+    monkeypatch.setattr(
+        profile_bootstrap_phases,
+        "_resolve_import_root",
+        lambda repo: repo,
+    )
+    monkeypatch.setattr(profile_bootstrap_phases, "_warmup", lambda icclim: None)
+    monkeypatch.setattr(
+        profile_bootstrap_phases,
+        "_build_workload",
+        lambda icclim, workload, *, chunks: result_ds,
+    )
+    out_path = tmp_path / "profile.json"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "profile_bootstrap_phases.py",
+            "--repo",
+            str(tmp_path),
+            "--workload",
+            "wsdi_yearly",
+            "--chunk-profile",
+            "default",
+            "--out",
+            str(out_path),
+        ],
+    )
+
+    profile_bootstrap_phases.main()
+
+    payload = json.loads(out_path.read_text())
+    assert payload["workload"] == "wsdi_yearly"
+    assert payload["chunk_profile"] == "default"
+    assert payload["bootstrap_profile"] == {"bootstrap_family": "test"}

--- a/tests/test_tool_helpers.py
+++ b/tests/test_tool_helpers.py
@@ -1,0 +1,301 @@
+from __future__ import annotations
+
+import inspect
+import json
+from types import ModuleType, SimpleNamespace
+
+import pytest
+import xarray as xr
+
+from icclim._core.constants import NEEDS_NORMAL, QUANTILE_BASED, REFERENCE_PERIOD_INDEX
+from tools import compare_real_data_validation as compare_tools
+from tools import debug_real_data_validation as debug_tools
+from tools import extract_icclim_funs as extract_tools
+from tools import update_logo_version as logo_tools
+
+
+def test_compare_variable_handles_numeric_and_non_numeric() -> None:
+    left = xr.DataArray([1.0, 2.0, float("nan")])
+    right = xr.DataArray([1.0, 3.0, float("nan")])
+    numeric = compare_tools._compare_variable(left, right)
+    assert numeric["equal"] is False
+    assert numeric["changed_cells"] == 1
+    assert numeric["max_abs_diff"] == 1.0
+
+    non_numeric_left = xr.DataArray(["a", "b"])
+    non_numeric_right = xr.DataArray(["a", "b"])
+    non_numeric = compare_tools._compare_variable(non_numeric_left, non_numeric_right)
+    assert non_numeric == {"equal": True, "changed_cells": 0}
+
+
+def test_compare_variable_reports_shape_or_dim_mismatch() -> None:
+    dims_mismatch = compare_tools._compare_variable(
+        xr.DataArray([1, 2], dims=("time",)),
+        xr.DataArray([1, 2], dims=("lat",)),
+    )
+    assert dims_mismatch["equal"] is False
+    assert "dims differ" in dims_mismatch["reason"]
+
+    shape_mismatch = compare_tools._compare_variable(
+        xr.DataArray([1, 2]),
+        xr.DataArray([1, 2, 3]),
+    )
+    assert shape_mismatch["equal"] is False
+    assert "shape differ" in shape_mismatch["reason"]
+
+
+def test_compare_datasets_collects_shared_vars_and_attrs(tmp_path: Path) -> None:
+    current = xr.Dataset(
+        data_vars={"tas": (("time",), [1.0, 2.0])},
+        coords={"time": [0, 1], "lat": 42.0},
+        attrs={"history": "new", "title": "same"},
+    )
+    baseline = xr.Dataset(
+        data_vars={"tas": (("time",), [1.0, 2.0])},
+        coords={"time": [0, 1], "lat": 42.0},
+        attrs={"history": "old", "title": "same"},
+    )
+    current_path = tmp_path / "current.nc"
+    baseline_path = tmp_path / "baseline.nc"
+    current.to_netcdf(current_path)
+    baseline.to_netcdf(baseline_path)
+
+    result = compare_tools._compare_datasets(current_path, baseline_path)
+    assert result["data_var_comparison"]["tas"]["equal"] is True
+    assert result["coord_comparison"]["lat"]["equal"] is True
+    assert result["dataset_attrs"]["history_equal"] is False
+    assert result["dataset_attrs"]["non_history_equal"]["title"] is True
+
+
+def test_compare_main_writes_json(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    current = tmp_path / "current.nc"
+    baseline = tmp_path / "baseline.nc"
+    out = tmp_path / "summary.json"
+    xr.Dataset({"tas": (("time",), [1.0])}).to_netcdf(current)
+    xr.Dataset({"tas": (("time",), [1.0])}).to_netcdf(baseline)
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "compare_real_data_validation.py",
+            "--current",
+            str(current),
+            "--baseline",
+            str(baseline),
+            "--out",
+            str(out),
+        ],
+    )
+
+    compare_tools.main()
+
+    written = json.loads(out.read_text())
+    assert written["data_var_comparison"]["tas"]["equal"] is True
+    assert '"data_var_comparison"' in capsys.readouterr().out
+
+
+def test_debug_load_validation_module_errors_when_loader_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        debug_tools.importlib.util,
+        "spec_from_file_location",
+        lambda *args, **kwargs: None,
+    )
+    with pytest.raises(RuntimeError, match="Cannot load validation module"):
+        debug_tools._load_validation_module()
+
+
+def test_debug_main_completed_payload(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    fake_icclim = ModuleType("icclim")
+    monkeypatch.setitem(__import__("sys").modules, "icclim", fake_icclim)
+    fake_validation = SimpleNamespace(
+        _warmup=lambda _icclim: None,
+        _build_workload=lambda _icclim, _workload: xr.Dataset(
+            {"tas": (("time",), [1.0, 2.0])}, coords={"time": [0, 1]}
+        ),
+    )
+    monkeypatch.setattr(debug_tools, "_load_validation_module", lambda: fake_validation)
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "debug_real_data_validation.py",
+            "--repo",
+            str(tmp_path),
+            "--workload",
+            "demo",
+        ],
+    )
+
+    debug_tools.main()
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "completed"
+    assert payload["data_vars"] == ["tas"]
+    assert payload["sizes"]["time"] == 2
+
+
+def test_debug_main_failed_payload(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    fake_icclim = ModuleType("icclim")
+    monkeypatch.setitem(__import__("sys").modules, "icclim", fake_icclim)
+    fake_validation = SimpleNamespace(
+        _warmup=lambda _icclim: None,
+        _build_workload=lambda _icclim, _workload: (_ for _ in ()).throw(
+            ValueError("boom")
+        ),
+    )
+    monkeypatch.setattr(debug_tools, "_load_validation_module", lambda: fake_validation)
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "debug_real_data_validation.py",
+            "--repo",
+            str(tmp_path),
+            "--workload",
+            "demo",
+        ],
+    )
+
+    debug_tools.main()
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "failed"
+    assert payload["error_type"] == "ValueError"
+    assert "boom" in payload["error_message"]
+
+
+def test_logo_run_replaces_version_placeholder(tmp_path: Path) -> None:
+    source = tmp_path / "logo.svg"
+    dest = tmp_path / "out.svg"
+    source.write_text("hello {{icclim.__version__}} world\n")
+
+    logo_tools._run(source, dest)
+
+    assert "{{icclim.__version__}}" not in dest.read_text()
+
+
+def test_extract_helper_flags_and_arguments() -> None:
+    index = SimpleNamespace(
+        qualifiers=[NEEDS_NORMAL, QUANTILE_BASED, REFERENCE_PERIOD_INDEX]
+    )
+    assert extract_tools._is_compared_to_normal(index) is True
+    assert extract_tools._is_quantile_based(index) is True
+    assert extract_tools._can_have_reference_period(index) is True
+
+    args = extract_tools._get_arguments(["threshold", "user_index"])
+    assert "threshold" not in args
+    assert "user_index" not in args
+    assert "index_name" in args
+
+
+def test_extract_threshold_and_output_helpers() -> None:
+    index = SimpleNamespace(
+        output_unit="degC",
+        threshold=[
+            "> 10 degree_Celsius",
+            {"query": "> 90 doy_per", "threshold_min_value": "1 mm/day"},
+        ],
+    )
+    assert extract_tools._get_output_unit_argument(index) == 'out_unit="degC"'
+    threshold_arg = extract_tools._get_threshold_argument(index)
+    assert "build_threshold" in threshold_arg
+    assert "threshold_min_value" in threshold_arg
+
+
+def test_extract_parameter_declaration_and_signature_building() -> None:
+    params = {
+        "required": inspect.Parameter(
+            "required",
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            annotation=str,
+        ),
+        "optional": inspect.Parameter(
+            "optional",
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            annotation="Literal[start, end]",
+            default="yes",
+        ),
+    }
+    signature_args = extract_tools._build_fun_signature_args(params)
+    assert "required: str" in signature_args
+    assert "optional: Literal['start', 'end'] = \"yes\"" in signature_args
+
+
+def test_extract_doc_and_threshold_format_helpers(tmp_path: Path) -> None:
+    doc = extract_tools._get_params_docstring(
+        ["threshold"],
+        """
+        Summary.
+
+        Parameters
+        ----------
+        threshold : str
+            Threshold description.
+        ignored : str
+            Ignored.
+        """,
+    )
+    assert "threshold" in doc
+    assert "ignored" not in doc
+
+    formatted = extract_tools._format_thresh(
+        {"query": "> 90 doy_per", "threshold_min_value": "1 mm/day"}
+    )
+    assert "build_threshold" in formatted
+    assert 'threshold_min_value="1 mm/day"' in formatted
+
+    doc_path = tmp_path / "index.rst"
+    doc_path.write_text(
+        "before\n.. Generated API comment:Begin\nold\n.. Generated API comment:End\nafter\n"
+    )
+    extract_tools._generate_doc(doc_path, "\n    replacement\n")
+    assert "replacement" in doc_path.read_text()
+
+
+def test_extract_header_and_all_helpers() -> None:
+    header = extract_tools._build_module_header("generic")
+    assert "auto-generated" in header
+    assert "build_threshold" in header
+
+    all_block = extract_tools._build__all__(["TG", "SU"])
+    assert '"tg"' in all_block
+    assert '"su"' in all_block
+
+
+def test_extract_main_routes_to_generators(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    calls: list[tuple[str, Path]] = []
+
+    monkeypatch.setattr(
+        extract_tools, "_generate_ecad_api", lambda path: calls.append(("ecad", path))
+    )
+    monkeypatch.setattr(
+        extract_tools, "_generate_dcsc_api", lambda path: calls.append(("dcsc", path))
+    )
+    monkeypatch.setattr(
+        extract_tools,
+        "_generate_generic_api",
+        lambda path: calls.append(("generic", path)),
+    )
+    monkeypatch.setattr(
+        extract_tools,
+        "_generate_doc",
+        lambda path, content: calls.append((content.strip(), path)),
+    )
+    monkeypatch.setattr(extract_tools, "_get_ecad_doc", lambda: "ecad_doc")
+    monkeypatch.setattr(extract_tools, "_get_dcsc_doc", lambda: "dcsc_doc")
+    monkeypatch.setattr(extract_tools, "_get_generic_doc", lambda: "generic_doc")
+    monkeypatch.setattr("sys.argv", ["extract_icclim_funs.py", str(tmp_path)])
+
+    extract_tools.main()
+
+    assert ("ecad", tmp_path / "_ecad.py") in calls
+    assert ("dcsc", tmp_path / "_dcsc.py") in calls
+    assert ("generic", tmp_path / "_generic.py") in calls
+    assert ("ecad_doc", extract_tools.PATH_TO_ECAD_DOC_FILE) in calls

--- a/tools/profile_bootstrap_phases.py
+++ b/tools/profile_bootstrap_phases.py
@@ -186,7 +186,16 @@ def main() -> None:
     started = time.perf_counter()
     with (
         _timed_patch(primitives_module, "_normalize_bootstrap_chunks", phase_stats),
-        _timed_patch(bootstrap_module, "build_bootstrap_reference_sample", phase_stats),
+        _timed_patch(
+            primitives_module,
+            "build_bootstrap_reference_sample",
+            phase_stats,
+        ),
+        _timed_patch(
+            primitives_module,
+            "build_bootstrap_prepared_inputs",
+            phase_stats,
+        ),
         _timed_patch(
             bootstrap_module, "build_bootstrap_temporal_indexing", phase_stats
         ),

--- a/tools/profile_bootstrap_phases.py
+++ b/tools/profile_bootstrap_phases.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import xarray as xr
+
+TAS_GLOB = "/scratch/globc/page/models/tas_day_ACCESS-CM2_historical_*.nc"
+LAT_SLICE = slice(35.0, 70.0)
+LON_SLICE = slice(0.0, 40.0)
+BASE_PERIOD = ("1961-01-01", "1990-12-31")
+TIME_RANGE = ("1950-01-01", "2014-12-31")
+DEFAULT_CHUNKS = {"time": 365, "lat": 24, "lon": 32}
+ALT_CHUNKS = {"time": 730, "lat": 7, "lon": 9}
+
+
+def _open_var(
+    file_glob: str,
+    var_name: str,
+    *,
+    chunks: dict[str, int],
+) -> xr.DataArray:
+    import glob
+
+    files = sorted(glob.glob(file_glob))
+    if not files:
+        raise FileNotFoundError(file_glob)
+    ds = xr.open_mfdataset(files, combine="by_coords", chunks=chunks)
+    return ds[var_name].sel(lat=LAT_SLICE, lon=LON_SLICE)
+
+
+def _build_workload(icclim, workload: str, *, chunks: dict[str, int]) -> xr.Dataset:
+    tas = _open_var(TAS_GLOB, "tas", chunks=chunks)
+    if workload == "generic_tas_compound_percentile_or_fraction_yearly":
+        return icclim.fraction_of_total(
+            in_files=tas,
+            var_name="tas",
+            threshold=icclim.build_threshold(
+                thresholds=["> 95 doy_per", "<= 10 doy_per"],
+                logical_link="or",
+                reference_period=BASE_PERIOD,
+            ),
+            time_range=TIME_RANGE,
+            slice_mode="year",
+        )
+    if workload == "generic_tas_spell_bootstrap_yearly":
+        return icclim.sum_of_spell_lengths(
+            in_files=tas,
+            var_name="tas",
+            threshold=icclim.build_threshold(
+                "> 90 doy_per",
+                reference_period=BASE_PERIOD,
+            ),
+            time_range=TIME_RANGE,
+            slice_mode="year",
+            min_spell_length=6,
+        )
+    if workload == "wsdi_yearly":
+        return icclim.index(
+            index_name="WSDI",
+            in_files=tas,
+            var_name="tas",
+            base_period_time_range=BASE_PERIOD,
+            time_range=TIME_RANGE,
+            slice_mode="year",
+        )
+    if workload == "csdi_yearly":
+        return icclim.index(
+            index_name="CSDI",
+            in_files=tas,
+            var_name="tas",
+            base_period_time_range=BASE_PERIOD,
+            time_range=TIME_RANGE,
+            slice_mode="year",
+        )
+    msg = f"Unsupported workload: {workload}"
+    raise ValueError(msg)
+
+
+def _warmup(icclim) -> None:
+    time_coord = xr.date_range("2000-01-01", periods=365 * 4 + 1, freq="D")
+    tas = xr.DataArray(
+        np.full((len(time_coord), 1, 1), 300.0, dtype=np.float32),
+        dims=["time", "lat", "lon"],
+        coords={"time": time_coord, "lat": [0], "lon": [0]},
+        attrs={"units": "K"},
+        name="tas",
+    ).chunk({"time": 365, "lat": 1, "lon": 1})
+    try:
+        icclim.index(
+            index_name="TG",
+            in_files=tas,
+            var_name="tas",
+            slice_mode="month",
+        ).load()
+    except Exception:
+        pass
+
+
+@contextmanager
+def _timed_patch(module: Any, attr: str, stats: dict[str, dict[str, float]]):
+    original = getattr(module, attr)
+
+    def wrapped(*args, **kwargs):
+        start = time.perf_counter()
+        result = original(*args, **kwargs)
+        elapsed = time.perf_counter() - start
+        phase_stats = stats.setdefault(attr, {"seconds": 0.0, "calls": 0.0})
+        phase_stats["seconds"] += elapsed
+        phase_stats["calls"] += 1.0
+        return result
+
+    setattr(module, attr, wrapped)
+    try:
+        yield
+    finally:
+        setattr(module, attr, original)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--workload", required=True)
+    parser.add_argument("--chunk-profile", choices=("default", "alt"), required=True)
+    parser.add_argument("--out", required=True)
+    args = parser.parse_args()
+
+    repo = Path(args.repo).resolve()
+    sys.path.insert(0, str(repo / "src"))
+
+    import icclim
+    import icclim._core.generic.bootstrap as bootstrap_module
+    import icclim._core.generic.bootstrap_primitives as primitives_module
+    from icclim._core.generic.functions import (
+        get_bootstrap_profile,
+        reset_bootstrap_profile,
+    )
+
+    chunk_profile = DEFAULT_CHUNKS if args.chunk_profile == "default" else ALT_CHUNKS
+    phase_stats: dict[str, dict[str, float]] = {}
+    reset_bootstrap_profile()
+    _warmup(icclim)
+
+    started = time.perf_counter()
+    with (
+        _timed_patch(primitives_module, "_normalize_bootstrap_chunks", phase_stats),
+        _timed_patch(bootstrap_module, "build_bootstrap_reference_sample", phase_stats),
+        _timed_patch(
+            bootstrap_module, "build_bootstrap_temporal_indexing", phase_stats
+        ),
+        _timed_patch(bootstrap_module, "build_bootstrap_array_inputs", phase_stats),
+    ):
+        ds = _build_workload(icclim, args.workload, chunks=chunk_profile).load()
+    elapsed = time.perf_counter() - started
+
+    payload = {
+        "workload": args.workload,
+        "chunk_profile": args.chunk_profile,
+        "duration_seconds": elapsed,
+        "data_vars": list(ds.data_vars),
+        "phase_stats": phase_stats,
+        "bootstrap_profile": get_bootstrap_profile(),
+    }
+    out_path = Path(args.out)
+    out_path.write_text(json.dumps(payload, indent=2, sort_keys=True))
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/profile_bootstrap_phases.py
+++ b/tools/profile_bootstrap_phases.py
@@ -37,6 +37,42 @@ def _open_var(
 
 def _build_workload(icclim, workload: str, *, chunks: dict[str, int]) -> xr.Dataset:
     tas = _open_var(TAS_GLOB, "tas", chunks=chunks)
+    if workload == "generic_tas_compound_percentile_or_count_yearly":
+        return icclim.count_occurrences(
+            in_files=tas,
+            var_name="tas",
+            threshold=icclim.build_threshold(
+                thresholds=["> 95 doy_per", "<= 10 doy_per"],
+                logical_link="or",
+                reference_period=BASE_PERIOD,
+            ),
+            time_range=TIME_RANGE,
+            slice_mode="year",
+        )
+    if workload == "generic_tas_compound_percentile_or_average_yearly":
+        return icclim.average(
+            in_files=tas,
+            var_name="tas",
+            threshold=icclim.build_threshold(
+                thresholds=["> 95 doy_per", "<= 10 doy_per"],
+                logical_link="or",
+                reference_period=BASE_PERIOD,
+            ),
+            time_range=TIME_RANGE,
+            slice_mode="year",
+        )
+    if workload == "generic_tas_compound_percentile_or_sum_yearly":
+        return icclim.sum(
+            in_files=tas,
+            var_name="tas",
+            threshold=icclim.build_threshold(
+                thresholds=["> 95 doy_per", "<= 10 doy_per"],
+                logical_link="or",
+                reference_period=BASE_PERIOD,
+            ),
+            time_range=TIME_RANGE,
+            slice_mode="year",
+        )
     if workload == "generic_tas_compound_percentile_or_fraction_yearly":
         return icclim.fraction_of_total(
             in_files=tas,

--- a/tools/profile_bootstrap_phases.py
+++ b/tools/profile_bootstrap_phases.py
@@ -159,6 +159,19 @@ def _timed_patch(module: Any, attr: str, stats: dict[str, dict[str, float]]):
         setattr(module, attr, original)
 
 
+@contextmanager
+def _timed_patch_if_present(
+    module: Any,
+    attr: str,
+    stats: dict[str, dict[str, float]],
+):
+    if not hasattr(module, attr):
+        yield
+        return
+    with _timed_patch(module, attr, stats):
+        yield
+
+
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--repo", required=True)
@@ -185,7 +198,11 @@ def main() -> None:
 
     started = time.perf_counter()
     with (
-        _timed_patch(primitives_module, "_normalize_bootstrap_chunks", phase_stats),
+        _timed_patch_if_present(
+            primitives_module,
+            "_normalize_bootstrap_chunks",
+            phase_stats,
+        ),
         _timed_patch(
             primitives_module,
             "build_bootstrap_reference_sample",

--- a/tools/profile_bootstrap_phases.py
+++ b/tools/profile_bootstrap_phases.py
@@ -20,6 +20,14 @@ DEFAULT_CHUNKS = {"time": 365, "lat": 24, "lon": 32}
 ALT_CHUNKS = {"time": 730, "lat": 7, "lon": 9}
 
 
+def _resolve_import_root(repo: Path) -> Path:
+    for candidate in (repo / "src", repo / "icclim", repo):
+        if (candidate / "icclim" / "__init__.py").is_file():
+            return candidate
+    msg = f"Could not locate icclim package import root under {repo}"
+    raise FileNotFoundError(msg)
+
+
 def _open_var(
     file_glob: str,
     var_name: str,
@@ -181,7 +189,7 @@ def main() -> None:
     args = parser.parse_args()
 
     repo = Path(args.repo).resolve()
-    sys.path.insert(0, str(repo / "src"))
+    sys.path.insert(0, str(_resolve_import_root(repo)))
 
     import icclim
     import icclim._core.generic.bootstrap as bootstrap_module

--- a/tools/run_real_data_validation.py
+++ b/tools/run_real_data_validation.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import glob
 import json
+import os
 import subprocess
 import sys
 import time
@@ -23,6 +24,22 @@ TIME_RANGE = ("1950-01-01", "2014-12-31")
 TASMAX_TIME_RANGE = ("1986-01-01", "1999-12-31")
 DATE_EVENT_TIME_RANGE = ("1980-01-01", "2014-12-31")
 CHUNKS = {"time": 365, "lat": 24, "lon": 32}
+ALT_CHUNKS = {"time": 730, "lat": 7, "lon": 9}
+
+
+def _selected_chunks() -> dict[str, int]:
+    profile = os.environ.get("ICCLIM_REAL_DATA_CHUNK_PROFILE", "default")
+    if profile == "alt":
+        return ALT_CHUNKS
+    return CHUNKS
+
+
+def _resolve_import_root(repo: Path) -> Path:
+    for candidate in (repo / "src", repo / "icclim", repo):
+        if (candidate / "icclim" / "__init__.py").is_file():
+            return candidate
+    msg = f"Could not locate icclim package import root under {repo}"
+    raise FileNotFoundError(msg)
 
 
 def _git_rev_parse(repo: Path, ref: str) -> str | None:
@@ -45,7 +62,7 @@ def _open_var(
     files = sorted(glob.glob(file_glob))
     if not files:
         raise FileNotFoundError(file_glob)
-    ds = xr.open_mfdataset(files, combine="by_coords", chunks=CHUNKS)
+    ds = xr.open_mfdataset(files, combine="by_coords", chunks=_selected_chunks())
     return ds[var_name].sel(lat=lat_slice, lon=lon_slice)
 
 
@@ -311,6 +328,32 @@ def _build_workload(icclim, workload: str) -> xr.Dataset:
             time_range=TIME_RANGE,
             slice_mode="year",
         )
+    if workload == "generic_tas_compound_percentile_or_average_yearly":
+        tas = _open_var(TAS_GLOB, "tas")
+        return icclim.average(
+            in_files=tas,
+            var_name="tas",
+            threshold=icclim.build_threshold(
+                thresholds=["> 95 doy_per", "<= 10 doy_per"],
+                logical_link="or",
+                reference_period=BASE_PERIOD,
+            ),
+            time_range=TIME_RANGE,
+            slice_mode="year",
+        )
+    if workload == "generic_tas_compound_percentile_or_sum_yearly":
+        tas = _open_var(TAS_GLOB, "tas")
+        return icclim.sum(
+            in_files=tas,
+            var_name="tas",
+            threshold=icclim.build_threshold(
+                thresholds=["> 95 doy_per", "<= 10 doy_per"],
+                logical_link="or",
+                reference_period=BASE_PERIOD,
+            ),
+            time_range=TIME_RANGE,
+            slice_mode="year",
+        )
     if workload == "generic_tas_compound_percentile_or_fraction_yearly":
         tas = _open_var(TAS_GLOB, "tas")
         return icclim.fraction_of_total(
@@ -435,6 +478,16 @@ def _build_workload(icclim, workload: str) -> xr.Dataset:
             time_range=TIME_RANGE,
             slice_mode="year",
         )
+    if workload == "csdi_yearly":
+        tas = _open_var(TAS_GLOB, "tas")
+        return icclim.index(
+            index_name="CSDI",
+            in_files=tas,
+            var_name="tas",
+            base_period_time_range=BASE_PERIOD,
+            time_range=TIME_RANGE,
+            slice_mode="year",
+        )
     if workload == "tg90p_save_thresholds_monthly":
         tas = _open_var(TAS_GLOB, "tas")
         return icclim.index(
@@ -511,7 +564,7 @@ def main() -> None:
     args = parser.parse_args()
 
     repo = Path(args.repo).resolve()
-    sys.path.insert(0, str(repo / "src"))
+    sys.path.insert(0, str(_resolve_import_root(repo)))
     import icclim
 
     out_dir = Path(args.out_dir)


### PR DESCRIPTION
## Summary
- stabilize optimized bootstrap study materialization for validated chunk-sensitive paths
- keep the spell family on the exact materialization path while preserving compound leaf reuse
- extend the real-data validation runner to select explicit chunk profiles and document the validated chunk-robustness boundary

## Local validation
- `pytest -q tests/test_generic_functions.py tests/test_bootstrap_primitives.py tests/test_main.py -k 'compound_percentile_or or fraction_of_total or average or sum or wsdi or csdi or spell'`
  - `33 passed`
- `pre-commit run --files src/icclim/_core/generic/bootstrap_primitives.py src/icclim/_core/generic/functions.py tests/test_generic_functions.py tests/test_bootstrap_primitives.py tools/run_real_data_validation.py tools/profile_bootstrap_phases.py doc/source/dev/bootstrap_architecture.rst`
  - passed

## Kraken validation
Trusted baseline exactness on Monday, August 3, 2026:
- `generic_tas_spell_bootstrap_yearly`: exact vs fresh `master`
- `wsdi_yearly`: exact vs fresh `master`
- `csdi_yearly`: exact vs fresh `master`

Chunk-profile exactness on Monday, August 3, 2026:
- `generic_tas_compound_percentile_or_count_yearly`: exact current vs alt
- `generic_tas_compound_percentile_or_average_yearly`: exact current vs alt
- `generic_tas_compound_percentile_or_sum_yearly`: exact current vs alt
- `generic_tas_compound_percentile_or_fraction_yearly`: exact current vs alt
- `generic_tas_spell_bootstrap_yearly`: exact current vs alt
- `wsdi_yearly`: exact current vs alt
- `csdi_yearly`: exact current vs alt

## Chunk-performance result
Compound percentile `OR` value aggregates are now effectively chunk-neutral on the validated real-data subset:
- `average`
  - default `117.72s`
  - alt `117.30s`
- `sum`
  - default `116.93s`
  - alt `117.17s`
- `fraction_of_total`
  - default `119.40s`
  - alt `118.64s`

Spell-family timings with the narrowed materialization path remain strong:
- `generic_tas_spell_bootstrap_yearly`
  - current `84.21s`
  - fresh `master` `109.85s`
- `wsdi_yearly`
  - current `84.42s`
  - fresh `master` `105.96s`
- `csdi_yearly`
  - current `84.39s`
  - fresh `master` `105.91s`
