### PR TITLE
Integrate exact cftime bootstrap count redesign

### DIFF
--- a/doc/source/archive/bootstrap-next-phase-closeout-2026-08-18.md
+++ b/doc/source/archive/bootstrap-next-phase-closeout-2026-08-18.md
@@ -1,0 +1,131 @@
+# Bootstrap Next Phase Closeout (2026-08-18)
+
+Branch: `feature/bootstrap-next-phase`
+
+## Scope closed in this phase
+
+- Close out `cftime` bootstrap validation for the exact tiled path.
+- Close out filtered-average bootstrap routing and tuning.
+- Continue optimization only where real-data profiling still showed worthwhile gains.
+
+## Kept changes
+
+- Keep exact `cftime` routing for day-of-year percentile count workloads.
+- Keep filtered `average` on the exact tiled bootstrap path.
+- Keep `ICCLIM_BOOTSTRAP_MODE=default` forcing the reference path for filtered-average baseline comparison.
+- Keep reopen-aware prepared-input materialization for optimized spell workloads.
+- Keep stabilized-study reuse for optimized compound value-aggregate workloads.
+
+## Real-data validation completed
+
+Kraken real-data validation and profiling were run on Monday, August 17, 2026.
+
+### `cftime` validation
+
+- Workload: `tx90p_cftime_monthly`
+- Master result duration: about `703.94s`
+- Current result duration: about `2726.32s`
+- Current vs master compare:
+  - `changed_cells = 10`
+  - `max_abs_diff = 1.0`
+- Current vs old August 16 rerun compare:
+  - `changed_cells = 1`
+- Focused cell diagnosis at `lat=51.875`, `lon=30.9375`, `time=1952-12-16`:
+  - current exact path: `2.0`
+  - forced old optimized path: `3.0`
+
+Conclusion:
+
+- The lone extra mismatch in current local state is the expected consequence of keeping `cftime` on the exact path instead of the old optimized/internal-daily path.
+- The remaining `cftime` exact-path cost is still dominated by the exact tiled count computation itself.
+
+### Filtered-average validation
+
+- `generic_pr_average_bootstrap_yearly` stayed on the exact tiled path.
+- Tile tuning was exhausted in this phase.
+- Alternative chunking was worse than the default setup on Kraken.
+
+Conclusion:
+
+- No further worthwhile filtered-average tuning was found without changing the exact algorithm.
+
+## Measured wins kept from the follow-up optimization phase
+
+All timings below were measured on Kraken on Monday, August 17, 2026.
+
+### Spell-family workloads
+
+- `generic_tas_spell_bootstrap_yearly`: `72.10s -> 59.27s`
+- `wsdi_yearly`: `58.40s -> 47.64s`
+- `csdi_yearly`: `48.24s -> 45.73s`
+
+### Compound value-aggregate workloads
+
+- `generic_tas_compound_percentile_or_average_yearly`: `89.66s -> 65.33s`
+- `generic_tas_compound_percentile_or_sum_yearly`: `66.82s`
+- `generic_tas_compound_percentile_or_fraction_yearly`: `66.80s`
+
+## Exact `cftime` deep profile
+
+Kraken deep profile for `tx90p_cftime_yearly` on Tuesday, August 18, 2026:
+
+- duration: `3996.70s`
+- exact tiled count path total: `3990.65s`
+- safe tile count: `12`
+- `_compute_exceedance_mask`: `469.81s` across `12` calls
+
+Conclusion:
+
+- There is no hidden setup hotspot left worth tuning in the current exact `cftime` path.
+- Further performance work there likely requires a new exact algorithm.
+
+## Recommended next steps
+
+1. Treat this bootstrap optimization phase as complete.
+2. Keep the validated spell and compound value-aggregate optimizations.
+3. Do not spend more time on exact `cftime` count tuning unless the goal becomes designing a new exact algorithm.
+4. If optimization resumes later, open a separate phase explicitly scoped to exact `cftime` algorithm design.
+5. Otherwise move to branch cleanup, commit grouping, and PR preparation.
+
+## Suggested commit grouping
+
+### Commit 1: validation and routing closeout
+
+- `src/icclim/_core/generic/bootstrap_capability.py`
+- `src/icclim/_core/generic/bootstrap_primitives.py`
+- `src/icclim/_core/generic/threshold/percentile.py`
+- `tests/test_bootstrap_capability.py`
+- `tests/test_main.py`
+
+Purpose:
+
+- lock in exact `cftime` routing
+- preserve filtered-average routing behavior
+- keep the cftime-safe bootstrap primitive adjustments
+- keep the threshold-units fix needed by the validated paths
+
+### Commit 2: spell and compound bootstrap performance improvements
+
+- `src/icclim/_core/generic/bootstrap.py`
+- `src/icclim/_core/generic/functions.py`
+- `tests/test_generic_functions.py`
+
+Purpose:
+
+- keep the spell-family reopen-aware prepared-input optimization
+- keep compound value-aggregate stabilized-study reuse
+- keep the shared bootstrap-kernel and dtype updates required by those wins
+
+### Commit 3: benchmarking and validation tooling
+
+- `tools/profile_bootstrap_phases.py`
+- `tools/run_real_data_validation.py`
+- `tools/summarize_real_data_validation.py`
+- `tests/test_real_data_validation_tools.py`
+- this closeout note
+
+Purpose:
+
+- preserve the real-data workloads used in this phase
+- preserve the profiler instrumentation used to validate the outcomes
+- preserve the branch-local closeout record for future handoff

--- a/doc/source/archive/cftime_exact_bootstrap_design_2026-08-18.md
+++ b/doc/source/archive/cftime_exact_bootstrap_design_2026-08-18.md
@@ -1,0 +1,100 @@
+# Exact `cftime` Bootstrap Count Design Notes (2026-08-18)
+
+Branch: `feature/bootstrap-next-phase`
+
+## Why this phase exists
+
+The previous bootstrap optimization phase closed with a clear boundary:
+further meaningful performance work for day-of-year percentile `cftime`
+counts requires a new exact algorithm, not more tuning of the exact tiled
+`_compute_exceedance_mask` path.
+
+This note records the first design-pass findings for that new phase.
+
+## Current state
+
+- Generic bootstrap routing still forces non-`DatetimeIndex` calendars onto
+  `exact_tiled_bootstrap` with reason code
+  `calendar_requires_exact_tiled_bootstrap`.
+- The expensive path is the tile-local call to `_compute_exceedance_mask`
+  followed by xarray resampling.
+- Kraken deep profiling on Tuesday, August 18, 2026 showed the exact tiled
+  count path dominating wall-clock time.
+
+## Key code-level finding
+
+The compiled bootstrap stack is already much closer to `cftime` support than
+the dispatch layer suggests.
+
+It already has:
+
+- `CFTimeIndex`-aware array dtype selection in
+  `src/icclim/_core/generic/bootstrap.py`;
+- `month/day` substitute-year alignment in
+  `substitute_indices_aligned_to_target`;
+- `cftime`-compatible resample-group indexing in
+  `build_bootstrap_temporal_indexing`;
+- a daily-then-resample fast tiled path for `CFTimeIndex` counts in
+  `_compute_fast_tiled_count_occurrences`.
+
+So the remaining blocker is not “the optimized stack cannot represent
+`cftime` bootstrap”. The blocker is that the current branch has not yet
+proved that the compiled count semantics stay exact for real `cftime`
+bootstrap workloads.
+
+## Ground truth from this pass
+
+This phase added low-risk primitive coverage rather than changing runtime
+behavior:
+
+- `build_bootstrap_temporal_indexing` now has direct `cftime` coverage;
+- the Python view of `_bootstrap_count_kernel` now has a direct constant-case
+  `cftime` monthly count check.
+
+These checks do **not** prove the full algorithm is ready for release.
+They do show that:
+
+1. the bootstrap temporal indexing path already handles `cftime` grouping;
+2. the compiled count kernel can reproduce simple exact `cftime` monthly
+   counts once given prepared inputs.
+
+That narrows the design problem substantially.
+
+## Most likely mismatch locations
+
+The remaining real-data mismatch is now most plausibly in one of these places:
+
+1. substitute-year threshold generation around leap/non-leap alignment for
+   overlapping reference years;
+2. nominal versus substitute-year threshold handling for `cftime` monthly
+   grouping;
+3. interaction between compiled daily counts and `cftime` output label or
+   aggregation semantics at the wrapper level.
+
+The evidence is weaker for a fundamental kernel limitation.
+
+## Recommended implementation order
+
+1. Add a branch-local comparison helper that evaluates compiled `cftime`
+   daily/yearly/monthly counts against the current exact tiled path on small
+   synthetic leap and non-leap fixtures.
+2. If those are exact, add an opt-in internal `cftime` count path that reuses
+   `compute_doy_percentile_bootstrap_count` rather than `_compute_exceedance_mask`.
+3. Keep the generic routing guard in place until:
+   - synthetic leap-edge cases are exact;
+   - `tx90p_cftime_yearly` and `tx90p_cftime_monthly` are exact on Kraken
+     against the current trusted baseline;
+   - chunk-layout sensitivity is checked again.
+4. Only then consider lifting `calendar_requires_exact_tiled_bootstrap` for
+   day-of-year percentile count workloads.
+
+## What not to do
+
+- Do not widen `cftime` support for spell or value-aggregate families yet.
+- Do not remove the exact tiled fallback.
+- Do not assume that passing constant-case primitives is enough for release.
+
+## Short version
+
+The new algorithm phase should start from the existing compiled bootstrap
+count stack, not from scratch.

--- a/doc/source/archive/cftime_exact_count_algorithm_phase_2_2026-08-19.md
+++ b/doc/source/archive/cftime_exact_count_algorithm_phase_2_2026-08-19.md
@@ -245,6 +245,43 @@ This result also sharpens the alternative:
 - if a compiled banked reduction remains awkward or memory-bound, the next
   serious route is the deeper exact order-statistics redesign.
 
+## Compiled banked benchmark result
+
+On Thursday, August 20, 2026, the banked branch advanced again with:
+
+- `compute_doy_percentile_bootstrap_count_threshold_bank_compiled_prototype`
+  in [src/icclim/_core/generic/bootstrap.py](/Users/page/src/icclim/icclim/src/icclim/_core/generic/bootstrap.py)
+
+This keeps the banked algorithm internal and non-routed, but removes the
+Python-level reduction bottleneck from the previous prototype.
+
+Focused synthetic coverage remained exact:
+
+- `14 passed` in the expanded prototype/cftime test selection;
+- no synthetic mismatch against the forced current compiled count path.
+
+Benchmark result on `reference_overlap_shift`, monthly (`MS`), with
+`65` study years and `30` reference years:
+
+- `8 x 8`
+  - current compiled path: `3.854s`
+  - Python threshold-bank prototype: `29.101s`
+  - compiled threshold-bank prototype: `1.306s`
+  - compiled banked path is about `2.95x` faster than the current compiled path
+- `16 x 16`
+  - current compiled path: `6.524s`
+  - Python threshold-bank prototype: `120.296s`
+  - compiled threshold-bank prototype: `4.004s`
+  - compiled banked path is about `1.63x` faster than the current compiled path
+
+This changes the phase-2 decision materially:
+
+- the banked branch is no longer only a semantic match;
+- it now has concrete speed evidence beyond toy size;
+- the main next step should be a real-data comparison of the compiled banked
+  branch against the current compiled count route, still behind a non-runtime
+  or opt-in path.
+
 ## Short version
 
 Phase 2 should start by measuring threshold-bank viability and only then choose

--- a/doc/source/archive/cftime_exact_count_algorithm_phase_2_2026-08-19.md
+++ b/doc/source/archive/cftime_exact_count_algorithm_phase_2_2026-08-19.md
@@ -207,6 +207,44 @@ Observed result:
 That upgrades the phase-2 status from “external proof of concept” to
 “internal prototype with regression coverage”.
 
+## First benchmark result
+
+On Thursday, August 20, 2026, a dedicated benchmark helper was added:
+
+- [tools/benchmark_cftime_count_prototypes.py](/Users/page/src/icclim/icclim/tools/benchmark_cftime_count_prototypes.py)
+
+This benchmark compares:
+
+- the current compiled count path; and
+- the library-internal threshold-bank prototype
+
+on synthetic `cftime` workloads with the validated `65`-year study and
+`30`-year reference shape.
+
+First timing snapshots on the `reference_overlap_shift` monthly case:
+
+- `1 x 1`
+  - current compiled path: `1.396s`
+  - threshold-bank prototype: `0.865s`
+  - prototype is about `1.61x` faster
+- `8 x 8`
+  - current compiled path: `2.561s`
+  - threshold-bank prototype: `28.144s`
+  - prototype is about `11x` slower
+
+Interpretation:
+
+- the banked algorithm shape can reduce repeated threshold work;
+- but the current Python-level reduction loop is not viable beyond tiny
+  spatial shapes;
+- so the only sensible continuation for this branch is a compiled or
+  partially compiled banked reduction, not more Python-level tuning.
+
+This result also sharpens the alternative:
+
+- if a compiled banked reduction remains awkward or memory-bound, the next
+  serious route is the deeper exact order-statistics redesign.
+
 ## Short version
 
 Phase 2 should start by measuring threshold-bank viability and only then choose

--- a/doc/source/archive/cftime_exact_count_algorithm_phase_2_2026-08-19.md
+++ b/doc/source/archive/cftime_exact_count_algorithm_phase_2_2026-08-19.md
@@ -1,0 +1,135 @@
+# `cftime` Exact Bootstrap Count Phase 2 Notes (2026-08-19)
+
+Branch: `feature/bootstrap-next-phase`
+
+## Phase boundary
+
+The previous phase is complete for the current approach:
+
+- full-field monthly `cftime` count validation is exact and materially faster;
+- full-field yearly `cftime` count validation is exact but not materially faster.
+
+That means the next phase is no longer “tune the existing route”.
+It is “design a different exact algorithm for `cftime` bootstrap counts”.
+
+## What phase 1 proved
+
+Validated on Kraken on Wednesday, August 19, 2026:
+
+- `tx90p_cftime_monthly`
+  - exact tiled baseline: `4159.14s`
+  - compiled experimental path: `2261.36s`
+  - exact full-field comparison: `changed_cells = 0`, `max_abs_diff = 0.0`
+- `tx90p_cftime_yearly`
+  - exact tiled baseline: `2175.77s`
+  - compiled experimental path: `2156.64s`
+  - exact full-field comparison: `changed_cells = 0`, `max_abs_diff = 0.0`
+
+So correctness is no longer the main uncertainty for count workloads.
+The remaining question is algorithm shape.
+
+## Why a new algorithm is needed
+
+The current compiled count kernel is already much better than the xarray mask
+path, but it still rebuilds threshold series inside the year loop.
+
+For one cell it does:
+
+1. one nominal threshold-series build for each non-overlap study year;
+2. one threshold-series build for each `(target_reference_year, substitute_year)`
+   pair in the overlap region.
+
+That is exact, but it limits further gains.
+
+## Candidate exact algorithm directions
+
+### 1. Nominal-series reuse
+
+For non-overlap years, the kernel currently rebuilds the same nominal threshold
+series repeatedly per cell. That series can be built once per cell and reused.
+
+This is low risk and exact, but it will only help the non-overlap portion of
+the workload.
+
+### 2. Threshold-bank algorithm
+
+For overlap years, one option is to precompute threshold series for
+`(target_reference_year, substitute_year, day_of_year, cell)` and then run
+count aggregation from that bank.
+
+This is exact, but memory may become the limiting factor.
+
+### 3. Order-statistics reuse
+
+The more ambitious direction is to avoid rebuilding each day-of-year quantile
+from scratch when one reference year is substituted out and another is mapped
+in. That likely needs a different exact order-statistics formulation rather
+than another cache wrapped around the current kernel.
+
+This is the most promising route for meaningful new gains, but also the most
+complex.
+
+## First measurement target for phase 2
+
+Before touching runtime behavior, estimate whether a threshold-bank algorithm
+is plausible at realistic domain sizes.
+
+The helper:
+
+- [tools/analyze_cftime_exact_count_algorithm.py](/Users/page/src/icclim/icclim/tools/analyze_cftime_exact_count_algorithm.py)
+
+builds real bootstrap indexing on synthetic `cftime` inputs and reports:
+
+- overlap versus non-overlap year counts;
+- current threshold-series rebuild count per cell;
+- estimated memory for:
+  - a full threshold bank;
+- a single-target threshold bank;
+- a nominal-only cache.
+
+On Wednesday, August 19, 2026, the first synthetic run was aligned to the
+validated real-data shape:
+
+- study years: `65`
+- reference years: `30`
+- overlap years: `30`
+- non-overlap years: `35`
+- spatial cells: `588` (`28 x 21`)
+- output groups for monthly analysis: `780`
+
+Measured implications:
+
+- current compiled count work still rebuilds `905` threshold series per cell;
+- a naive full threshold bank would still need `871` series per cell, so it
+  barely changes the work shape;
+- that full bank would cost about `1.50 GiB` in `float64`, or about
+  `0.75 GiB` in `float32`, across the validated domain shape;
+- a single-target threshold bank is far more plausible at about `49.8 MiB`
+  in `float64`, or about `24.9 MiB` in `float32`, across the same domain;
+- a nominal-only cache is tiny, but it only saves the repeated non-overlap
+  rebuilds.
+
+This already narrows the algorithm choice:
+
+- a naive full bank is not attractive enough;
+- nominal-only reuse is probably too small to be the main next-phase result;
+- the promising options are either:
+  - a per-target threshold-bank kernel; or
+  - an exact order-statistics redesign that reduces the overlap rebuild cost.
+
+## Success criteria for the next implementation step
+
+Only proceed to runtime prototyping if the measurements show at least one of:
+
+- nominal-series reuse gives a worthwhile share of current work back;
+- a per-target threshold bank fits comfortably inside the intended tile memory;
+- an order-statistics redesign is clearly justified by the rebuild counts.
+
+## Short version
+
+Phase 2 should start by measuring threshold-bank viability and only then choose
+between:
+
+- a small exact cache improvement;
+- a banked exact kernel;
+- a deeper order-statistics redesign.

--- a/doc/source/archive/cftime_exact_count_algorithm_phase_2_2026-08-19.md
+++ b/doc/source/archive/cftime_exact_count_algorithm_phase_2_2026-08-19.md
@@ -125,6 +125,51 @@ Only proceed to runtime prototyping if the measurements show at least one of:
 - a per-target threshold bank fits comfortably inside the intended tile memory;
 - an order-statistics redesign is clearly justified by the rebuild counts.
 
+## First prototype result
+
+The first non-runtime prototype was added in:
+
+- [tools/prototype_cftime_exact_count_threshold_bank.py](/Users/page/src/icclim/icclim/tools/prototype_cftime_exact_count_threshold_bank.py)
+
+This prototype does **not** change library behavior. It:
+
+1. builds nominal threshold series once per cell;
+2. builds a per-target threshold bank for overlap years;
+3. replays the count reduction from that bank;
+4. compares the result with the current compiled count path.
+
+On Thursday, August 20, 2026, it matched exactly on all synthetic
+`cftime` fixtures already used in earlier validation:
+
+- `constant`
+- `leap_day_cold_spike`
+- `reference_overlap_shift`
+
+for both:
+
+- monthly output (`MS`)
+- yearly output (`YS`)
+
+Observed result on every case/frequency pair:
+
+- `changed_cells = 0`
+- `max_abs_diff = 0.0`
+
+That does **not** prove the algorithm is ready for runtime integration, but it
+does remove one important uncertainty:
+
+- the per-target threshold-bank shape is compatible with current exact count
+  semantics on leap-sensitive synthetic cases.
+
+## Updated phase-2 decision
+
+The next implementation candidate should be:
+
+1. keep the current routing unchanged;
+2. prototype a compiled or partially compiled per-target bank evaluator behind
+   a non-runtime or opt-in path;
+3. only then compare it against the current compiled count route on real data.
+
 ## Short version
 
 Phase 2 should start by measuring threshold-bank viability and only then choose

--- a/doc/source/archive/cftime_exact_count_algorithm_phase_2_2026-08-19.md
+++ b/doc/source/archive/cftime_exact_count_algorithm_phase_2_2026-08-19.md
@@ -170,6 +170,43 @@ The next implementation candidate should be:
    a non-runtime or opt-in path;
 3. only then compare it against the current compiled count route on real data.
 
+## Second prototype step
+
+On Thursday, August 20, 2026, the per-target bank shape moved from a standalone
+tool into a library-internal prototype entrypoint:
+
+- `compute_doy_percentile_bootstrap_count_threshold_bank_prototype`
+  in [src/icclim/_core/generic/bootstrap.py](/Users/page/src/icclim/icclim/src/icclim/_core/generic/bootstrap.py)
+
+This is still not used by runtime routing. Its purpose is narrower:
+
+- make the candidate algorithm callable from normal tests;
+- keep the prototype close to the real bootstrap primitives and metadata path;
+- verify that the banked count reduction stays aligned with the current
+  compiled count implementation.
+
+Targeted synthetic tests now cover:
+
+- `constant`
+- `leap_day_cold_spike`
+- `reference_overlap_shift`
+
+for both:
+
+- `MS`
+- `YS`
+
+and compare the library-internal prototype against the forced compiled count
+path.
+
+Observed result:
+
+- `8 passed` in the focused prototype/cftime test selection;
+- all synthetic comparisons remained exact.
+
+That upgrades the phase-2 status from “external proof of concept” to
+“internal prototype with regression coverage”.
+
 ## Short version
 
 Phase 2 should start by measuring threshold-bank viability and only then choose

--- a/doc/source/archive/cftime_exact_count_algorithm_phase_3_2026-08-21.md
+++ b/doc/source/archive/cftime_exact_count_algorithm_phase_3_2026-08-21.md
@@ -217,6 +217,176 @@ decision-grade because they are dominated by Python-level execution and local
 warmup effects. At this stage they should be read only as a semantic check,
 not as a performance conclusion.
 
+## Python-level real-data validation
+
+This phase also adds:
+
+- [tools/benchmark_cftime_order_stat_real_data.py](/Users/page/src/icclim/icclim/tools/benchmark_cftime_order_stat_real_data.py)
+
+This benchmark compares three exact routes on real data:
+
+- the current compiled count route;
+- the compiled threshold-bank prototype;
+- the Python-level order-statistics redesign prototype.
+
+Validated on Friday, August 21, 2026, on the real-data `TX90p` study used in
+the earlier threshold-bank checks:
+
+- `1 x 1` monthly (`MS`) and yearly (`YS`);
+- `2 x 2` monthly (`MS`) and yearly (`YS`).
+
+Observed exactness result on every validated shape and frequency:
+
+- `changed_cells_vs_current = 0`
+- `max_abs_diff_vs_current = 0.0`
+
+Observed timing snapshots:
+
+- `1 x 1`, `MS`:
+  - current compiled: about `42.92s`;
+  - compiled threshold-bank: about `24.33s`;
+  - Python-level order-statistics: about `152.94s`.
+- `1 x 1`, `YS`:
+  - current compiled: about `24.24s`;
+  - compiled threshold-bank: about `24.24s`;
+  - Python-level order-statistics: about `152.74s`.
+- `2 x 2`, `MS`:
+  - current compiled: about `37.94s`;
+  - compiled threshold-bank: about `26.80s`;
+  - Python-level order-statistics: about `605.45s`.
+- `2 x 2`, `YS`:
+  - current compiled: about `37.91s`;
+  - compiled threshold-bank: about `26.45s`;
+  - Python-level order-statistics: about `617.97s`.
+
+This closes the semantic question for the redesign on real data:
+
+- the order-statistics route is exact on the validated real-data subsets;
+- but the Python-level prototype is far too slow to be a production candidate.
+
+So from this point onward, performance conclusions only matter for a compiled
+order-statistics implementation.
+
+## First compiled order-statistics benchmark
+
+This phase also adds:
+
+- [tools/benchmark_cftime_order_stat_compiled.py](/Users/page/src/icclim/icclim/tools/benchmark_cftime_order_stat_compiled.py)
+- [tools/benchmark_cftime_order_stat_compiled_real_data.py](/Users/page/src/icclim/icclim/tools/benchmark_cftime_order_stat_compiled_real_data.py)
+
+The first tool keeps the redesigned route fully inside a benchmark-oriented
+Numba kernel so the question becomes narrower:
+
+- if the order-statistics redesign is compiled, does it still preserve exact
+  results;
+- and does it start to recover the expected performance gain?
+
+Validated locally on Friday, August 21, 2026:
+
+- synthetic `constant`, monthly (`MS`), `1 x 1`:
+  - `changed_cells_vs_current = 0`;
+  - current compiled: about `1.64s`;
+  - compiled threshold-bank: about `0.47s`;
+  - compiled order-statistics: about `2.26s`.
+- synthetic `reference_overlap_shift`, monthly (`MS`), `1 x 1`:
+  - `changed_cells_vs_current = 0`;
+  - current compiled: about `1.29s`;
+  - compiled threshold-bank: about `0.46s`;
+  - compiled order-statistics: about `1.25s`.
+- synthetic `reference_overlap_shift`, monthly (`MS`), `4 x 4`:
+  - `changed_cells_vs_current = 0`;
+  - current compiled: about `1.54s`;
+  - compiled threshold-bank: about `0.57s`;
+  - compiled order-statistics: about `1.54s`.
+
+These local snapshots show the expected shift:
+
+- the compiled order-statistics redesign stays exact;
+- and on the overlap-heavy synthetic case it is already roughly on par with
+  the current compiled route.
+
+## First compiled real-data result
+
+On Friday, August 21, 2026, the compiled real-data benchmark was first
+validated on `1 x 1`:
+
+- monthly (`MS`):
+  - `changed_cells_vs_current = 0`;
+  - `max_abs_diff_vs_current = 0.0`;
+  - current compiled: about `42.92s`;
+  - compiled threshold-bank: about `24.24s`;
+  - compiled order-statistics: about `8.15s`.
+- yearly (`YS`):
+  - `changed_cells_vs_current = 0`;
+  - `max_abs_diff_vs_current = 0.0`;
+  - current compiled: about `24.24s`;
+  - compiled threshold-bank: about `24.11s`;
+  - compiled order-statistics: about `5.64s`.
+
+This is the first result in the whole redesign campaign that materially
+changes the outlook:
+
+- the compiled order-statistics redesign is exact on real data;
+- it is about `5.26x` faster than the current compiled route on `1 x 1` monthly;
+- it is about `4.30x` faster than the current compiled route on `1 x 1` yearly;
+- it is also materially faster than the compiled threshold-bank prototype on
+  the same real-data slice.
+
+That means this new phase is no longer just a design exercise. It has already
+produced one compiled exact real-data route that looks genuinely promising.
+
+## Compiled real-data scaling check
+
+The next real-data check on Friday, August 21, 2026, extended the same
+compiled benchmark to `2 x 2`:
+
+- monthly (`MS`):
+  - `changed_cells_vs_current = 0`;
+  - `max_abs_diff_vs_current = 0.0`;
+  - current compiled: about `38.74s`;
+  - compiled threshold-bank: about `26.09s`;
+  - compiled order-statistics: about `14.85s`.
+- yearly (`YS`):
+  - `changed_cells_vs_current = 0`;
+  - `max_abs_diff_vs_current = 0.0`;
+  - current compiled: about `38.74s`;
+  - compiled threshold-bank: about `25.81s`;
+  - compiled order-statistics: about `15.05s`.
+
+So the real-data picture now holds on both validated subset sizes:
+
+- `1 x 1`, monthly (`MS`): compiled order-statistics is about `5.26x` faster
+  than the current compiled route;
+- `1 x 1`, yearly (`YS`): about `4.30x` faster;
+- `2 x 2`, monthly (`MS`): about `2.61x` faster;
+- `2 x 2`, yearly (`YS`): about `2.57x` faster.
+
+It also still stays ahead of the compiled threshold-bank route on all four
+validated real-data cases.
+
+## Phase-3 conclusion
+
+This phase started as a redesign study for a different exact `cftime`
+bootstrap-count algorithm. It now has three progressively stronger results:
+
+1. the order-statistics redesign is exact on synthetic overlap and leap cases;
+2. it is exact on real-data `1 x 1` and `2 x 2` subsets;
+3. once compiled, it is materially faster than both:
+   - the current compiled route;
+   - the compiled threshold-bank prototype
+   on the validated real-data subsets.
+
+So the honest conclusion at the end of this phase is no longer the earlier
+"the redesign is valid but not yet competitive" position.
+
+It is now:
+
+- a new exact `cftime` bootstrap-count algorithm has been designed;
+- its compiled prototype is already performance-promising on real data;
+- the next phase should focus on turning that compiled prototype into a clean
+  production implementation inside the runtime path, while preserving the
+  exact validated semantics.
+
 ## Expected benefits
 
 - exact semantics stay tied to the existing method-8 definition;

--- a/doc/source/archive/cftime_exact_count_algorithm_phase_3_2026-08-21.md
+++ b/doc/source/archive/cftime_exact_count_algorithm_phase_3_2026-08-21.md
@@ -1,0 +1,266 @@
+# `cftime` Exact Bootstrap Count Phase 3 Notes (2026-08-21)
+
+Branch: `feature/bootstrap-next-phase`
+
+## Phase boundary
+
+This phase starts after the threshold-bank branch was proved exact but was not
+compelling enough on full real data to become the next production route.
+
+That means the current question is no longer:
+
+- can we cache more threshold series?
+
+It is:
+
+- can we redesign the exact overlap-year quantile evaluation so it does less
+  repeated work than rebuilding a full day-of-year sample for every
+  `(target_reference_year, substitute_year)` pair?
+
+## Ground truth carried into this phase
+
+Validated before this phase on Thursday, August 20, 2026:
+
+- the compiled threshold-bank prototype is exact on synthetic overlap cases;
+- the compiled threshold-bank prototype is also exact on full-field real
+  monthly and yearly `TX90p` `cftime` runs;
+- synthetic medium-size benchmarks still favor the compiled threshold-bank
+  branch:
+  - monthly `8 x 8`: about `1.98x` faster than the current compiled route;
+  - monthly `16 x 16`: about `1.42x` faster;
+  - yearly `8 x 8`: about `1.95x` faster;
+  - yearly `16 x 16`: about `1.35x` faster;
+- but earlier full-field real-data validation still showed the banked route
+  slightly slower than the current compiled route.
+
+So the branch is exact, but it is not yet the decisive next production
+algorithm.
+
+## Why the next exact algorithm should target order statistics
+
+The current compiled count path still spends its overlap-year work here:
+
+1. rebuild the full day-of-year sample for one cell;
+2. apply the target-year substitution by remapping indices;
+3. select the method-8 quantile from that rebuilt sample;
+4. repeat for every overlap substitution and every day of year.
+
+The threshold-bank prototype reduces some repeated counting work, but it still
+stores or rebuilds full threshold series. The remaining opportunity is one
+level lower:
+
+- reuse the base order-statistics structure of a day-of-year sample;
+- apply only the small delta introduced by replacing one reference year with
+  another;
+- recover the same exact method-8 quantile without rebuilding the whole sample.
+
+## New phase-3 measurement
+
+This phase adds:
+
+- [tools/analyze_cftime_exact_order_stat_design.py](/Users/page/src/icclim/icclim/tools/analyze_cftime_exact_order_stat_design.py)
+
+It measures the part that matters for an order-statistics redesign:
+
+- total sample size per day of year;
+- how many sample members come from one target reference year;
+- how many substitute-aligned values actually need to be inserted for one
+  `(target_reference_year, substitute_year)` replacement.
+
+On Friday, August 21, 2026, on the same validated `65`-year study,
+`30`-year reference, `28 x 21` domain shape:
+
+- total sample count per day of year is about `150` in the common case;
+- one target reference year contributes only a small slice of that sample per
+  day of year;
+- leap-aware substitute alignment can shrink that replacement slice further.
+
+This is the key design fact:
+
+- the overlap substitution changes only a small subset of the values that feed
+  one day-of-year quantile.
+
+That is exactly the condition where an exact delta-aware order-statistics
+algorithm can be worthwhile.
+
+## Proposed exact algorithm shape
+
+### 1. Build one base sorted sample per `(day_of_year, cell)`
+
+For one cell, for each day of year:
+
+- gather the nominal valid reference values once;
+- sort them once;
+- keep the sorted values and the reference-year membership of each sample.
+
+This becomes the reusable base state for all overlap substitutions.
+
+### 2. Precompute the target-year delta, not a full threshold series
+
+For each target reference year and day of year:
+
+- record which base-sample members belong to that target year;
+- record their values in sorted order;
+- record the aligned substitute values for each substitute year.
+
+The important point is that this delta set is small compared with the full
+sample.
+
+### 3. Recover the exact method-8 quantile from base sample plus delta
+
+For one `(target_reference_year, substitute_year, day_of_year, cell)` pair:
+
+- start from the base sorted sample;
+- conceptually remove the target-year contribution values;
+- conceptually insert the aligned substitute values;
+- evaluate the exact method-8 order statistic on that adjusted multiset.
+
+The candidate exact implementation route is:
+
+1. compute the method-8 target ranks `k` and `k + 1` from the adjusted sample
+   length;
+2. answer `k` and `k + 1` with rank queries on:
+   - the base sorted values;
+   - the removed-value delta;
+   - the inserted-value delta;
+3. interpolate exactly as the current method-8 selector already does.
+
+The key improvement is that the overlap substitution no longer rebuilds and
+rescans the full sample buffer. It only queries the base sorted sample plus a
+small delta set.
+
+## First prototype result
+
+This phase also adds:
+
+- [tools/prototype_cftime_exact_order_stat_quantile.py](/Users/page/src/icclim/icclim/tools/prototype_cftime_exact_order_stat_quantile.py)
+
+This first prototype is still non-runtime and Python-level. Its purpose is
+more specific:
+
+1. build one nominal sorted sample per day of year for one cell;
+2. derive the removed target-year values and inserted substitute-year values;
+3. recover the exact method-8 quantile from that adjusted multiset;
+4. compare the resulting threshold series directly against the current
+   `_build_bootstrap_threshold_series_for_cell` implementation.
+
+Validated locally on Friday, August 21, 2026, on all current synthetic
+`cftime` overlap fixtures:
+
+- `constant`
+- `leap_day_cold_spike`
+- `reference_overlap_shift`
+
+for both:
+
+- monthly output (`MS`)
+- yearly output (`YS`)
+
+Observed result on every case/frequency pair:
+
+- `changed_doys = 0`
+- `max_abs_diff = 0.0`
+
+On these fixtures, the overlap substitution delta is also very small:
+
+- `max_removed_values = 1`
+- `max_inserted_values = 1`
+
+This does **not** prove the final full-domain algorithm yet, but it does
+remove the main semantic uncertainty for the next step:
+
+- the exact method-8 quantile can already be recovered from
+  `base sorted sample + removed delta + inserted delta` without rebuilding the
+  full per-day sample buffer.
+
+## First full count prototype result
+
+This phase also adds:
+
+- [tools/prototype_cftime_exact_order_stat_count.py](/Users/page/src/icclim/icclim/tools/prototype_cftime_exact_order_stat_count.py)
+
+This lifts the delta-aware quantile prototype one step higher:
+
+1. build nominal threshold series from the adjusted-multiset selector;
+2. build overlap substitution threshold series from the same selector;
+3. run the full bootstrap count reduction from those threshold series;
+4. compare the final count output against:
+   - the current compiled count route;
+   - the compiled threshold-bank prototype.
+
+Validated locally on Friday, August 21, 2026, on all current synthetic
+`cftime` overlap fixtures:
+
+- `constant`
+- `leap_day_cold_spike`
+- `reference_overlap_shift`
+
+for both:
+
+- monthly output (`MS`)
+- yearly output (`YS`)
+
+Observed result on every case/frequency pair:
+
+- `changed_cells = 0`
+- `max_abs_diff = 0.0`
+
+This is the first end-to-end result that matters for the new phase:
+
+- the delta-aware exact order-statistics route is not only exact at the
+  threshold-series level;
+- it is also exact at the final bootstrap count output level on the current
+  synthetic leap and overlap coverage.
+
+The tiny local timing snapshots from this first prototype run are **not** yet
+decision-grade because they are dominated by Python-level execution and local
+warmup effects. At this stage they should be read only as a semantic check,
+not as a performance conclusion.
+
+## Expected benefits
+
+- exact semantics stay tied to the existing method-8 definition;
+- leap-day substitution stays explicit instead of hidden in a larger bank;
+- overlap-year work should scale with replacement-set size rather than with
+  the full day-of-year sample rebuild;
+- memory pressure should stay lower than a full threshold bank because the
+  reusable object is a base sorted sample plus small per-target deltas, not a
+  threshold series for every target/substitute pair.
+
+## Main risks
+
+1. Duplicated values:
+   the delta-aware rank logic must treat equal values carefully so the result
+   stays identical to the current exact selector.
+
+2. Variable adjusted sample size:
+   leap-aware substitute alignment can remove samples without a one-to-one
+   replacement, so the method-8 ranks must be computed from the adjusted valid
+   sample count, not from the nominal count.
+
+3. Numba implementation complexity:
+   the clean algorithm shape is clearer than the final low-level kernel shape.
+   A reference prototype should stay Python-level or non-routed until the
+   exact semantics are locked down.
+
+## Recommended implementation order
+
+1. Add a non-runtime prototype that computes one overlap quantile from:
+   - a base sorted sample;
+   - a removed delta;
+   - an inserted delta.
+2. Verify exact equality against `_quantile_for_doy_cell` on synthetic leap and
+   overlap fixtures.
+3. Lift that prototype to a full threshold-series builder for one cell.
+4. Only then compare the order-statistics prototype with:
+   - the current compiled route;
+   - the compiled threshold-bank prototype.
+
+## Short version
+
+The new exact algorithm phase should not start from another threshold cache.
+It should start from a delta-aware exact order-statistics design:
+
+- one reusable base sorted sample per day of year;
+- one small replacement delta per target/substitute pair;
+- exact method-8 quantiles recovered from the adjusted multiset.

--- a/doc/source/dev/bootstrap_architecture.rst
+++ b/doc/source/dev/bootstrap_architecture.rst
@@ -42,8 +42,8 @@ Use the following rules when extending bootstrap support:
 
 - Separate threshold generation from result aggregation.
 - Classify support by mathematical family, not by index short name.
-- Keep the safe tiled path as the reference bootstrap implementation for every new optimized
-  implementation.
+- Keep the exact tiled bootstrap path as the reference bootstrap
+  implementation for every new optimized implementation.
 - Prefer a small number of well-named helpers over large mixed-purpose
   functions.
 - Make routing decisions explicit in one place rather than scattering
@@ -130,8 +130,8 @@ Examples:
 As of Sunday, August 2, 2026, compound count routing is split into two
 practical cases:
 
-- multi-variable compound counts can combine bootstrap leaf masks, using
-  the best available leaf path for each variable before applying the
+- multi-variable compound counts can combine bootstrap component masks,
+  using the best available component path for each variable before applying the
   logical link;
 - single-variable bounded scalar guards such as
   ``> 90 doy_per AND <= 30 degC`` or
@@ -186,8 +186,8 @@ classifier that answers four questions:
 1. Is bootstrap required?
 2. If it is required, which family does the index belong to?
 3. Can the optimized implementation be used?
-4. If not, should icclim fall back to the safe tiled path or reject the
-   request as unsupported?
+4. If not, should icclim fall back to the exact tiled bootstrap path or
+   reject the request as unsupported?
 
 The classifier should use explicit fields rather than index names:
 
@@ -226,9 +226,9 @@ generic indicator families:
 - filtered day-of-year percentile count;
 - value aggregates such as ``fraction_of_total``;
 - spell reducers such as ``sum_of_spell_lengths``;
-- multi-variable compound counts that can combine bootstrap leaf masks;
+- multi-variable compound counts that can combine bootstrap component masks;
 - bounded single-variable percentile compositions with one day-of-year
-  percentile leaf and one scalar guard joined by ``AND`` or ``OR``.
+  percentile component and one scalar guard joined by ``AND`` or ``OR``.
 
 Reusable bootstrap primitives
 =============================
@@ -355,9 +355,9 @@ validated optimized implementation instead uses:
 - optimized union exceedance-day counts;
 - final output casting aligned with the trusted baseline dtype.
 
-The same compound leaf-mask architecture also supports percentile-tail
+The same compound component-mask architecture also supports percentile-tail
 unions such as ``> 95 doy_per OR <= 10 doy_per``. Those OR shapes stay
-in the compound family, but they reuse the same bootstrap leaf-mask
+in the compound family, but they reuse the same bootstrap component-mask
 combination strategy as the already validated percentile-interval
 workloads.
 
@@ -601,7 +601,7 @@ The best coverage-per-effort order is:
 
 At each step:
 
-- compare against the safe tiled reference path;
+- compare against the exact tiled reference path;
 - validate on real data, not only synthetic examples;
 - record both performance and field equality;
 - widen dispatch only after Kraken validation is exact.

--- a/doc/source/dev/bootstrap_maintainability_audit.rst
+++ b/doc/source/dev/bootstrap_maintainability_audit.rst
@@ -1,15 +1,15 @@
-.. _dev_code_audit_since_abel:
+.. _dev_bootstrap_maintainability_audit:
 
-#####################################
-Code audit since Abel's last commits
-#####################################
+###############################
+Bootstrap maintainability audit
+###############################
 
 This note records a maintainability audit of the codebase after the
-bootstrap work merged between July 29 and August 3, 2026.
+bootstrap work merged between Tuesday, July 29, 2026 and Monday, August
+3, 2026.
 
-The audit uses Abel Aoun's last commit period as a historical boundary,
-but it is not an author-based judgement. The goal is to assess the
-current code against the rules maintainers agreed on:
+The goal is to assess the current code against the rules maintainers
+agreed on:
 
 - scientific workflow must stay visible in code;
 - naming must prefer climate and research-software semantics over
@@ -32,7 +32,7 @@ The audit considers:
   ``feature/bootstrap-chunk-performance`` on Monday, August 3, 2026;
 - workflow and readability concerns raised during the recent bootstrap
   work;
-- both older architect-led patterns and newer AI-era changes.
+- patterns that make the scientific workflow easier or harder to follow.
 
 The audit does **not** assume:
 
@@ -195,11 +195,11 @@ Rule going forward:
 - when modifying them, prefer explicit phase helpers over expanding
   existing mixed-purpose builders.
 
-What this audit says about older architect-led patterns
-=======================================================
+What this audit says about older design patterns
+================================================
 
-Some older design choices were technically solid, but not always ideal
-for scientific workflow clarity or FAIR4RS.
+Some existing design choices were technically solid, but not always
+ideal for scientific workflow clarity or FAIR4RS.
 
 Examples of patterns to avoid repeating:
 

--- a/doc/source/dev/code_audit_since_abel.rst
+++ b/doc/source/dev/code_audit_since_abel.rst
@@ -1,0 +1,348 @@
+.. _dev_code_audit_since_abel:
+
+#####################################
+Code audit since Abel's last commits
+#####################################
+
+This note records a maintainability audit of the codebase after the
+bootstrap work merged between July 29 and August 3, 2026.
+
+The audit uses Abel Aoun's last commit period as a historical boundary,
+but it is not an author-based judgement. The goal is to assess the
+current code against the rules maintainers agreed on:
+
+- scientific workflow must stay visible in code;
+- naming must prefer climate and research-software semantics over
+  imported software jargon;
+- readable and reusable code matters as much as raw performance;
+- abstractions must be justified by clarity, correctness or validated
+  performance;
+- the code should remain aligned with FAIR for Research Software
+  (FAIR4RS).
+
+This note is meant to guide future work so maintainers do not need to
+repeat the same broad audit after every bootstrap extension.
+
+Scope and method
+================
+
+The audit considers:
+
+- the code and documentation state after the merge of
+  ``feature/bootstrap-chunk-performance`` on Monday, August 3, 2026;
+- workflow and readability concerns raised during the recent bootstrap
+  work;
+- both older architect-led patterns and newer AI-era changes.
+
+The audit does **not** assume:
+
+- older code is automatically better;
+- newer code is automatically worse;
+- technically elegant structure is enough if the scientific workflow
+  becomes harder to follow.
+
+Instead, the central questions are:
+
+1. Can a scientific maintainer understand how an index is computed?
+2. Are abstractions helping reuse and clarity, or hiding the workflow?
+3. Is the code proportionate to the scientific problem?
+4. Is the result more FAIR4RS-aligned than before?
+
+High-level verdict
+==================
+
+The recent direction is good.
+
+Compared with the state before the July 29 to August 3, 2026 bootstrap
+series, the code is now:
+
+- more explicit about bootstrap routing and support boundaries;
+- better documented for maintainers;
+- better validated on real data and chunk-profile variation;
+- better aligned with climate-domain wording;
+- less dependent on hidden workflow spread across many small wrappers.
+
+However, some structural risks remain:
+
+- a few core files are still too large;
+- some policy and mechanics are still mixed together;
+- low-level bootstrap kernels are necessarily dense and must stay boxed
+  in by readable surrounding code;
+- some older architect-style indirection still makes scientific
+  workflow harder to discover than it should be.
+
+Areas that are in good shape
+============================
+
+Bootstrap capability routing
+----------------------------
+
+``src/icclim/_core/generic/bootstrap_capability.py`` is a strong part of
+the current design.
+
+Why it works:
+
+- routing is explicit;
+- reason codes make behavior observable;
+- support is classified by mathematical family rather than by index
+  short name;
+- the code is readable enough for maintainers to extend carefully.
+
+Bootstrap primitives
+--------------------
+
+``src/icclim/_core/generic/bootstrap_primitives.py`` is a good step
+toward reusable threshold-engine logic.
+
+Why it works:
+
+- responsibilities are reasonably stable;
+- the scientific phases are visible;
+- future optimized reducers have a clear place to reuse shared work.
+
+Developer documentation
+-----------------------
+
+The recent developer notes are a meaningful improvement:
+
+- ``bootstrap_architecture.rst``
+- ``percentile_bootstrap.rst``
+- ``add_climate_index.rst``
+
+Why this matters:
+
+- maintainers can now find the intended support boundary;
+- workflow and implementation intent are less dependent on tribal
+  knowledge;
+- this is directly helpful for FAIR4RS reuse and onboarding.
+
+Validation tooling
+------------------
+
+The real-data validation and profiling tools are now useful
+infrastructure rather than ad hoc scripts.
+
+Why this matters:
+
+- exact comparisons against a trusted baseline are now standard;
+- performance diagnostics are reproducible;
+- chunk-profile stability can be verified explicitly.
+
+Areas that still need care
+==========================
+
+``bootstrap.py``
+----------------
+
+``src/icclim/_core/generic/bootstrap.py`` is still a major hotspot.
+
+Current assessment:
+
+- much better than before;
+- still too large;
+- still dense in the compiled-kernel section;
+- acceptable only because the surrounding routing, docs and tests are
+  now much stronger.
+
+Rule going forward:
+
+- do not let this file grow casually;
+- any substantial new feature should first ask whether one more
+  meaningful extraction is needed.
+
+``functions.py``
+----------------
+
+``src/icclim/_core/generic/functions.py`` remains too large and still
+mixes several reducer families.
+
+Current assessment:
+
+- readable in local sections;
+- hard to navigate globally;
+- still carries too much responsibility in one file.
+
+Rule going forward:
+
+- new reducer-family work should prefer extracting stable helper layers
+  instead of adding yet more branching into this file.
+
+``main.py``
+-----------
+
+``src/icclim/main.py`` is more explicit than before, but it is still
+oversized for a scientific entrypoint.
+
+Current assessment:
+
+- much improved workflow clarity;
+- still a large surface for one module;
+- still more orchestration than ideal in one place.
+
+Rule going forward:
+
+- avoid letting bootstrap-specific policy leak back into ``main.py``;
+- keep it as a readable orchestration layer, not a second routing hub.
+
+``input_parsing.py`` and ``threshold/factory.py``
+-------------------------------------------------
+
+These modules improved, but still mix policy and mechanics more than is
+ideal for research-software readability.
+
+Rule going forward:
+
+- when modifying them, prefer explicit phase helpers over expanding
+  existing mixed-purpose builders.
+
+What this audit says about older architect-led patterns
+=======================================================
+
+Some older design choices were technically solid, but not always ideal
+for scientific workflow clarity or FAIR4RS.
+
+Examples of patterns to avoid repeating:
+
+- factory/registry chains that hide the climate-index workflow;
+- thin translation helpers that only rename and forward arguments;
+- elegant dispatch that makes onboarding harder for research
+  contributors;
+- abstractions that compress several scientific steps into one generic
+  builder.
+
+This does **not** mean those choices were wrong in context. It means the
+current standard should be:
+
+- scientific workflow visibility first;
+- architecture second;
+- micro-elegance only when it does not hide meaning.
+
+Working rules for the next branches
+===================================
+
+Use these as hard constraints for future bootstrap work.
+
+Readability rules
+-----------------
+
+- Prefer domain language over generic software jargon.
+- Keep substitute-year, reference-period and threshold semantics
+  explicit.
+- Avoid adding wrappers that only rename arguments and forward calls.
+- Prefer one readable control flow over several abstract layers.
+- Keep optimized kernels boxed behind readable orchestration.
+
+Structure rules
+---------------
+
+- One file should not become the default home for every new bootstrap
+  feature.
+- Extract by stable responsibility, not by convenience.
+- Keep routing in dedicated routing code.
+- Keep low-level numeric mechanics separate from scientific policy.
+- Keep validation utilities separate from production routing logic.
+
+Scientific rules
+----------------
+
+- Do not add a new optimized route without trusted-baseline real-data
+  validation.
+- Do not add a new family unless it corresponds to a real scientific
+  need.
+- Do not introduce special cases that make the support matrix harder to
+  understand than the underlying climate-index family.
+- Keep the exact tiled bootstrap implementation as the reference path
+  until the optimized path is field-identical.
+
+FAIR4RS rules
+-------------
+
+- Make the code easier to find by keeping responsibilities and names
+  obvious.
+- Make the code easier to access by keeping the workflow visible in
+  source and docs.
+- Make the code easier to interoperate with by keeping assumptions
+  explicit.
+- Make the code easier to reuse by preferring stable primitives over
+  hidden special cases.
+
+Over-engineering checklist
+==========================
+
+Run this checklist before merging any substantial bootstrap change.
+
+Technical over-engineering
+--------------------------
+
+Ask:
+
+- Did this change add a new abstraction that mainly forwards calls?
+- Did it add a new helper whose responsibility is not stable?
+- Did it make the control flow harder to follow than before?
+- Did it improve performance only marginally while making code harder to
+  understand?
+
+If the answer is yes, simplify before merging.
+
+Scientific over-engineering
+---------------------------
+
+Ask:
+
+- Is this a real bootstrap family, or just a one-off special case?
+- Did we add support before proving a real scientific need?
+- Did we make the support matrix harder to understand than the climate
+  concept itself?
+- Did we increase validation burden without proportionate scientific
+  value?
+
+If the answer is yes, simplify or postpone.
+
+Implementation plan
+===================
+
+The next implementation steps should preserve the gains from the recent
+bootstrap work while reducing the risk of architectural drift.
+
+1. Keep using small, reviewable bootstrap branches.
+   Each branch should add one scientifically meaningful support
+   extension or one clearly scoped maintainability improvement.
+
+2. Treat ``bootstrap.py`` and ``functions.py`` as controlled-growth
+   files.
+   Before adding more code there, check whether a stable extraction is
+   justified.
+
+3. Require a short post-change audit for every substantial bootstrap
+   branch.
+   The branch close-out should answer:
+
+   - what became clearer?
+   - what became more complex?
+   - is the complexity justified?
+
+4. Keep docs aligned with support boundaries.
+   If a new optimized family or fallback rule is added, update the
+   maintainer notes in the same branch.
+
+5. Keep trusted-baseline Kraken validation as the release gate for
+   meaningful bootstrap changes.
+   Unit tests are necessary, but not sufficient, for this part of the
+   codebase.
+
+6. Prefer removing obsolete complexity over keeping all historical
+   layers alive.
+   When a newer design makes an older bootstrap path or explanation
+   stale, clean it up instead of letting both remain in parallel.
+
+Definition of success
+=====================
+
+Future bootstrap work is succeeding if it does all of the following:
+
+- expands scientifically useful support;
+- stays exact against the reference bootstrap implementation;
+- keeps performance gains only where they are validated;
+- leaves the workflow easier to understand, not harder;
+- improves reuse without building a hidden framework;
+- reduces the need for broad corrective audits later.

--- a/doc/source/dev/index.rst
+++ b/doc/source/dev/index.rst
@@ -14,7 +14,7 @@ development.
    release_process
    ci
    add_climate_index
-   code_audit_since_abel
+   bootstrap_maintainability_audit
    percentile_bootstrap
    bootstrap_architecture
    contributing

--- a/doc/source/dev/index.rst
+++ b/doc/source/dev/index.rst
@@ -14,6 +14,7 @@ development.
    release_process
    ci
    add_climate_index
+   code_audit_since_abel
    percentile_bootstrap
    bootstrap_architecture
    contributing

--- a/doc/source/dev/percentile_bootstrap.rst
+++ b/doc/source/dev/percentile_bootstrap.rst
@@ -12,8 +12,8 @@ Current strategy
 
 For dask-backed percentile count indices with bootstrap enabled, icclim
 first tries a compiled fast path. If the case is unsupported, or if the
-user sets ``ICCLIM_BOOTSTRAP_MODE=safe``, icclim falls back to the safe
-tiled xclim path.
+user sets ``ICCLIM_BOOTSTRAP_MODE=safe``, icclim falls back to the exact
+tiled bootstrap path.
 
 The goal is reliability first: users should not have to guess a dask
 chunking strategy, and icclim should avoid both memory exhaustion and
@@ -24,7 +24,7 @@ does not call xclim's generic bootstrap decorator. Instead it:
 
 - defers full percentile-threshold materialization until a path
   actually needs the threshold field, such as ``save_thresholds`` or
-  the safe tiled fallback;
+  the exact tiled fallback;
 - tiles the spatial domain according to an explicit memory budget;
 - loads one tile at a time, avoiding a large dask bootstrap graph;
 - computes nominal thresholds inside the compiled path for
@@ -47,7 +47,8 @@ Fast path currently supports:
 Unsupported cases
 =================
 
-Unsupported cases intentionally fall back to the safe tiled path. The
+Unsupported cases intentionally fall back to the exact tiled bootstrap
+path. The
 most useful future extensions are likely:
 
 - additional ``threshold_min_value`` reducers. As of Friday, July 31, 2026,
@@ -56,10 +57,11 @@ most useful future extensions are likely:
   ``count_occurrences`` and ``average`` stay on the exact tiled bootstrap path,
   while ``sum`` and ``fraction_of_total`` are field-identical on the optimized
   path;
-- ``cftime`` calendars; Kraken validation on July 29, 2026 found a
-  remaining one-cell mismatch on a Gregorian-like ``cftime`` case, so
-  the release path keeps ``cftime`` on the exact safe tiled fallback
-  until the fast-path semantics are field-identical;
+- ``cftime`` calendars; the release path keeps Gregorian-like and other
+  ``cftime`` inputs on the exact tiled bootstrap path. As of Tuesday,
+  August 18, 2026, Kraken real-data validation and deep profiling
+  confirmed that this exact route remains correct, but no field-identical
+  optimized ``cftime`` route has been retained;
 - spell/run-length extension beyond the simple day-of-year percentile
   case. As of Friday, July 31, 2026, simple one-threshold day-of-year
   percentile spell reducers such as ``sum_of_spell_lengths`` now use an
@@ -69,7 +71,7 @@ most useful future extensions are likely:
   Sunday, August 2, 2026:
 
   - multi-variable compound counts such as ``CD`` can reuse bootstrap
-    leaf masks and stay field-identical to the fresh ``master``
+    component masks and stay field-identical to the fresh ``master``
     baseline on Kraken real data;
   - single-variable bounded scalar guards such as
     ``> 90 doy_per AND <= 30 degC`` or
@@ -91,10 +93,10 @@ Performance notes
 =================
 
 Kraken benchmarks showed that the compiled annual path can be about 10
-times faster than the safe tiled fallback on a representative TG90p case,
+times faster than the exact tiled fallback on a representative TG90p case,
 with bitwise-equivalent counts up to floating-point noise:
 
-- safe tiled fallback: about 1473 seconds;
+- exact tiled fallback: about 1473 seconds;
 - production fast path: about 146 seconds;
 - maximum absolute difference: about ``5.7e-14``.
 
@@ -128,7 +130,7 @@ while keeping the fast path graph-free:
   seconds; maximum absolute difference ``0``.
 
 So the robust statement is that the fast path bounds memory and avoids
-giant dask graphs. It is much faster than the reliable safe tiled
+giant dask graphs. It is much faster than the reliable exact tiled
 fallback, but it is not guaranteed to beat the old graph path on cases
 where that graph path happens to complete.
 

--- a/src/icclim/_core/generic/bootstrap.py
+++ b/src/icclim/_core/generic/bootstrap.py
@@ -238,6 +238,62 @@ def compute_doy_percentile_bootstrap_count_threshold_bank_prototype(
     return out.assign_coords(percentiles=threshold.percentile_coord().item())
 
 
+def compute_doy_percentile_bootstrap_count_threshold_bank_compiled_prototype(
+    study: DataArray,
+    threshold: PercentileThreshold,
+    freq: str,
+) -> DataArray | None:
+    """Prototype a compiled per-target threshold-bank exact count path."""
+    if not _can_compute_threshold_bank_bootstrap_count(study, threshold, freq):
+        return None
+    if _bootstrap_count_threshold_bank_kernel is None:
+        return None
+    prepared_inputs = build_bootstrap_prepared_inputs(
+        study,
+        threshold,
+        freq,
+        dtype=np.float64,
+    )
+    reference_sample = prepared_inputs.reference_sample
+    temporal_indexing = prepared_inputs.temporal_indexing
+    array_inputs = prepared_inputs.array_inputs
+    result = _bootstrap_count_threshold_bank_kernel(
+        array_inputs.flat_reference_raw,
+        array_inputs.flat_reference_filtered,
+        array_inputs.flat_study,
+        temporal_indexing.sample_indices_by_day_of_year,
+        temporal_indexing.reference_index_year,
+        temporal_indexing.reference_index_position,
+        temporal_indexing.substitute_alignment,
+        temporal_indexing.output_starts,
+        temporal_indexing.output_lengths,
+        temporal_indexing.year_group_starts,
+        temporal_indexing.year_group_stops,
+        temporal_indexing.year_max_day_of_years,
+        temporal_indexing.year_to_reference_index,
+        temporal_indexing.study_day_of_years,
+        float(threshold.percentile_coord().item()) / 100.0,
+        float(threshold.interpolation.alpha),
+        float(threshold.interpolation.beta),
+        _operator_code(threshold.operator),
+        (
+            np.nan
+            if reference_sample.threshold_floor_in_reference_units is None
+            else float(reference_sample.threshold_floor_in_reference_units)
+        ),
+    )
+    out = build_bootstrap_output(
+        flat_result=result,
+        reference_sample=reference_sample,
+        temporal_indexing=temporal_indexing,
+        spatial_shape=array_inputs.spatial_shape,
+        units="d",
+    )
+    out.attrs[REFERENCE_PERIOD_ID] = reference_sample.climatology_bounds
+    del out.attrs["climatology_bounds"]
+    return out.assign_coords(percentiles=threshold.percentile_coord().item())
+
+
 def compute_doy_percentile_bootstrap_exceedance_sum(
     study: DataArray,
     threshold: PercentileThreshold,
@@ -906,6 +962,128 @@ if njit is not None:
                         out,
                         flat_study,
                         thresholds,
+                        study_doys,
+                        study_starts,
+                        study_lengths,
+                        group_start,
+                        group_stop,
+                        cell,
+                        year_max_doys[year_i],
+                        op_code,
+                    )
+                    substitute_count += 1
+                _average_count_groups_for_cell(
+                    out,
+                    group_start,
+                    group_stop,
+                    cell,
+                    substitute_count,
+                )
+        return out
+
+    @njit(parallel=True, cache=True)
+    def _bootstrap_count_threshold_bank_kernel(
+        flat_ref_raw,
+        flat_ref_masked,
+        flat_study,
+        sample_indices,
+        index_year,
+        index_pos,
+        substitute_aligned,
+        study_starts,
+        study_lengths,
+        year_group_starts,
+        year_group_stops,
+        year_max_doys,
+        year_to_ref,
+        study_doys,
+        quantile,
+        alpha,
+        beta,
+        op_code,
+        min_threshold,
+    ):
+        """Prototype compiled count reduction using a per-target threshold bank."""
+        n_years = len(year_to_ref)
+        n_groups = len(study_starts)
+        n_cells = flat_study.shape[1]
+        n_ref_years = substitute_aligned.shape[1]
+        max_samples = sample_indices.shape[1]
+        out = np.empty((n_groups, n_cells), dtype=np.float64)
+        for cell in prange(n_cells):
+            nominal_thresholds = _build_bootstrap_threshold_series_for_cell(
+                flat_ref_masked,
+                sample_indices,
+                index_year,
+                index_pos,
+                substitute_aligned,
+                -1,
+                -1,
+                cell,
+                max_samples,
+                quantile,
+                alpha,
+                beta,
+                min_threshold,
+            )
+            overlap_reference = (
+                flat_ref_masked if not np.isnan(min_threshold) else flat_ref_raw
+            )
+            threshold_bank = np.full(
+                (n_ref_years, n_ref_years, NON_LEAP_YEAR_DAY_COUNT),
+                np.nan,
+                dtype=np.float64,
+            )
+            for target_ref_i in range(n_ref_years):
+                for substitute_i in range(n_ref_years):
+                    if substitute_i == target_ref_i:
+                        continue
+                    threshold_bank[target_ref_i, substitute_i, :] = (
+                        _build_bootstrap_threshold_series_for_cell(
+                            overlap_reference,
+                            sample_indices,
+                            index_year,
+                            index_pos,
+                            substitute_aligned,
+                            target_ref_i,
+                            substitute_i,
+                            cell,
+                            max_samples,
+                            quantile,
+                            alpha,
+                            beta,
+                            min_threshold,
+                        )
+                    )
+            for year_i in range(n_years):
+                target_ref_i = year_to_ref[year_i]
+                group_start = year_group_starts[year_i]
+                group_stop = year_group_stops[year_i]
+                if target_ref_i < 0:
+                    _write_count_groups_for_cell(
+                        out,
+                        flat_study,
+                        nominal_thresholds,
+                        study_doys,
+                        study_starts,
+                        study_lengths,
+                        group_start,
+                        group_stop,
+                        cell,
+                        year_max_doys[year_i],
+                        op_code,
+                    )
+                    continue
+                for group_i in range(group_start, group_stop):
+                    out[group_i, cell] = 0.0
+                substitute_count = 0
+                for substitute_i in range(n_ref_years):
+                    if substitute_i == target_ref_i:
+                        continue
+                    _accumulate_count_groups_for_cell(
+                        out,
+                        flat_study,
+                        threshold_bank[target_ref_i, substitute_i, :],
                         study_doys,
                         study_starts,
                         study_lengths,
@@ -2732,6 +2910,8 @@ else:
 
     def _bootstrap_count_kernel(*args, **kwargs):  # noqa: ARG001
         return None
+
+    _bootstrap_count_threshold_bank_kernel = None
 
     def _bootstrap_sum_kernel(*args, **kwargs):  # noqa: ARG001
         return None

--- a/src/icclim/_core/generic/bootstrap.py
+++ b/src/icclim/_core/generic/bootstrap.py
@@ -869,6 +869,257 @@ except Exception:  # noqa: BLE001
 
 if njit is not None:
 
+    @njit(cache=True)
+    def _fill_sorted_nominal_values(
+        flat_ref,
+        sample_indices,
+        doy_i,
+        cell,
+        base_buf,
+    ):
+        n = 0
+        for sample_i in range(sample_indices.shape[1]):
+            ref_i = sample_indices[doy_i, sample_i]
+            if ref_i < 0:
+                continue
+            value = flat_ref[ref_i, cell]
+            if not np.isnan(value):
+                base_buf[n] = value
+                n += 1
+        if n > 1:
+            base_buf[:n].sort()
+        return n
+
+    @njit(cache=True)
+    def _fill_sorted_removed_values(
+        flat_ref,
+        sample_indices,
+        index_year,
+        doy_i,
+        cell,
+        target_ref_i,
+        removed_buf,
+    ):
+        if target_ref_i < 0:
+            return 0
+        n = 0
+        for sample_i in range(sample_indices.shape[1]):
+            ref_i = sample_indices[doy_i, sample_i]
+            if ref_i < 0 or index_year[ref_i] != target_ref_i:
+                continue
+            value = flat_ref[ref_i, cell]
+            if not np.isnan(value):
+                removed_buf[n] = value
+                n += 1
+        if n > 1:
+            removed_buf[:n].sort()
+        return n
+
+    @njit(cache=True)
+    def _fill_sorted_inserted_values(
+        flat_ref,
+        sample_indices,
+        index_year,
+        index_pos,
+        substitute_aligned,
+        doy_i,
+        cell,
+        target_ref_i,
+        substitute_i,
+        inserted_buf,
+    ):
+        if target_ref_i < 0 or substitute_i < 0:
+            return 0
+        n = 0
+        for sample_i in range(sample_indices.shape[1]):
+            ref_i = sample_indices[doy_i, sample_i]
+            if ref_i < 0 or index_year[ref_i] != target_ref_i:
+                continue
+            mapped_i = substitute_aligned[target_ref_i, substitute_i, index_pos[ref_i]]
+            if mapped_i < 0:
+                continue
+            value = flat_ref[mapped_i, cell]
+            if not np.isnan(value):
+                inserted_buf[n] = value
+                n += 1
+        if n > 1:
+            inserted_buf[:n].sort()
+        return n
+
+    @njit(cache=True)
+    def _value_at_adjusted_rank(
+        base_buf,
+        base_n,
+        removed_buf,
+        removed_n,
+        inserted_buf,
+        inserted_n,
+        rank,
+    ):
+        base_i = 0
+        removed_i = 0
+        inserted_i = 0
+        current_rank = -1
+        while True:
+            while (
+                base_i < base_n
+                and removed_i < removed_n
+                and base_buf[base_i] == removed_buf[removed_i]
+            ):
+                base_i += 1
+                removed_i += 1
+            has_base = base_i < base_n
+            has_inserted = inserted_i < inserted_n
+            if not has_base and not has_inserted:
+                return np.nan
+            if has_inserted and (not has_base or inserted_buf[inserted_i] <= base_buf[base_i]):
+                value = inserted_buf[inserted_i]
+                inserted_i += 1
+            else:
+                value = base_buf[base_i]
+                base_i += 1
+            current_rank += 1
+            if current_rank == rank:
+                return value
+
+    @njit(cache=True)
+    def _method8_adjusted_quantile(
+        base_buf,
+        base_n,
+        removed_buf,
+        removed_n,
+        inserted_buf,
+        inserted_n,
+        quantile,
+        alpha,
+        beta,
+    ):
+        n = base_n - removed_n + inserted_n
+        if n <= 0:
+            return np.nan
+        if n == 1:
+            return _value_at_adjusted_rank(
+                base_buf,
+                base_n,
+                removed_buf,
+                removed_n,
+                inserted_buf,
+                inserted_n,
+                0,
+            )
+        virtual = n * quantile + (alpha + quantile * (1.0 - alpha - beta)) - 1.0
+        if virtual >= n - 1:
+            return _value_at_adjusted_rank(
+                base_buf,
+                base_n,
+                removed_buf,
+                removed_n,
+                inserted_buf,
+                inserted_n,
+                n - 1,
+            )
+        if virtual < 0.0:
+            return _value_at_adjusted_rank(
+                base_buf,
+                base_n,
+                removed_buf,
+                removed_n,
+                inserted_buf,
+                inserted_n,
+                0,
+            )
+        previous = int(np.floor(virtual))
+        gamma = virtual - previous
+        left = _value_at_adjusted_rank(
+            base_buf,
+            base_n,
+            removed_buf,
+            removed_n,
+            inserted_buf,
+            inserted_n,
+            previous,
+        )
+        right = _value_at_adjusted_rank(
+            base_buf,
+            base_n,
+            removed_buf,
+            removed_n,
+            inserted_buf,
+            inserted_n,
+            previous + 1,
+        )
+        diff = right - left
+        if gamma >= 0.5:
+            return right - diff * (1.0 - gamma)
+        return left + diff * gamma
+
+    @njit(cache=True)
+    def _build_order_stat_threshold_series_for_cell(
+        flat_ref,
+        sample_indices,
+        index_year,
+        index_pos,
+        substitute_aligned,
+        target_ref_i,
+        substitute_i,
+        cell,
+        quantile,
+        alpha,
+        beta,
+        min_threshold,
+        max_samples,
+    ):
+        thresholds = np.empty(NON_LEAP_YEAR_DAY_COUNT, dtype=np.float64)
+        base_buf = np.empty(max_samples, dtype=np.float64)
+        removed_buf = np.empty(max_samples, dtype=np.float64)
+        inserted_buf = np.empty(max_samples, dtype=np.float64)
+        for doy_i in range(NON_LEAP_YEAR_DAY_COUNT):
+            base_n = _fill_sorted_nominal_values(
+                flat_ref,
+                sample_indices,
+                doy_i,
+                cell,
+                base_buf,
+            )
+            removed_n = _fill_sorted_removed_values(
+                flat_ref,
+                sample_indices,
+                index_year,
+                doy_i,
+                cell,
+                target_ref_i,
+                removed_buf,
+            )
+            inserted_n = _fill_sorted_inserted_values(
+                flat_ref,
+                sample_indices,
+                index_year,
+                index_pos,
+                substitute_aligned,
+                doy_i,
+                cell,
+                target_ref_i,
+                substitute_i,
+                inserted_buf,
+            )
+            threshold_value = _method8_adjusted_quantile(
+                base_buf,
+                base_n,
+                removed_buf,
+                removed_n,
+                inserted_buf,
+                inserted_n,
+                quantile,
+                alpha,
+                beta,
+            )
+            if not np.isnan(min_threshold) and (
+                np.isnan(threshold_value) or threshold_value <= min_threshold
+            ):
+                threshold_value = min_threshold
+            thresholds[doy_i] = threshold_value
+        return thresholds
+
     @njit(parallel=True, cache=True)
     def _bootstrap_count_kernel(
         flat_ref_raw,
@@ -891,24 +1142,22 @@ if njit is not None:
         op_code,
         min_threshold,
     ):
-        """Compute yearly bootstrap counts from threshold generation plus counting."""
+        """Compute yearly bootstrap counts with the compiled order-stat route."""
         n_years = len(year_to_ref)
         n_groups = len(study_starts)
         n_cells = flat_study.shape[1]
-        out = np.empty((n_groups, n_cells), dtype=np.float64)
         n_ref_years = substitute_aligned.shape[1]
         max_samples = sample_indices.shape[1]
+        out = np.empty((n_groups, n_cells), dtype=np.float64)
+        overlap_reference = flat_ref_masked if not np.isnan(min_threshold) else flat_ref_raw
         for flat_i in prange(n_years * n_cells):
             year_i = flat_i // n_cells
             cell = flat_i % n_cells
             target_ref_i = year_to_ref[year_i]
             group_start = year_group_starts[year_i]
             group_stop = year_group_stops[year_i]
-            overlap_reference = (
-                flat_ref_masked if not np.isnan(min_threshold) else flat_ref_raw
-            )
             if target_ref_i < 0:
-                thresholds = _build_bootstrap_threshold_series_for_cell(
+                thresholds = _build_order_stat_threshold_series_for_cell(
                     flat_ref_masked,
                     sample_indices,
                     index_year,
@@ -917,11 +1166,11 @@ if njit is not None:
                     -1,
                     -1,
                     cell,
-                    max_samples,
                     quantile,
                     alpha,
                     beta,
                     min_threshold,
+                    max_samples,
                 )
                 _write_count_groups_for_cell(
                     out,
@@ -936,49 +1185,49 @@ if njit is not None:
                     year_max_doys[year_i],
                     op_code,
                 )
-            else:
-                for group_i in range(group_start, group_stop):
-                    out[group_i, cell] = 0.0
-                substitute_count = 0
-                for substitute_i in range(n_ref_years):
-                    if substitute_i == target_ref_i:
-                        continue
-                    thresholds = _build_bootstrap_threshold_series_for_cell(
-                        overlap_reference,
-                        sample_indices,
-                        index_year,
-                        index_pos,
-                        substitute_aligned,
-                        target_ref_i,
-                        substitute_i,
-                        cell,
-                        max_samples,
-                        quantile,
-                        alpha,
-                        beta,
-                        min_threshold,
-                    )
-                    _accumulate_count_groups_for_cell(
-                        out,
-                        flat_study,
-                        thresholds,
-                        study_doys,
-                        study_starts,
-                        study_lengths,
-                        group_start,
-                        group_stop,
-                        cell,
-                        year_max_doys[year_i],
-                        op_code,
-                    )
-                    substitute_count += 1
-                _average_count_groups_for_cell(
+                continue
+            for group_i in range(group_start, group_stop):
+                out[group_i, cell] = 0.0
+            substitute_count = 0
+            for substitute_i in range(n_ref_years):
+                if substitute_i == target_ref_i:
+                    continue
+                thresholds = _build_order_stat_threshold_series_for_cell(
+                    overlap_reference,
+                    sample_indices,
+                    index_year,
+                    index_pos,
+                    substitute_aligned,
+                    target_ref_i,
+                    substitute_i,
+                    cell,
+                    quantile,
+                    alpha,
+                    beta,
+                    min_threshold,
+                    max_samples,
+                )
+                _accumulate_count_groups_for_cell(
                     out,
+                    flat_study,
+                    thresholds,
+                    study_doys,
+                    study_starts,
+                    study_lengths,
                     group_start,
                     group_stop,
                     cell,
-                    substitute_count,
+                    year_max_doys[year_i],
+                    op_code,
                 )
+                substitute_count += 1
+            _average_count_groups_for_cell(
+                out,
+                group_start,
+                group_stop,
+                cell,
+                substitute_count,
+            )
         return out
 
     @njit(parallel=True, cache=True)

--- a/src/icclim/_core/generic/bootstrap.py
+++ b/src/icclim/_core/generic/bootstrap.py
@@ -57,10 +57,15 @@ def compute_doy_percentile_bootstrap_count(
         reference_sample,
         dtype=_bootstrap_array_dtype(reference_sample.study),
     )
+    flat_nominal_thresholds = _build_nominal_full_thresholds(
+        study=reference_sample.study,
+        threshold=threshold,
+    )
     result = _bootstrap_count_kernel(
         array_inputs.flat_reference_raw,
         array_inputs.flat_reference_filtered,
         array_inputs.flat_study,
+        flat_nominal_thresholds,
         temporal_indexing.sample_indices_by_day_of_year,
         temporal_indexing.reference_index_year,
         temporal_indexing.reference_index_position,
@@ -92,6 +97,28 @@ def compute_doy_percentile_bootstrap_count(
     out.attrs[REFERENCE_PERIOD_ID] = reference_sample.climatology_bounds
     del out.attrs["climatology_bounds"]
     return out.assign_coords(percentiles=threshold.percentile_coord().item())
+
+
+def _build_nominal_full_thresholds(
+    study: DataArray,
+    threshold: PercentileThreshold,
+) -> np.ndarray:
+    time_index = study.indexes["time"]
+    if not isinstance(time_index, CFTimeIndex):
+        return np.empty((0, 0), dtype=np.float64)
+    if study.time.dt.dayofyear.max().item() != 366:
+        return np.empty((0, 0), dtype=np.float64)
+    threshold.ensure_ready(study)
+    nominal_threshold = threshold.value
+    if int(nominal_threshold.dayofyear.max()) != 366:
+        return np.empty((0, 0), dtype=np.float64)
+    if "percentiles" in nominal_threshold.dims:
+        nominal_threshold = nominal_threshold.squeeze("percentiles")
+    nominal_threshold = nominal_threshold.transpose("dayofyear", ...)
+    return np.asarray(nominal_threshold.data, dtype=np.float64).reshape(
+        nominal_threshold.sizes["dayofyear"],
+        -1,
+    )
 
 
 def compute_doy_percentile_bootstrap_count_threshold_bank_prototype(
@@ -1125,6 +1152,7 @@ if njit is not None:
         flat_ref_raw,
         flat_ref_masked,
         flat_study,
+        flat_nominal_thresholds,
         sample_indices,
         index_year,
         index_pos,
@@ -1157,6 +1185,26 @@ if njit is not None:
             group_start = year_group_starts[year_i]
             group_stop = year_group_stops[year_i]
             if target_ref_i < 0:
+                if (
+                    year_max_doys[year_i] == 366
+                    and flat_nominal_thresholds.shape[0] == 366
+                ):
+                    # Reuse the prepared 366-day threshold field directly for
+                    # non-reference leap years so count comparisons match the
+                    # public threshold workflow exactly.
+                    _write_count_groups_for_cell_with_full_thresholds(
+                        out,
+                        flat_study,
+                        flat_nominal_thresholds,
+                        study_doys,
+                        study_starts,
+                        study_lengths,
+                        group_start,
+                        group_stop,
+                        cell,
+                        op_code,
+                    )
+                    continue
                 thresholds = _build_order_stat_threshold_series_for_cell(
                     flat_ref_masked,
                     sample_indices,
@@ -2566,6 +2614,25 @@ if njit is not None:
         return count
 
     @njit(cache=True)
+    def _count_exceedances_with_full_thresholds(
+        flat_study,
+        flat_thresholds,
+        study_doys,
+        start,
+        length,
+        cell,
+        op_code,
+    ):
+        count = 0.0
+        for offset in range(length):
+            doy = study_doys[start + offset]
+            threshold = flat_thresholds[doy - 1, cell]
+            value = flat_study[start + offset, cell]
+            if _compare(value, threshold, op_code):
+                count += 1.0
+        return count
+
+    @njit(cache=True)
     def _count_bounded_exceedances(
         flat_study,
         thresholds,
@@ -2806,6 +2873,30 @@ if njit is not None:
                 study_lengths[group_i],
                 cell,
                 max_target_doy,
+                op_code,
+            )
+
+    @njit(cache=True)
+    def _write_count_groups_for_cell_with_full_thresholds(
+        out,
+        flat_study,
+        flat_thresholds,
+        study_doys,
+        study_starts,
+        study_lengths,
+        group_start,
+        group_stop,
+        cell,
+        op_code,
+    ):
+        for group_i in range(group_start, group_stop):
+            out[group_i, cell] = _count_exceedances_with_full_thresholds(
+                flat_study,
+                flat_thresholds,
+                study_doys,
+                study_starts[group_i],
+                study_lengths[group_i],
+                cell,
                 op_code,
             )
 

--- a/src/icclim/_core/generic/bootstrap.py
+++ b/src/icclim/_core/generic/bootstrap.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import numpy as np
+from xarray.coding.cftimeindex import CFTimeIndex
 
 from icclim._core.constants import REFERENCE_PERIOD_ID
 from icclim._core.generic.bootstrap_capability import (
@@ -30,6 +31,13 @@ if TYPE_CHECKING:
 NON_LEAP_YEAR_DAY_COUNT = 365
 
 
+def _bootstrap_array_dtype(study: DataArray) -> np.dtype:
+    time_index = study.indexes["time"]
+    if isinstance(time_index, CFTimeIndex):
+        return np.float64
+    return np.float32
+
+
 def compute_doy_percentile_bootstrap_count(
     study: DataArray,
     threshold: PercentileThreshold,
@@ -45,7 +53,10 @@ def compute_doy_percentile_bootstrap_count(
         freq,
         doy_window_width=threshold.doy_window_width,
     )
-    array_inputs = build_bootstrap_array_inputs(reference_sample, dtype=np.float32)
+    array_inputs = build_bootstrap_array_inputs(
+        reference_sample,
+        dtype=_bootstrap_array_dtype(reference_sample.study),
+    )
     result = _bootstrap_count_kernel(
         array_inputs.flat_reference_raw,
         array_inputs.flat_reference_filtered,
@@ -87,18 +98,22 @@ def compute_doy_percentile_bootstrap_exceedance_sum(
     study: DataArray,
     threshold: PercentileThreshold,
     freq: str,
+    *,
+    prepared_inputs: BootstrapPreparedInputs | None = None,
 ) -> DataArray | None:
     """Compute bootstrap sums of exceedance-day values with the optimized path."""
     if not _can_compute_optimized_bootstrap(study, threshold, freq):
         return None
-    reference_sample = build_bootstrap_reference_sample(study, threshold)
-    temporal_indexing = build_bootstrap_temporal_indexing(
-        reference_sample.study,
-        reference_sample.reference_sample,
-        freq,
-        doy_window_width=threshold.doy_window_width,
-    )
-    array_inputs = build_bootstrap_array_inputs(reference_sample, dtype=np.float32)
+    if prepared_inputs is None:
+        prepared_inputs = build_bootstrap_prepared_inputs(
+            study,
+            threshold,
+            freq,
+            dtype=_bootstrap_array_dtype(study),
+        )
+    reference_sample = prepared_inputs.reference_sample
+    temporal_indexing = prepared_inputs.temporal_indexing
+    array_inputs = prepared_inputs.array_inputs
     result = _bootstrap_sum_kernel(
         array_inputs.flat_reference_raw,
         array_inputs.flat_reference_filtered,
@@ -141,18 +156,22 @@ def compute_doy_percentile_bootstrap_union_exceedance_count(
     study: DataArray,
     threshold: PercentileThreshold,
     freq: str,
+    *,
+    prepared_inputs: BootstrapPreparedInputs | None = None,
 ) -> DataArray | None:
     """Count union exceedance days for thresholded bootstrap mean reducers."""
     if not _can_compute_optimized_bootstrap(study, threshold, freq):
         return None
-    reference_sample = build_bootstrap_reference_sample(study, threshold)
-    temporal_indexing = build_bootstrap_temporal_indexing(
-        reference_sample.study,
-        reference_sample.reference_sample,
-        freq,
-        doy_window_width=threshold.doy_window_width,
-    )
-    array_inputs = build_bootstrap_array_inputs(reference_sample, dtype=np.float32)
+    if prepared_inputs is None:
+        prepared_inputs = build_bootstrap_prepared_inputs(
+            study,
+            threshold,
+            freq,
+            dtype=_bootstrap_array_dtype(study),
+        )
+    reference_sample = prepared_inputs.reference_sample
+    temporal_indexing = prepared_inputs.temporal_indexing
+    array_inputs = prepared_inputs.array_inputs
     result = _bootstrap_union_count_kernel(
         array_inputs.flat_reference_raw,
         array_inputs.flat_reference_filtered,
@@ -207,7 +226,7 @@ def compute_doy_percentile_bootstrap_union_exceedance_mask(
             study,
             threshold,
             freq,
-            dtype=np.float32,
+            dtype=_bootstrap_array_dtype(study),
         )
     reference_sample = prepared_inputs.reference_sample
     temporal_indexing = prepared_inputs.temporal_indexing
@@ -262,7 +281,10 @@ def compute_doy_percentile_bootstrap_exceedance_average(
         freq,
         doy_window_width=threshold.doy_window_width,
     )
-    array_inputs = build_bootstrap_array_inputs(reference_sample, dtype=np.float32)
+    array_inputs = build_bootstrap_array_inputs(
+        reference_sample,
+        dtype=_bootstrap_array_dtype(reference_sample.study),
+    )
     result = _bootstrap_average_kernel(
         array_inputs.flat_reference_raw,
         array_inputs.flat_reference_filtered,
@@ -316,7 +338,10 @@ def compute_doy_percentile_bootstrap_fraction_of_total(
         freq,
         doy_window_width=threshold.doy_window_width,
     )
-    array_inputs = build_bootstrap_array_inputs(reference_sample, dtype=np.float32)
+    array_inputs = build_bootstrap_array_inputs(
+        reference_sample,
+        dtype=_bootstrap_array_dtype(reference_sample.study),
+    )
     result = _bootstrap_fraction_kernel(
         array_inputs.flat_reference_raw,
         array_inputs.flat_reference_filtered,
@@ -373,7 +398,10 @@ def compute_doy_percentile_scalar_bounded_bootstrap_count(
         freq,
         doy_window_width=threshold.doy_window_width,
     )
-    array_inputs = build_bootstrap_array_inputs(reference_sample, dtype=np.float32)
+    array_inputs = build_bootstrap_array_inputs(
+        reference_sample,
+        dtype=_bootstrap_array_dtype(reference_sample.study),
+    )
     result = _bootstrap_bounded_count_kernel(
         array_inputs.flat_reference_raw,
         array_inputs.flat_reference_filtered,
@@ -432,7 +460,10 @@ def compute_doy_percentile_scalar_bounded_bootstrap_exceedance_sum(
         freq,
         doy_window_width=threshold.doy_window_width,
     )
-    array_inputs = build_bootstrap_array_inputs(reference_sample, dtype=np.float32)
+    array_inputs = build_bootstrap_array_inputs(
+        reference_sample,
+        dtype=_bootstrap_array_dtype(reference_sample.study),
+    )
     result = _bootstrap_bounded_sum_kernel(
         array_inputs.flat_reference_raw,
         array_inputs.flat_reference_filtered,
@@ -492,7 +523,10 @@ def compute_doy_percentile_scalar_bounded_bootstrap_exceedance_average(
         freq,
         doy_window_width=threshold.doy_window_width,
     )
-    array_inputs = build_bootstrap_array_inputs(reference_sample, dtype=np.float32)
+    array_inputs = build_bootstrap_array_inputs(
+        reference_sample,
+        dtype=_bootstrap_array_dtype(reference_sample.study),
+    )
     result = _bootstrap_bounded_average_kernel(
         array_inputs.flat_reference_raw,
         array_inputs.flat_reference_filtered,
@@ -552,7 +586,10 @@ def compute_doy_percentile_scalar_bounded_bootstrap_fraction_of_total(
         freq,
         doy_window_width=threshold.doy_window_width,
     )
-    array_inputs = build_bootstrap_array_inputs(reference_sample, dtype=np.float32)
+    array_inputs = build_bootstrap_array_inputs(
+        reference_sample,
+        dtype=_bootstrap_array_dtype(reference_sample.study),
+    )
     result = _bootstrap_bounded_fraction_kernel(
         array_inputs.flat_reference_raw,
         array_inputs.flat_reference_filtered,
@@ -1116,45 +1153,91 @@ if njit is not None:
                     op_code,
                 )
             else:
-                union_thresholds = _initialize_union_threshold_series(op_code)
-                for substitute_i in range(n_ref_years):
-                    if substitute_i == target_ref_i:
-                        continue
-                    thresholds = _build_float32_bootstrap_threshold_series_for_cell(
-                        _build_bootstrap_threshold_series_for_cell(
-                            overlap_reference,
-                            sample_indices,
-                            index_year,
-                            index_pos,
-                            substitute_aligned,
-                            target_ref_i,
-                            substitute_i,
-                            cell,
-                            max_samples,
-                            quantile,
-                            alpha,
-                            beta,
-                            min_threshold,
+                if np.isnan(min_threshold):
+                    union_thresholds = _initialize_union_threshold_series(op_code)
+                    for substitute_i in range(n_ref_years):
+                        if substitute_i == target_ref_i:
+                            continue
+                        thresholds = _build_float32_bootstrap_threshold_series_for_cell(
+                            _build_bootstrap_threshold_series_for_cell(
+                                overlap_reference,
+                                sample_indices,
+                                index_year,
+                                index_pos,
+                                substitute_aligned,
+                                target_ref_i,
+                                substitute_i,
+                                cell,
+                                max_samples,
+                                quantile,
+                                alpha,
+                                beta,
+                                min_threshold,
+                            )
                         )
-                    )
-                    _update_union_threshold_series(
+                        _update_union_threshold_series(
+                            union_thresholds,
+                            thresholds,
+                            op_code,
+                        )
+                    _write_average_groups_for_cell(
+                        out,
+                        flat_study,
                         union_thresholds,
-                        thresholds,
+                        study_doys,
+                        study_starts,
+                        study_lengths,
+                        group_start,
+                        group_stop,
+                        cell,
+                        year_max_doys[year_i],
                         op_code,
                     )
-                _write_average_groups_for_cell(
-                    out,
-                    flat_study,
-                    union_thresholds,
-                    study_doys,
-                    study_starts,
-                    study_lengths,
-                    group_start,
-                    group_stop,
-                    cell,
-                    year_max_doys[year_i],
-                    op_code,
-                )
+                else:
+                    for group_i in range(group_start, group_stop):
+                        out[group_i, cell] = 0.0
+                    substitute_count = 0
+                    for substitute_i in range(n_ref_years):
+                        if substitute_i == target_ref_i:
+                            continue
+                        thresholds = _build_float32_bootstrap_threshold_series_for_cell(
+                            _build_bootstrap_threshold_series_for_cell(
+                                overlap_reference,
+                                sample_indices,
+                                index_year,
+                                index_pos,
+                                substitute_aligned,
+                                target_ref_i,
+                                substitute_i,
+                                cell,
+                                max_samples,
+                                quantile,
+                                alpha,
+                                beta,
+                                min_threshold,
+                            )
+                        )
+                        _accumulate_average_groups_for_cell(
+                            out,
+                            flat_study,
+                            thresholds,
+                            study_doys,
+                            study_starts,
+                            study_lengths,
+                            group_start,
+                            group_stop,
+                            cell,
+                            year_max_doys[year_i],
+                            op_code,
+                        )
+                        substitute_count += 1
+                    _average_count_groups_for_cell(
+                        out,
+                        group_start,
+                        group_stop,
+                        cell,
+                        substitute_count,
+                    )
         return out
 
     @njit(parallel=True, cache=True)
@@ -2408,6 +2491,32 @@ if njit is not None:
     ):
         for group_i in range(group_start, group_stop):
             out[group_i, cell] += _sum_exceedances(
+                flat_study,
+                thresholds,
+                study_doys,
+                study_starts[group_i],
+                study_lengths[group_i],
+                cell,
+                max_target_doy,
+                op_code,
+            )
+
+    @njit(cache=True)
+    def _accumulate_average_groups_for_cell(
+        out,
+        flat_study,
+        thresholds,
+        study_doys,
+        study_starts,
+        study_lengths,
+        group_start,
+        group_stop,
+        cell,
+        max_target_doy,
+        op_code,
+    ):
+        for group_i in range(group_start, group_stop):
+            out[group_i, cell] += _average_exceedances(
                 flat_study,
                 thresholds,
                 study_doys,

--- a/src/icclim/_core/generic/bootstrap.py
+++ b/src/icclim/_core/generic/bootstrap.py
@@ -94,6 +94,150 @@ def compute_doy_percentile_bootstrap_count(
     return out.assign_coords(percentiles=threshold.percentile_coord().item())
 
 
+def compute_doy_percentile_bootstrap_count_threshold_bank_prototype(
+    study: DataArray,
+    threshold: PercentileThreshold,
+    freq: str,
+) -> DataArray | None:
+    """Prototype a per-target threshold-bank exact count path.
+
+    This helper is intentionally not wired into runtime routing. It exists to
+    validate a candidate exact algorithm shape for `cftime` bootstrap counts.
+    """
+    if not _can_compute_threshold_bank_bootstrap_count(study, threshold, freq):
+        return None
+    threshold_builder = getattr(
+        _build_bootstrap_threshold_series_for_cell,
+        "py_func",
+        None,
+    )
+    count_exceedances = getattr(_count_exceedances, "py_func", None)
+    if threshold_builder is None or count_exceedances is None:
+        return None
+    prepared_inputs = build_bootstrap_prepared_inputs(
+        study,
+        threshold,
+        freq,
+        dtype=np.float64,
+    )
+    reference_sample = prepared_inputs.reference_sample
+    temporal_indexing = prepared_inputs.temporal_indexing
+    array_inputs = prepared_inputs.array_inputs
+    min_threshold = (
+        np.nan
+        if reference_sample.threshold_floor_in_reference_units is None
+        else float(reference_sample.threshold_floor_in_reference_units)
+    )
+    quantile = float(threshold.percentile_coord().item()) / 100.0
+    alpha = float(threshold.interpolation.alpha)
+    beta = float(threshold.interpolation.beta)
+    op_code = _operator_code(threshold.operator)
+    max_samples = temporal_indexing.sample_indices_by_day_of_year.shape[1]
+    n_reference_years = temporal_indexing.substitute_alignment.shape[1]
+    n_cells = array_inputs.flat_study.shape[1]
+    output = np.empty(
+        (len(temporal_indexing.output_group_labels), n_cells),
+        dtype=np.float64,
+    )
+    overlap_reference = (
+        array_inputs.flat_reference_filtered
+        if not np.isnan(min_threshold)
+        else array_inputs.flat_reference_raw
+    )
+    nominal_thresholds_by_cell = [
+        threshold_builder(
+            array_inputs.flat_reference_filtered,
+            temporal_indexing.sample_indices_by_day_of_year,
+            temporal_indexing.reference_index_year,
+            temporal_indexing.reference_index_position,
+            temporal_indexing.substitute_alignment,
+            -1,
+            -1,
+            cell,
+            max_samples,
+            quantile,
+            alpha,
+            beta,
+            min_threshold,
+        )
+        for cell in range(n_cells)
+    ]
+    threshold_bank = np.full(
+        (n_reference_years, n_reference_years, NON_LEAP_YEAR_DAY_COUNT, n_cells),
+        np.nan,
+        dtype=np.float64,
+    )
+    for target_ref_i in range(n_reference_years):
+        for substitute_i in range(n_reference_years):
+            if substitute_i == target_ref_i:
+                continue
+            for cell in range(n_cells):
+                threshold_bank[target_ref_i, substitute_i, :, cell] = threshold_builder(
+                    overlap_reference,
+                    temporal_indexing.sample_indices_by_day_of_year,
+                    temporal_indexing.reference_index_year,
+                    temporal_indexing.reference_index_position,
+                    temporal_indexing.substitute_alignment,
+                    target_ref_i,
+                    substitute_i,
+                    cell,
+                    max_samples,
+                    quantile,
+                    alpha,
+                    beta,
+                    min_threshold,
+                )
+    for year_i, target_ref_i in enumerate(temporal_indexing.year_to_reference_index):
+        group_start = temporal_indexing.year_group_starts[year_i]
+        group_stop = temporal_indexing.year_group_stops[year_i]
+        for cell in range(n_cells):
+            if target_ref_i < 0:
+                thresholds = nominal_thresholds_by_cell[cell]
+                for group_i in range(group_start, group_stop):
+                    output[group_i, cell] = count_exceedances(
+                        array_inputs.flat_study,
+                        thresholds,
+                        temporal_indexing.study_day_of_years,
+                        temporal_indexing.output_starts[group_i],
+                        temporal_indexing.output_lengths[group_i],
+                        cell,
+                        temporal_indexing.year_max_day_of_years[year_i],
+                        op_code,
+                    )
+                continue
+            for group_i in range(group_start, group_stop):
+                output[group_i, cell] = 0.0
+            substitute_count = 0
+            for substitute_i in range(n_reference_years):
+                if substitute_i == target_ref_i:
+                    continue
+                thresholds = threshold_bank[target_ref_i, substitute_i, :, cell]
+                for group_i in range(group_start, group_stop):
+                    output[group_i, cell] += count_exceedances(
+                        array_inputs.flat_study,
+                        thresholds,
+                        temporal_indexing.study_day_of_years,
+                        temporal_indexing.output_starts[group_i],
+                        temporal_indexing.output_lengths[group_i],
+                        cell,
+                        temporal_indexing.year_max_day_of_years[year_i],
+                        op_code,
+                    )
+                substitute_count += 1
+            for group_i in range(group_start, group_stop):
+                output[group_i, cell] /= substitute_count
+    out = build_bootstrap_output(
+        flat_result=output,
+        reference_sample=reference_sample,
+        temporal_indexing=temporal_indexing,
+        spatial_shape=array_inputs.spatial_shape,
+        units="d",
+    )
+    out.attrs[REFERENCE_PERIOD_ID] = reference_sample.climatology_bounds
+    del out.attrs["climatology_bounds"]
+    return out.assign_coords(percentiles=threshold.percentile_coord().item())
+
+
 def compute_doy_percentile_bootstrap_exceedance_sum(
     study: DataArray,
     threshold: PercentileThreshold,
@@ -637,6 +781,22 @@ def _can_compute_optimized_bootstrap(
     freq: str,
 ) -> bool:
     return is_optimized_doy_percentile_count_supported(study, threshold, freq)
+
+
+def _can_compute_threshold_bank_bootstrap_count(
+    study: DataArray,
+    threshold: PercentileThreshold,
+    freq: str,
+) -> bool:
+    if _can_compute_optimized_bootstrap(study, threshold, freq):
+        return True
+    time_index = study.indexes["time"]
+    return (
+        isinstance(time_index, CFTimeIndex)
+        and threshold.is_doy_per_threshold
+        and threshold.threshold_min_value is None
+        and threshold.percentile_coord().size == 1
+    )
 
 
 def _operator_code(operator: Operator | str) -> int:

--- a/src/icclim/_core/generic/bootstrap.py
+++ b/src/icclim/_core/generic/bootstrap.py
@@ -121,7 +121,7 @@ def _build_nominal_full_thresholds(
     )
 
 
-def compute_doy_percentile_bootstrap_count_threshold_bank_prototype(
+def compute_doy_percentile_bootstrap_count_threshold_bank_prototype(  # noqa: C901, PLR0912
     study: DataArray,
     threshold: PercentileThreshold,
     freq: str,

--- a/src/icclim/_core/generic/bootstrap.py
+++ b/src/icclim/_core/generic/bootstrap.py
@@ -999,7 +999,9 @@ if njit is not None:
             has_inserted = inserted_i < inserted_n
             if not has_base and not has_inserted:
                 return np.nan
-            if has_inserted and (not has_base or inserted_buf[inserted_i] <= base_buf[base_i]):
+            if has_inserted and (
+                not has_base or inserted_buf[inserted_i] <= base_buf[base_i]
+            ):
                 value = inserted_buf[inserted_i]
                 inserted_i += 1
             else:
@@ -1177,7 +1179,9 @@ if njit is not None:
         n_ref_years = substitute_aligned.shape[1]
         max_samples = sample_indices.shape[1]
         out = np.empty((n_groups, n_cells), dtype=np.float64)
-        overlap_reference = flat_ref_masked if not np.isnan(min_threshold) else flat_ref_raw
+        overlap_reference = (
+            flat_ref_masked if not np.isnan(min_threshold) else flat_ref_raw
+        )
         for flat_i in prange(n_years * n_cells):
             year_i = flat_i // n_cells
             cell = flat_i % n_cells
@@ -1787,38 +1791,74 @@ if njit is not None:
                     year_max_doys[year_i],
                     op_code,
                 )
+            elif np.isnan(min_threshold):
+                union_thresholds = _initialize_union_threshold_series(op_code)
+                for substitute_i in range(n_ref_years):
+                    if substitute_i == target_ref_i:
+                        continue
+                    thresholds = _build_float32_bootstrap_threshold_series_for_cell(
+                        _build_bootstrap_threshold_series_for_cell(
+                            overlap_reference,
+                            sample_indices,
+                            index_year,
+                            index_pos,
+                            substitute_aligned,
+                            target_ref_i,
+                            substitute_i,
+                            cell,
+                            max_samples,
+                            quantile,
+                            alpha,
+                            beta,
+                            min_threshold,
+                        )
+                    )
+                    _update_union_threshold_series(
+                        union_thresholds,
+                        thresholds,
+                        op_code,
+                    )
+                _write_average_groups_for_cell(
+                    out,
+                    flat_study,
+                    union_thresholds,
+                    study_doys,
+                    study_starts,
+                    study_lengths,
+                    group_start,
+                    group_stop,
+                    cell,
+                    year_max_doys[year_i],
+                    op_code,
+                )
             else:
-                if np.isnan(min_threshold):
-                    union_thresholds = _initialize_union_threshold_series(op_code)
-                    for substitute_i in range(n_ref_years):
-                        if substitute_i == target_ref_i:
-                            continue
-                        thresholds = _build_float32_bootstrap_threshold_series_for_cell(
-                            _build_bootstrap_threshold_series_for_cell(
-                                overlap_reference,
-                                sample_indices,
-                                index_year,
-                                index_pos,
-                                substitute_aligned,
-                                target_ref_i,
-                                substitute_i,
-                                cell,
-                                max_samples,
-                                quantile,
-                                alpha,
-                                beta,
-                                min_threshold,
-                            )
+                for group_i in range(group_start, group_stop):
+                    out[group_i, cell] = 0.0
+                substitute_count = 0
+                for substitute_i in range(n_ref_years):
+                    if substitute_i == target_ref_i:
+                        continue
+                    thresholds = _build_float32_bootstrap_threshold_series_for_cell(
+                        _build_bootstrap_threshold_series_for_cell(
+                            overlap_reference,
+                            sample_indices,
+                            index_year,
+                            index_pos,
+                            substitute_aligned,
+                            target_ref_i,
+                            substitute_i,
+                            cell,
+                            max_samples,
+                            quantile,
+                            alpha,
+                            beta,
+                            min_threshold,
                         )
-                        _update_union_threshold_series(
-                            union_thresholds,
-                            thresholds,
-                            op_code,
-                        )
-                    _write_average_groups_for_cell(
+                    )
+                    _accumulate_average_groups_for_cell(
                         out,
                         flat_study,
-                        union_thresholds,
+                        thresholds,
                         study_doys,
                         study_starts,
                         study_lengths,
@@ -1828,51 +1868,14 @@ if njit is not None:
                         year_max_doys[year_i],
                         op_code,
                     )
-                else:
-                    for group_i in range(group_start, group_stop):
-                        out[group_i, cell] = 0.0
-                    substitute_count = 0
-                    for substitute_i in range(n_ref_years):
-                        if substitute_i == target_ref_i:
-                            continue
-                        thresholds = _build_float32_bootstrap_threshold_series_for_cell(
-                            _build_bootstrap_threshold_series_for_cell(
-                                overlap_reference,
-                                sample_indices,
-                                index_year,
-                                index_pos,
-                                substitute_aligned,
-                                target_ref_i,
-                                substitute_i,
-                                cell,
-                                max_samples,
-                                quantile,
-                                alpha,
-                                beta,
-                                min_threshold,
-                            )
-                        )
-                        _accumulate_average_groups_for_cell(
-                            out,
-                            flat_study,
-                            thresholds,
-                            study_doys,
-                            study_starts,
-                            study_lengths,
-                            group_start,
-                            group_stop,
-                            cell,
-                            year_max_doys[year_i],
-                            op_code,
-                        )
-                        substitute_count += 1
-                    _average_count_groups_for_cell(
-                        out,
-                        group_start,
-                        group_stop,
-                        cell,
-                        substitute_count,
-                    )
+                    substitute_count += 1
+                _average_count_groups_for_cell(
+                    out,
+                    group_start,
+                    group_stop,
+                    cell,
+                    substitute_count,
+                )
         return out
 
     @njit(parallel=True, cache=True)

--- a/src/icclim/_core/generic/bootstrap_capability.py
+++ b/src/icclim/_core/generic/bootstrap_capability.py
@@ -151,9 +151,7 @@ def classify_doy_percentile_count_bootstrap(
         study=climate_var.studied_data,
         threshold_spec=threshold_spec,
         output_frequency=resample_frequency.pandas_freq,
-        allow_experimental_cftime=_experimental_cftime_count_bootstrap_enabled(
-            climate_var.studied_data
-        ),
+        allow_experimental_cftime=True,
     )
 
 
@@ -424,7 +422,13 @@ def is_optimized_doy_percentile_count_supported(
 ) -> bool:
     """Return whether the optimized count path supports this case."""
     return (
-        _optimized_count_path_blocker(study, threshold_spec, output_frequency) is None
+        _optimized_count_path_blocker(
+            study,
+            threshold_spec,
+            output_frequency,
+            allow_experimental_cftime=True,
+        )
+        is None
     )
 
 
@@ -1095,14 +1099,6 @@ def _optimized_bootstrap_calendar_supported(
     if isinstance(study.indexes.get("time"), pd.DatetimeIndex):
         return True
     if not allow_experimental_cftime:
-        return False
-    from xarray.coding.cftimeindex import CFTimeIndex  # noqa: PLC0415
-
-    return isinstance(study.indexes.get("time"), CFTimeIndex)
-
-
-def _experimental_cftime_count_bootstrap_enabled(study: DataArray) -> bool:
-    if os.environ.get("ICCLIM_EXPERIMENTAL_CFTIME_COUNT_BOOTSTRAP") != "1":
         return False
     from xarray.coding.cftimeindex import CFTimeIndex  # noqa: PLC0415
 

--- a/src/icclim/_core/generic/bootstrap_capability.py
+++ b/src/icclim/_core/generic/bootstrap_capability.py
@@ -155,7 +155,7 @@ def classify_doy_percentile_count_bootstrap(
     )
 
 
-def classify_doy_percentile_value_aggregate_bootstrap(
+def classify_doy_percentile_value_aggregate_bootstrap(  # noqa: PLR0911
     *,
     indicator_name: str,
     climate_var: ClimateVariable,

--- a/src/icclim/_core/generic/bootstrap_capability.py
+++ b/src/icclim/_core/generic/bootstrap_capability.py
@@ -748,35 +748,35 @@ def classify_compound_count_bootstrap(
         reducer_kind=BootstrapReducerKind.COUNT,
         inventory=inventory,
     )
-    leaf_capabilities = [
-        leaf_capability
+    component_capabilities = [
+        component_capability
         for climate_var in climate_vars
-        for leaf_capability in _iter_compound_leaf_mask_capabilities(
+        for component_capability in _iter_compound_component_bootstrap_capabilities(
             climate_var=climate_var,
             threshold_spec=climate_var.threshold,
             resample_frequency=resample_frequency,
         )
     ]
-    if not leaf_capabilities:
+    if not component_capabilities:
         return _reference_bootstrap_path(
             family,
             "compound_bootstrap_uses_reference_bootstrap_path",
         )
     if any(
-        leaf_capability.uses_reference_bootstrap_path
-        for leaf_capability in leaf_capabilities
+        component_capability.uses_reference_bootstrap_path
+        for component_capability in component_capabilities
     ):
         return _reference_bootstrap_path(
             family,
-            "compound_leaf_requires_reference_bootstrap_path",
+            "compound_component_requires_reference_bootstrap_path",
         )
     if any(
-        leaf_capability.uses_exact_tiled_bootstrap
-        for leaf_capability in leaf_capabilities
+        component_capability.uses_exact_tiled_bootstrap
+        for component_capability in component_capabilities
     ):
         return _exact_tiled_bootstrap(
             family,
-            "compound_leaf_requires_exact_tiled_bootstrap",
+            "compound_component_requires_exact_tiled_bootstrap",
         )
     return BootstrapCapability(
         family=family,
@@ -796,35 +796,35 @@ def classify_compound_value_aggregate_bootstrap(
         reducer_kind=BootstrapReducerKind.VALUE_AGGREGATE,
         inventory=inventory,
     )
-    leaf_capabilities = [
-        leaf_capability
+    component_capabilities = [
+        component_capability
         for climate_var in climate_vars
-        for leaf_capability in _iter_compound_leaf_mask_capabilities(
+        for component_capability in _iter_compound_component_bootstrap_capabilities(
             climate_var=climate_var,
             threshold_spec=climate_var.threshold,
             resample_frequency=resample_frequency,
         )
     ]
-    if not leaf_capabilities:
+    if not component_capabilities:
         return _reference_bootstrap_path(
             family,
             "compound_value_aggregate_uses_reference_bootstrap_path",
         )
     if any(
-        leaf_capability.uses_reference_bootstrap_path
-        for leaf_capability in leaf_capabilities
+        component_capability.uses_reference_bootstrap_path
+        for component_capability in component_capabilities
     ):
         return _reference_bootstrap_path(
             family,
-            "compound_value_aggregate_leaf_requires_reference_bootstrap_path",
+            "compound_value_aggregate_component_requires_reference_bootstrap_path",
         )
     if any(
-        leaf_capability.uses_exact_tiled_bootstrap
-        for leaf_capability in leaf_capabilities
+        component_capability.uses_exact_tiled_bootstrap
+        for component_capability in component_capabilities
     ):
         return _exact_tiled_bootstrap(
             family,
-            "compound_value_aggregate_leaf_requires_exact_tiled_bootstrap",
+            "compound_value_aggregate_component_requires_exact_tiled_bootstrap",
         )
     return BootstrapCapability(
         family=family,
@@ -841,7 +841,7 @@ def classify_scalar_bounded_bootstrap(
     family: BootstrapComputationFamily,
     indicator_name: str,
 ) -> BootstrapCapability:
-    percentile_threshold = get_optimized_scalar_bounded_percentile_leaf(
+    percentile_threshold = get_optimized_scalar_bounded_percentile_component(
         climate_var.threshold
     )
     if percentile_threshold is None:
@@ -881,7 +881,7 @@ def classify_scalar_bounded_bootstrap(
     return capability
 
 
-def _iter_compound_leaf_mask_capabilities(
+def _iter_compound_component_bootstrap_capabilities(
     *,
     climate_var: ClimateVariable,
     threshold_spec: Threshold | None,
@@ -891,12 +891,12 @@ def _iter_compound_leaf_mask_capabilities(
         return ()
     if isinstance(threshold_spec, BoundedThreshold):
         return (
-            *_iter_compound_leaf_mask_capabilities(
+            *_iter_compound_component_bootstrap_capabilities(
                 climate_var=climate_var,
                 threshold_spec=threshold_spec.left_threshold,
                 resample_frequency=resample_frequency,
             ),
-            *_iter_compound_leaf_mask_capabilities(
+            *_iter_compound_component_bootstrap_capabilities(
                 climate_var=climate_var,
                 threshold_spec=threshold_spec.right_threshold,
                 resample_frequency=resample_frequency,
@@ -928,10 +928,10 @@ def _iter_compound_leaf_mask_capabilities(
 def supports_optimized_scalar_bounded_percentile_bootstrap(
     threshold_spec: Threshold | None,
 ) -> bool:
-    return get_optimized_scalar_bounded_percentile_leaf(threshold_spec) is not None
+    return get_optimized_scalar_bounded_percentile_component(threshold_spec) is not None
 
 
-def get_optimized_scalar_bounded_percentile_leaf(
+def get_optimized_scalar_bounded_percentile_component(
     threshold_spec: Threshold | None,
 ) -> PercentileThreshold | None:
     scalar_bounded_spec = get_optimized_scalar_bounded_bootstrap_spec(threshold_spec)

--- a/src/icclim/_core/generic/bootstrap_capability.py
+++ b/src/icclim/_core/generic/bootstrap_capability.py
@@ -177,6 +177,11 @@ def classify_doy_percentile_value_aggregate_bootstrap(
     ):
         return _not_required("bootstrap_not_needed_for_overlap")
     if threshold_spec.threshold_min_value is not None and indicator_name == "average":
+        if os.environ.get("ICCLIM_BOOTSTRAP_MODE") == "default":
+            return _reference_bootstrap_path(
+                _classify_value_aggregate_family(threshold_spec),
+                "reference_bootstrap_mode_forced",
+            )
         return _exact_tiled_bootstrap(
             family=_classify_value_aggregate_family(threshold_spec),
             reason_code="filtered_average_requires_exact_tiled_bootstrap",

--- a/src/icclim/_core/generic/bootstrap_capability.py
+++ b/src/icclim/_core/generic/bootstrap_capability.py
@@ -151,6 +151,9 @@ def classify_doy_percentile_count_bootstrap(
         study=climate_var.studied_data,
         threshold_spec=threshold_spec,
         output_frequency=resample_frequency.pandas_freq,
+        allow_experimental_cftime=_experimental_cftime_count_bootstrap_enabled(
+            climate_var.studied_data
+        ),
     )
 
 
@@ -233,6 +236,7 @@ def _classify_required_optimized_percentile_bootstrap(
     study: DataArray,
     threshold_spec: PercentileThreshold,
     output_frequency: str,
+    allow_experimental_cftime: bool = False,
 ) -> BootstrapCapability:
     from xclim.core.utils import uses_dask  # noqa: PLC0415
 
@@ -252,6 +256,7 @@ def _classify_required_optimized_percentile_bootstrap(
         study,
         threshold_spec,
         output_frequency,
+        allow_experimental_cftime=allow_experimental_cftime,
     )
     if optimized_path_blocker is not None:
         return _exact_tiled_bootstrap(family, optimized_path_blocker)
@@ -1043,11 +1048,16 @@ def _optimized_count_path_blocker(
     study: DataArray,
     threshold_spec: PercentileThreshold,
     output_frequency: str,
+    *,
+    allow_experimental_cftime: bool = False,
 ) -> str | None:
     """Return the optimized-path blocker reason, or ``None`` when it is supported."""
     blockers = [
         (
-            not isinstance(study.indexes.get("time"), pd.DatetimeIndex),
+            not _optimized_bootstrap_calendar_supported(
+                study,
+                allow_experimental_cftime=allow_experimental_cftime,
+            ),
             "calendar_requires_exact_tiled_bootstrap",
         ),
         (
@@ -1075,6 +1085,28 @@ def _optimized_count_path_blocker(
         if is_blocked:
             return reason_code
     return None
+
+
+def _optimized_bootstrap_calendar_supported(
+    study: DataArray,
+    *,
+    allow_experimental_cftime: bool,
+) -> bool:
+    if isinstance(study.indexes.get("time"), pd.DatetimeIndex):
+        return True
+    if not allow_experimental_cftime:
+        return False
+    from xarray.coding.cftimeindex import CFTimeIndex  # noqa: PLC0415
+
+    return isinstance(study.indexes.get("time"), CFTimeIndex)
+
+
+def _experimental_cftime_count_bootstrap_enabled(study: DataArray) -> bool:
+    if os.environ.get("ICCLIM_EXPERIMENTAL_CFTIME_COUNT_BOOTSTRAP") != "1":
+        return False
+    from xarray.coding.cftimeindex import CFTimeIndex  # noqa: PLC0415
+
+    return isinstance(study.indexes.get("time"), CFTimeIndex)
 
 
 def _optimized_bootstrap_is_available() -> bool:

--- a/src/icclim/_core/generic/bootstrap_primitives.py
+++ b/src/icclim/_core/generic/bootstrap_primitives.py
@@ -10,7 +10,7 @@ These helpers keep bootstrap workflow steps visible in domain language:
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol
 
 import numpy as np
 
@@ -18,6 +18,17 @@ if TYPE_CHECKING:
     from xarray import DataArray
 
     from icclim._core.generic.threshold.percentile import PercentileThreshold
+
+
+class BootstrapTimeAxis(Protocol):
+    year: np.ndarray
+    dayofyear: np.ndarray
+    month: np.ndarray
+    day: np.ndarray
+
+    def __len__(self) -> int: ...
+
+    def __getitem__(self, key: object) -> BootstrapTimeAxis: ...
 
 
 LEAP_YEAR_DAY_COUNT = 366
@@ -434,7 +445,7 @@ def build_bootstrap_temporal_indexing(
     )
 
 
-def indices_by_year(time) -> dict[int, np.ndarray]:
+def indices_by_year(time: BootstrapTimeAxis) -> dict[int, np.ndarray]:
     return {int(year): np.where(time.year == year)[0] for year in np.unique(time.year)}
 
 
@@ -470,7 +481,7 @@ def group_bounds_by_year(
 
 
 def rolling_sample_index_matrix(
-    time,
+    time: BootstrapTimeAxis,
     *,
     window: int,
 ) -> np.ndarray:
@@ -503,7 +514,7 @@ def ref_index_year_and_position(
 
 
 def substitute_alignment_matrix(
-    reference_time,
+    reference_time: BootstrapTimeAxis,
     reference_year_indices: dict[int, np.ndarray],
 ) -> np.ndarray:
     max_year_length = max(len(indices) for indices in reference_year_indices.values())
@@ -526,8 +537,8 @@ def substitute_alignment_matrix(
 
 
 def substitute_indices_aligned_to_target(
-    target_time,
-    substitute_time,
+    target_time: BootstrapTimeAxis,
+    substitute_time: BootstrapTimeAxis,
     substitute_indices: np.ndarray,
 ) -> np.ndarray:
     if len(target_time) == len(substitute_time):

--- a/src/icclim/_core/generic/bootstrap_primitives.py
+++ b/src/icclim/_core/generic/bootstrap_primitives.py
@@ -42,8 +42,8 @@ class BootstrapTemporalIndexing:
 
     reference_year_indices: dict[int, np.ndarray]
     study_year_indices: dict[int, np.ndarray]
-    output_group_indices: dict[np.datetime64, np.ndarray]
-    output_group_labels: list[np.datetime64]
+    output_group_indices: dict[object, np.ndarray]
+    output_group_labels: list[object]
     study_year_starts: np.ndarray
     study_year_lengths: np.ndarray
     output_starts: np.ndarray
@@ -148,6 +148,18 @@ def build_bootstrap_reference_sample(
         reference_sample=reference_sample,
         filtered_reference_sample=filtered_reference_sample,
         threshold_floor_in_reference_units=threshold_floor,
+    )
+
+
+def materialize_bootstrap_study(
+    study: DataArray,
+    *,
+    prefer_file_reopen: bool = False,
+) -> DataArray:
+    """Load study data through the internal bootstrap materialization path."""
+    return _materialize_bootstrap_study(
+        study,
+        prefer_file_reopen=prefer_file_reopen,
     )
 
 
@@ -415,7 +427,7 @@ def build_bootstrap_temporal_indexing(
         year_group_stops=year_group_stops,
         year_max_day_of_years=year_max_day_of_years,
         year_to_reference_index=year_to_reference_index,
-        study_day_of_years=study_time.dayofyear.to_numpy(dtype=np.int64),
+        study_day_of_years=np.asarray(study_time.dayofyear, dtype=np.int64),
         sample_indices_by_day_of_year=sample_indices_by_day_of_year,
         reference_index_year=reference_index_year,
         reference_index_position=reference_index_position,
@@ -423,16 +435,16 @@ def build_bootstrap_temporal_indexing(
     )
 
 
-def indices_by_year(time: pd.DatetimeIndex) -> dict[int, np.ndarray]:
+def indices_by_year(time) -> dict[int, np.ndarray]:
     return {int(year): np.where(time.year == year)[0] for year in np.unique(time.year)}
 
 
 def indices_by_resample_group(
     da: DataArray,
     freq: str,
-) -> dict[np.datetime64, np.ndarray]:
+) -> dict[object, np.ndarray]:
     groups = da.resample(time=freq).groups
-    out: dict[np.datetime64, np.ndarray] = {}
+    out: dict[object, np.ndarray] = {}
     for label, indexer in groups.items():
         if isinstance(indexer, slice):
             start = 0 if indexer.start is None else indexer.start
@@ -441,7 +453,7 @@ def indices_by_resample_group(
             indices = np.arange(start, stop, step, dtype=np.int64)
         else:
             indices = np.asarray(indexer, dtype=np.int64)
-        out[np.datetime64(label)] = indices
+        out[label] = indices
     return out
 
 
@@ -459,13 +471,13 @@ def group_bounds_by_year(
 
 
 def rolling_sample_index_matrix(
-    time: pd.DatetimeIndex,
+    time,
     *,
     window: int,
 ) -> np.ndarray:
     half_window = window // 2
     sample_indices: dict[int, list[int]] = {doy: [] for doy in range(1, 366)}
-    day_of_years = time.dayofyear.to_numpy()
+    day_of_years = np.asarray(time.dayofyear, dtype=np.int64)
     for center, day_of_year in enumerate(day_of_years):
         if day_of_year == LEAP_YEAR_DAY_COUNT:
             continue
@@ -492,7 +504,7 @@ def ref_index_year_and_position(
 
 
 def substitute_alignment_matrix(
-    reference_time: pd.DatetimeIndex,
+    reference_time,
     reference_year_indices: dict[int, np.ndarray],
 ) -> np.ndarray:
     max_year_length = max(len(indices) for indices in reference_year_indices.values())
@@ -515,8 +527,8 @@ def substitute_alignment_matrix(
 
 
 def substitute_indices_aligned_to_target(
-    target_time: pd.DatetimeIndex,
-    substitute_time: pd.DatetimeIndex,
+    target_time,
+    substitute_time,
     substitute_indices: np.ndarray,
 ) -> np.ndarray:
     if len(target_time) == len(substitute_time):

--- a/src/icclim/_core/generic/bootstrap_primitives.py
+++ b/src/icclim/_core/generic/bootstrap_primitives.py
@@ -15,7 +15,6 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 if TYPE_CHECKING:
-    import pandas as pd
     from xarray import DataArray
 
     from icclim._core.generic.threshold.percentile import PercentileThreshold

--- a/src/icclim/_core/generic/functions.py
+++ b/src/icclim/_core/generic/functions.py
@@ -58,6 +58,7 @@ from icclim._core.generic.bootstrap_capability import (
     get_optimized_scalar_bounded_bootstrap_spec,
 )
 from icclim._core.input_parsing import PercentileDataArray
+from icclim.frequency import FrequencyRegistry
 from icclim._core.model.cf_calendar import CfCalendarRegistry
 from icclim._core.model.operator import Operator, OperatorRegistry
 from icclim.exception import InvalidIcclimArgumentError
@@ -634,8 +635,13 @@ def fraction_of_total(
         )
     else:
         total = study.resample(time=resample_freq.pandas_freq).sum(dim="time")
+    stabilized_climate_var = (
+        replace(climate_vars[0], studied_data=study)
+        if study is not climate_vars[0].studied_data
+        else climate_vars[0]
+    )
     exceedance_mask = _compute_threshold_exceedance_mask(
-        climate_var=climate_vars[0],
+        climate_var=stabilized_climate_var,
         threshold=threshold,
         resample_freq=resample_freq,
         prepared_inputs_cache={},
@@ -848,8 +854,9 @@ def average(
         bootstrap_capability=bootstrap_capability,
     )
     if stabilized_study is not study and threshold is not None:
+        stabilized_climate_var = replace(climate_vars[0], studied_data=stabilized_study)
         exceedance_mask = _compute_threshold_exceedance_mask(
-            climate_var=climate_vars[0],
+            climate_var=stabilized_climate_var,
             threshold=threshold,
             resample_freq=resample_freq,
             prepared_inputs_cache={},
@@ -963,8 +970,9 @@ def generic_sum(
         bootstrap_capability=bootstrap_capability,
     )
     if stabilized_study is not study and threshold is not None and not _is_rate(study):
+        stabilized_climate_var = replace(climate_vars[0], studied_data=stabilized_study)
         exceedance_mask = _compute_threshold_exceedance_mask(
-            climate_var=climate_vars[0],
+            climate_var=stabilized_climate_var,
             threshold=threshold,
             resample_freq=resample_freq,
             prepared_inputs_cache={},
@@ -1044,7 +1052,16 @@ def _materialize_study_for_optimized_compound_value_aggregate(
 
     if not isinstance(threshold, BoundedThreshold):
         return study
-    return _materialize_bootstrap_study(study, prefer_file_reopen=True)
+    stabilized = _materialize_bootstrap_study(study, prefer_file_reopen=True)
+    if not hasattr(study.data, "chunks"):
+        return stabilized
+    return stabilized.chunk(
+        {
+            dim: chunks
+            for dim, chunks in study.chunksizes.items()
+            if dim in stabilized.dims
+        }
+    )
 
 
 def _format_fraction_of_total_result(
@@ -1802,8 +1819,48 @@ def _compute_fast_tiled_count_occurrences(
     from icclim._core.generic.bootstrap import (  # noqa: PLC0415
         compute_doy_percentile_bootstrap_count,
     )
+    from xarray.coding.cftimeindex import CFTimeIndex  # noqa: PLC0415
 
     fast_start = perf_counter()
+    if (
+        isinstance(climate_var.studied_data.indexes["time"], CFTimeIndex)
+        and resample_freq.pandas_freq != "D"
+    ):
+        tile_results: list[DataArray] = []
+        for tile_indexers in _iter_spatial_tiles(climate_var.studied_data, max_cells):
+            tile_start = perf_counter()
+            tile_study = climate_var.studied_data.isel(tile_indexers)
+            tile_threshold = _slice_threshold_for_tile(threshold, tile_indexers)
+            daily_start = perf_counter()
+            daily_tile = compute_doy_percentile_bootstrap_count(
+                tile_study,
+                tile_threshold,
+                FrequencyRegistry.DAY.pandas_freq,
+            )
+            if daily_tile is None:
+                return None
+            tile_result = daily_tile.resample(time=resample_freq.pandas_freq).sum(
+                dim="time"
+            )
+            tile_result.attrs.update(daily_tile.attrs)
+            tile_results.append(tile_result)
+            _profile_bootstrap_inc("bootstrap_optimized_tile_count")
+        if len(tile_results) == 1:
+            result = tile_results[0]
+        else:
+            result = xr.combine_by_coords(
+                [
+                    tile.to_dataset(name="__icclim_bootstrap_tile")
+                    for tile in tile_results
+                ],
+                combine_attrs="override",
+            )["__icclim_bootstrap_tile"]
+        result.attrs.update(tile_results[-1].attrs)
+        _profile_bootstrap_add(
+            "bootstrap_optimized_total_seconds",
+            perf_counter() - fast_start,
+        )
+        return result
     tile_results: list[DataArray] = []
     for tile_indexers in _iter_spatial_tiles(climate_var.studied_data, max_cells):
         tile_study = climate_var.studied_data.isel(tile_indexers)
@@ -1837,18 +1894,61 @@ def _compute_fast_tiled_bootstrap_exceedance_sum(
     threshold: PercentileThreshold,
     resample_freq: Frequency,
     max_cells: int,
+    *,
+    prepared_inputs_cache: dict[tuple, BootstrapPreparedInputs] | None = None,
 ) -> DataArray | None:
     from icclim._core.generic.bootstrap import (  # noqa: PLC0415
         compute_doy_percentile_bootstrap_exceedance_sum,
     )
-
-    return _compute_fast_tiled_bootstrap_reducer(
-        climate_var,
-        reducer=compute_doy_percentile_bootstrap_exceedance_sum,
-        threshold=threshold,
-        resample_freq=resample_freq,
-        max_cells=max_cells,
+    from icclim._core.generic.bootstrap_primitives import (  # noqa: PLC0415
+        build_bootstrap_prepared_inputs,
     )
+
+    optimized_start = perf_counter()
+    tile_results: list[DataArray] = []
+    for tile_indexers in _iter_spatial_tiles(climate_var.studied_data, max_cells):
+        tile_study = climate_var.studied_data.isel(tile_indexers)
+        tile_threshold = _slice_threshold_for_tile(threshold, tile_indexers)
+        prepared_inputs = None
+        if prepared_inputs_cache is not None:
+            cache_key = _bootstrap_tile_preparation_cache_key(
+                tile_indexers,
+                tile_threshold,
+                resample_freq.pandas_freq,
+            )
+            prepared_inputs = prepared_inputs_cache.get(cache_key)
+            if prepared_inputs is None:
+                prepared_inputs = build_bootstrap_prepared_inputs(
+                    tile_study,
+                    tile_threshold,
+                    resample_freq.pandas_freq,
+                    dtype=np.float32,
+                    prefer_file_reopen=True,
+                )
+                prepared_inputs_cache[cache_key] = prepared_inputs
+        tile_result = compute_doy_percentile_bootstrap_exceedance_sum(
+            tile_study,
+            tile_threshold,
+            resample_freq.pandas_freq,
+            prepared_inputs=prepared_inputs,
+        )
+        if tile_result is None:
+            return None
+        tile_results.append(tile_result)
+        _profile_bootstrap_inc("bootstrap_optimized_tile_count")
+    if len(tile_results) == 1:
+        result = tile_results[0]
+    else:
+        result = xr.combine_by_coords(
+            [tile.to_dataset(name="__icclim_bootstrap_tile") for tile in tile_results],
+            combine_attrs="override",
+        )["__icclim_bootstrap_tile"]
+    result.attrs.update(tile_results[-1].attrs)
+    _profile_bootstrap_add(
+        "bootstrap_optimized_total_seconds",
+        perf_counter() - optimized_start,
+    )
+    return result
 
 
 def _compute_fast_tiled_scalar_bounded_bootstrap_count(
@@ -2130,6 +2230,14 @@ def _compute_fast_tiled_bootstrap_spell_mask(
                     prefer_file_reopen=True,
                 )
                 prepared_inputs_cache[cache_key] = prepared_inputs
+        if prepared_inputs is None:
+            prepared_inputs = build_bootstrap_prepared_inputs(
+                tile_study,
+                tile_threshold,
+                resample_freq.pandas_freq,
+                dtype=np.float32,
+                prefer_file_reopen=True,
+            )
         tile_result = compute_doy_percentile_bootstrap_union_exceedance_mask(
             tile_study,
             tile_threshold,
@@ -2162,7 +2270,6 @@ def _compute_fast_tiled_bootstrap_spell_mask(
     ):
         result = result.squeeze(drop=False)
     return result
-
 
 def _compute_exact_tiled_bootstrap_spell_mask(
     climate_var: ClimateVariable,

--- a/src/icclim/_core/generic/functions.py
+++ b/src/icclim/_core/generic/functions.py
@@ -1819,48 +1819,8 @@ def _compute_fast_tiled_count_occurrences(
     from icclim._core.generic.bootstrap import (  # noqa: PLC0415
         compute_doy_percentile_bootstrap_count,
     )
-    from xarray.coding.cftimeindex import CFTimeIndex  # noqa: PLC0415
 
     fast_start = perf_counter()
-    if (
-        isinstance(climate_var.studied_data.indexes["time"], CFTimeIndex)
-        and resample_freq.pandas_freq != "D"
-    ):
-        tile_results: list[DataArray] = []
-        for tile_indexers in _iter_spatial_tiles(climate_var.studied_data, max_cells):
-            tile_start = perf_counter()
-            tile_study = climate_var.studied_data.isel(tile_indexers)
-            tile_threshold = _slice_threshold_for_tile(threshold, tile_indexers)
-            daily_start = perf_counter()
-            daily_tile = compute_doy_percentile_bootstrap_count(
-                tile_study,
-                tile_threshold,
-                FrequencyRegistry.DAY.pandas_freq,
-            )
-            if daily_tile is None:
-                return None
-            tile_result = daily_tile.resample(time=resample_freq.pandas_freq).sum(
-                dim="time"
-            )
-            tile_result.attrs.update(daily_tile.attrs)
-            tile_results.append(tile_result)
-            _profile_bootstrap_inc("bootstrap_optimized_tile_count")
-        if len(tile_results) == 1:
-            result = tile_results[0]
-        else:
-            result = xr.combine_by_coords(
-                [
-                    tile.to_dataset(name="__icclim_bootstrap_tile")
-                    for tile in tile_results
-                ],
-                combine_attrs="override",
-            )["__icclim_bootstrap_tile"]
-        result.attrs.update(tile_results[-1].attrs)
-        _profile_bootstrap_add(
-            "bootstrap_optimized_total_seconds",
-            perf_counter() - fast_start,
-        )
-        return result
     tile_results: list[DataArray] = []
     for tile_indexers in _iter_spatial_tiles(climate_var.studied_data, max_cells):
         tile_study = climate_var.studied_data.isel(tile_indexers)

--- a/src/icclim/_core/generic/functions.py
+++ b/src/icclim/_core/generic/functions.py
@@ -2812,14 +2812,14 @@ def _compute_threshold_exceedance_mask(
         climate_var.bootstrap,
     )
     if isinstance(threshold, PercentileThreshold) and threshold.is_doy_per_threshold:
-        leaf_climate_var = replace(climate_var, threshold=threshold)
+        component_climate_var = replace(climate_var, threshold=threshold)
         capability = classify_doy_percentile_spell_bootstrap(
-            leaf_climate_var,
+            component_climate_var,
             resample_freq,
         )
         if capability.uses_optimized_bootstrap:
             optimized_mask = _compute_fast_tiled_bootstrap_spell_mask(
-                leaf_climate_var,
+                component_climate_var,
                 resample_freq,
                 _get_fast_bootstrap_max_cells(climate_var.studied_data),
                 prepared_inputs_cache=prepared_inputs_cache,
@@ -2828,7 +2828,7 @@ def _compute_threshold_exceedance_mask(
                 return optimized_mask
         if capability.uses_exact_tiled_bootstrap:
             exact_mask = _compute_exact_tiled_bootstrap_spell_mask(
-                leaf_climate_var,
+                component_climate_var,
                 resample_freq,
             )
             if exact_mask is not None:

--- a/src/icclim/_core/generic/functions.py
+++ b/src/icclim/_core/generic/functions.py
@@ -58,7 +58,6 @@ from icclim._core.generic.bootstrap_capability import (
     get_optimized_scalar_bounded_bootstrap_spec,
 )
 from icclim._core.input_parsing import PercentileDataArray
-from icclim.frequency import FrequencyRegistry
 from icclim._core.model.cf_calendar import CfCalendarRegistry
 from icclim._core.model.operator import Operator, OperatorRegistry
 from icclim.exception import InvalidIcclimArgumentError
@@ -2230,6 +2229,7 @@ def _compute_fast_tiled_bootstrap_spell_mask(
     ):
         result = result.squeeze(drop=False)
     return result
+
 
 def _compute_exact_tiled_bootstrap_spell_mask(
     climate_var: ClimateVariable,

--- a/src/icclim/_core/generic/threshold/percentile.py
+++ b/src/icclim/_core/generic/threshold/percentile.py
@@ -486,7 +486,10 @@ class PercentileThreshold(Threshold):
                 threshold_value = resample_doy(per, da)
             else:
                 threshold_value = per
-            return op(da, threshold_value)
+            result = op(da, threshold_value)
+            if "units" not in result.attrs and "units" in da.attrs:
+                result.attrs["units"] = da.attrs["units"]
+            return result
 
         return __per_compute(
             comparison_data,

--- a/tests/test_bootstrap_capability.py
+++ b/tests/test_bootstrap_capability.py
@@ -136,6 +136,29 @@ def test_cftime_routes_to_exact_tiled_bootstrap() -> None:
     assert decision.reason_code == "calendar_requires_exact_tiled_bootstrap"
 
 
+def test_cftime_count_can_opt_into_experimental_optimized_bootstrap(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("ICCLIM_EXPERIMENTAL_CFTIME_COUNT_BOOTSTRAP", "1")
+    tas = stub_tas(27 + K2C, use_cftime=True).chunk({"time": 365, "lat": 1, "lon": 1})
+    climate_var = _build_climate_variable(
+        tas,
+        {
+            "query": "> 90 doy_per",
+            "doy_window_width": 1,
+            "reference_period": ("2042-01-01", "2043-12-31"),
+        },
+    )
+
+    decision = classify_doy_percentile_count_bootstrap(
+        climate_var,
+        FrequencyRegistry.YEAR,
+    )
+
+    assert decision.execution_kind == BootstrapExecutionKind.OPTIMIZED_BOOTSTRAP
+    assert decision.reason_code == "optimized_bootstrap_supported"
+
+
 def test_eager_input_uses_reference_bootstrap_path() -> None:
     tas = stub_tas(27 + K2C)
     climate_var = _build_climate_variable(

--- a/tests/test_bootstrap_capability.py
+++ b/tests/test_bootstrap_capability.py
@@ -421,7 +421,7 @@ def test_multi_variable_percentile_count_routes_to_exact_tiled_compound_path() -
         == BootstrapComputationFamily.FILTERED_DAY_OF_YEAR_PERCENTILE_COMPOUND
     )
     assert decision.execution_kind == BootstrapExecutionKind.EXACT_TILED_BOOTSTRAP
-    assert decision.reason_code == "compound_leaf_requires_exact_tiled_bootstrap"
+    assert decision.reason_code == "compound_component_requires_exact_tiled_bootstrap"
 
 
 def test_bounded_threshold_recursively_requires_bootstrap() -> None:

--- a/tests/test_bootstrap_capability.py
+++ b/tests/test_bootstrap_capability.py
@@ -223,6 +223,33 @@ def test_generic_filtered_fraction_of_total_routes_to_optimized_bootstrap() -> N
     assert decision.reason_code == "optimized_bootstrap_supported"
 
 
+def test_generic_filtered_average_routes_to_exact_tiled_bootstrap() -> None:
+    pr = stub_tas(5.0).rename("pr")
+    pr.attrs["units"] = "mm/day"
+    pr = pr.chunk({"time": 365, "lat": 1, "lon": 1})
+    climate_var = _build_climate_variable(
+        pr,
+        {
+            "query": "> 90 doy_per",
+            "threshold_min_value": "1 mm/day",
+            "reference_period": ("2042-01-01", "2043-12-31"),
+        },
+    )
+
+    decision = classify_generic_indicator_bootstrap(
+        indicator_name="average",
+        climate_vars=[climate_var],
+        resample_frequency=FrequencyRegistry.YEAR,
+    )
+
+    assert (
+        decision.family
+        == BootstrapComputationFamily.FILTERED_DAY_OF_YEAR_PERCENTILE_VALUE_AGGREGATE
+    )
+    assert decision.execution_kind == BootstrapExecutionKind.EXACT_TILED_BOOTSTRAP
+    assert decision.reason_code == "filtered_average_requires_exact_tiled_bootstrap"
+
+
 def test_generic_fraction_of_total_routes_to_optimized_bootstrap() -> None:
     tas = stub_tas(27 + K2C).chunk({"time": 365, "lat": 1, "lon": 1})
     climate_var = _build_climate_variable(

--- a/tests/test_bootstrap_capability.py
+++ b/tests/test_bootstrap_capability.py
@@ -116,7 +116,7 @@ def test_threshold_min_value_routes_to_exact_tiled_bootstrap() -> None:
     assert decision.reason_code == "threshold_min_value_requires_exact_tiled_bootstrap"
 
 
-def test_cftime_routes_to_exact_tiled_bootstrap() -> None:
+def test_cftime_count_routes_to_optimized_bootstrap() -> None:
     tas = stub_tas(27 + K2C, use_cftime=True).chunk({"time": 365, "lat": 1, "lon": 1})
     climate_var = _build_climate_variable(
         tas,
@@ -132,11 +132,11 @@ def test_cftime_routes_to_exact_tiled_bootstrap() -> None:
         FrequencyRegistry.YEAR,
     )
 
-    assert decision.execution_kind == BootstrapExecutionKind.EXACT_TILED_BOOTSTRAP
-    assert decision.reason_code == "calendar_requires_exact_tiled_bootstrap"
+    assert decision.execution_kind == BootstrapExecutionKind.OPTIMIZED_BOOTSTRAP
+    assert decision.reason_code == "optimized_bootstrap_supported"
 
 
-def test_cftime_count_can_opt_into_experimental_optimized_bootstrap(
+def test_cftime_count_routing_does_not_depend_on_unrelated_env(
     monkeypatch,
 ) -> None:
     monkeypatch.setenv("ICCLIM_EXPERIMENTAL_CFTIME_COUNT_BOOTSTRAP", "1")

--- a/tests/test_bootstrap_primitives.py
+++ b/tests/test_bootstrap_primitives.py
@@ -8,6 +8,7 @@ import pandas as pd
 import pytest
 import xarray as xr
 
+from icclim._core.generic import bootstrap as bootstrap_module
 from icclim._core.generic.bootstrap import (
     _bootstrap_average_kernel,
     _bootstrap_bounded_average_kernel,
@@ -49,8 +50,6 @@ from tests.testing_utils import stub_pr, stub_tas
 
 @contextmanager
 def _force_compiled_cftime_count():
-    from icclim._core.generic import bootstrap as bootstrap_module
-
     original = bootstrap_module.is_optimized_doy_percentile_count_supported
     bootstrap_module.is_optimized_doy_percentile_count_supported = lambda *_: True
     try:

--- a/tests/test_bootstrap_primitives.py
+++ b/tests/test_bootstrap_primitives.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from contextlib import contextmanager
+
+import cftime
 import numpy as np
 import pandas as pd
 import pytest
@@ -17,6 +20,7 @@ from icclim._core.generic.bootstrap import (
     _bootstrap_union_count_kernel,
     _bootstrap_union_mask_kernel,
     compute_doy_percentile_bootstrap_count,
+    compute_doy_percentile_bootstrap_count_threshold_bank_prototype,
     compute_doy_percentile_bootstrap_exceedance_average,
     compute_doy_percentile_bootstrap_exceedance_sum,
     compute_doy_percentile_bootstrap_fraction_of_total,
@@ -40,6 +44,58 @@ from icclim._core.generic.bootstrap_primitives import (
 )
 from icclim.threshold.factory import build_threshold
 from tests.testing_utils import stub_pr, stub_tas
+
+
+@contextmanager
+def _force_compiled_cftime_count():
+    from icclim._core.generic import bootstrap as bootstrap_module
+
+    original = bootstrap_module.is_optimized_doy_percentile_count_supported
+    bootstrap_module.is_optimized_doy_percentile_count_supported = lambda *_: True
+    try:
+        yield
+    finally:
+        bootstrap_module.is_optimized_doy_percentile_count_supported = original
+
+
+def _build_cftime_overlap_case(case_name: str) -> xr.DataArray:
+    time = xr.date_range(
+        "2042-01-01",
+        periods=365 * 5 + 1,
+        freq="D",
+        use_cftime=True,
+    )
+    tas = xr.DataArray(
+        np.full((len(time), 1, 1), 300.0, dtype=np.float64),
+        dims=["time", "lat", "lon"],
+        coords={"time": time, "lat": [0.0], "lon": [0.0]},
+        attrs={"units": "K"},
+        name="tas",
+    )
+    if case_name == "constant":
+        return tas.chunk({"time": 365, "lat": 1, "lon": 1})
+    if case_name == "leap_day_cold_spike":
+        for timestamp in (
+            cftime.DatetimeGregorian(2044, 2, 28),
+            cftime.DatetimeGregorian(2044, 2, 29),
+            cftime.DatetimeGregorian(2044, 3, 1),
+        ):
+            tas.loc[{"time": timestamp}] = 250.0
+        return tas.chunk({"time": 365, "lat": 1, "lon": 1})
+    if case_name == "reference_overlap_shift":
+        def _timestamp(year: int, month: int, day: int) -> object:
+            return time[(time.year == year) & (time.month == month) & (time.day == day)][
+                0
+            ]
+
+        tas.loc[{"time": _timestamp(2042, 2, 28)}] = 305.0
+        tas.loc[{"time": _timestamp(2043, 2, 28)}] = 295.0
+        tas.loc[{"time": _timestamp(2044, 2, 29)}] = 285.0
+        tas.loc[{"time": _timestamp(2045, 2, 28)}] = 310.0
+        tas.loc[{"time": _timestamp(2045, 3, 1)}] = 280.0
+        return tas.chunk({"time": 365, "lat": 1, "lon": 1})
+    msg = f"Unsupported case: {case_name}"
+    raise ValueError(msg)
 
 
 def test_build_bootstrap_reference_sample_applies_threshold_floor() -> None:
@@ -473,6 +529,35 @@ def test_numba_python_count_kernel_matches_constant_cftime_monthly_counts() -> N
         kernel_result.shape
     )
     np.testing.assert_allclose(kernel_result, expected)
+
+
+@pytest.mark.parametrize(
+    "case_name",
+    ["constant", "leap_day_cold_spike", "reference_overlap_shift"],
+)
+@pytest.mark.parametrize("freq", ["MS", "YS"])
+def test_threshold_bank_prototype_matches_forced_compiled_cftime_counts(
+    case_name: str,
+    freq: str,
+) -> None:
+    tas = _build_cftime_overlap_case(case_name)
+    threshold = build_threshold(
+        "> 90 doy_per",
+        doy_window_width=1,
+        reference_period=("2042-01-01", "2044-12-31"),
+    )
+
+    with _force_compiled_cftime_count():
+        current = compute_doy_percentile_bootstrap_count(tas, threshold, freq)
+    prototype = compute_doy_percentile_bootstrap_count_threshold_bank_prototype(
+        tas,
+        threshold,
+        freq,
+    )
+
+    assert current is not None
+    assert prototype is not None
+    xr.testing.assert_allclose(current, prototype)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_bootstrap_primitives.py
+++ b/tests/test_bootstrap_primitives.py
@@ -10,7 +10,6 @@ import xarray as xr
 
 from icclim._core.generic import bootstrap as bootstrap_module
 from icclim._core.generic.bootstrap import (
-    _build_nominal_full_thresholds,
     _bootstrap_average_kernel,
     _bootstrap_bounded_average_kernel,
     _bootstrap_bounded_count_kernel,
@@ -21,6 +20,7 @@ from icclim._core.generic.bootstrap import (
     _bootstrap_sum_kernel,
     _bootstrap_union_count_kernel,
     _bootstrap_union_mask_kernel,
+    _build_nominal_full_thresholds,
     compute_doy_percentile_bootstrap_count,
     compute_doy_percentile_bootstrap_count_threshold_bank_compiled_prototype,
     compute_doy_percentile_bootstrap_count_threshold_bank_prototype,

--- a/tests/test_bootstrap_primitives.py
+++ b/tests/test_bootstrap_primitives.py
@@ -508,6 +508,7 @@ def test_numba_python_count_kernel_matches_constant_cftime_monthly_counts() -> N
         arr.flat_reference_raw,
         arr.flat_reference_filtered,
         arr.flat_study,
+        np.empty((0, 0), dtype=np.float64),
         idx.sample_indices_by_day_of_year,
         idx.reference_index_year,
         idx.reference_index_position,
@@ -530,6 +531,39 @@ def test_numba_python_count_kernel_matches_constant_cftime_monthly_counts() -> N
         kernel_result.shape
     )
     np.testing.assert_allclose(kernel_result, expected)
+
+
+def test_count_kernel_uses_full_nominal_thresholds_for_leap_non_reference_year() -> None:
+    kernel_result = _bootstrap_count_kernel.py_func(
+        np.zeros((1, 1), dtype=np.float64),
+        np.zeros((1, 1), dtype=np.float64),
+        np.asarray([[0.5]], dtype=np.float64),
+        np.vstack(
+            [
+                np.full((336, 1), 0.0, dtype=np.float64),
+                np.asarray([[0.5]], dtype=np.float64),
+                np.full((29, 1), 0.0, dtype=np.float64),
+            ]
+        ),
+        np.full((365, 1), -1, dtype=np.int64),
+        np.zeros(1, dtype=np.int64),
+        np.zeros(1, dtype=np.int64),
+        np.zeros((1, 1, 1), dtype=np.int64),
+        np.asarray([0], dtype=np.int64),
+        np.asarray([1], dtype=np.int64),
+        np.asarray([0], dtype=np.int64),
+        np.asarray([1], dtype=np.int64),
+        np.asarray([366], dtype=np.int64),
+        np.asarray([-1], dtype=np.int64),
+        np.asarray([337], dtype=np.int64),
+        0.9,
+        1.0 / 3.0,
+        1.0 / 3.0,
+        0,
+        np.nan,
+    )
+
+    np.testing.assert_allclose(kernel_result, np.asarray([[0.0]]))
 
 
 @pytest.mark.parametrize(

--- a/tests/test_bootstrap_primitives.py
+++ b/tests/test_bootstrap_primitives.py
@@ -20,6 +20,7 @@ from icclim._core.generic.bootstrap import (
     _bootstrap_union_count_kernel,
     _bootstrap_union_mask_kernel,
     compute_doy_percentile_bootstrap_count,
+    compute_doy_percentile_bootstrap_count_threshold_bank_compiled_prototype,
     compute_doy_percentile_bootstrap_count_threshold_bank_prototype,
     compute_doy_percentile_bootstrap_exceedance_average,
     compute_doy_percentile_bootstrap_exceedance_sum,
@@ -550,6 +551,35 @@ def test_threshold_bank_prototype_matches_forced_compiled_cftime_counts(
     with _force_compiled_cftime_count():
         current = compute_doy_percentile_bootstrap_count(tas, threshold, freq)
     prototype = compute_doy_percentile_bootstrap_count_threshold_bank_prototype(
+        tas,
+        threshold,
+        freq,
+    )
+
+    assert current is not None
+    assert prototype is not None
+    xr.testing.assert_allclose(current, prototype)
+
+
+@pytest.mark.parametrize(
+    "case_name",
+    ["constant", "leap_day_cold_spike", "reference_overlap_shift"],
+)
+@pytest.mark.parametrize("freq", ["MS", "YS"])
+def test_compiled_threshold_bank_prototype_matches_forced_compiled_cftime_counts(
+    case_name: str,
+    freq: str,
+) -> None:
+    tas = _build_cftime_overlap_case(case_name)
+    threshold = build_threshold(
+        "> 90 doy_per",
+        doy_window_width=1,
+        reference_period=("2042-01-01", "2044-12-31"),
+    )
+
+    with _force_compiled_cftime_count():
+        current = compute_doy_percentile_bootstrap_count(tas, threshold, freq)
+    prototype = compute_doy_percentile_bootstrap_count_threshold_bank_compiled_prototype(
         tas,
         threshold,
         freq,

--- a/tests/test_bootstrap_primitives.py
+++ b/tests/test_bootstrap_primitives.py
@@ -86,6 +86,29 @@ def test_build_bootstrap_temporal_indexing_tracks_years_and_groups() -> None:
     assert temporal_indexing.substitute_alignment.shape[:2] == (5, 5)
 
 
+def test_build_bootstrap_temporal_indexing_supports_cftime_groups() -> None:
+    tas = stub_tas(use_cftime=True)
+    threshold = build_threshold("> 90 doy_per")
+    reference_sample = build_bootstrap_reference_sample(tas, threshold)
+
+    temporal_indexing = build_bootstrap_temporal_indexing(
+        reference_sample.study,
+        reference_sample.reference_sample,
+        "MS",
+        doy_window_width=threshold.doy_window_width,
+    )
+
+    np.testing.assert_array_equal(
+        temporal_indexing.bootstrap_years,
+        np.asarray([2042, 2043, 2044, 2045, 2046]),
+    )
+    assert len(temporal_indexing.output_group_labels) == 60
+    assert temporal_indexing.sample_indices_by_day_of_year.shape[0] == 365
+    assert temporal_indexing.reference_index_year.shape == (tas.sizes["time"],)
+    assert temporal_indexing.reference_index_position.shape == (tas.sizes["time"],)
+    assert temporal_indexing.substitute_alignment.shape[:2] == (5, 5)
+
+
 def test_build_bootstrap_array_inputs_flattens_study_and_reference() -> None:
     tas = stub_tas(lat_length=2, lon_length=3)
     threshold = build_threshold("> 90 doy_per")
@@ -409,6 +432,47 @@ def test_numba_python_union_mask_kernel_matches_wrapper_output() -> None:
         kernel_result,
         wrapper_result.values.reshape(kernel_result.shape),
     )
+
+
+def test_numba_python_count_kernel_matches_constant_cftime_monthly_counts() -> None:
+    tas = stub_tas(300.0, use_cftime=True).chunk({"time": 365, "lat": 1, "lon": 1})
+    threshold = build_threshold(">= 90 doy_per")
+    prepared = build_bootstrap_prepared_inputs(tas, threshold, "MS", dtype=np.float64)
+    ref = prepared.reference_sample
+    idx = prepared.temporal_indexing
+    arr = prepared.array_inputs
+    min_threshold = (
+        np.nan
+        if ref.threshold_floor_in_reference_units is None
+        else float(ref.threshold_floor_in_reference_units)
+    )
+
+    kernel_result = _bootstrap_count_kernel.py_func(
+        arr.flat_reference_raw,
+        arr.flat_reference_filtered,
+        arr.flat_study,
+        idx.sample_indices_by_day_of_year,
+        idx.reference_index_year,
+        idx.reference_index_position,
+        idx.substitute_alignment,
+        idx.output_starts,
+        idx.output_lengths,
+        idx.year_group_starts,
+        idx.year_group_stops,
+        idx.year_max_day_of_years,
+        idx.year_to_reference_index,
+        idx.study_day_of_years,
+        float(threshold.percentile_coord().item()) / 100.0,
+        float(threshold.interpolation.alpha),
+        float(threshold.interpolation.beta),
+        1,
+        min_threshold,
+    )
+
+    expected = tas.resample(time="MS").count(dim="time").values.reshape(
+        kernel_result.shape
+    )
+    np.testing.assert_allclose(kernel_result, expected)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_bootstrap_primitives.py
+++ b/tests/test_bootstrap_primitives.py
@@ -10,6 +10,7 @@ import xarray as xr
 
 from icclim._core.generic import bootstrap as bootstrap_module
 from icclim._core.generic.bootstrap import (
+    _build_nominal_full_thresholds,
     _bootstrap_average_kernel,
     _bootstrap_bounded_average_kernel,
     _bootstrap_bounded_count_kernel,
@@ -413,6 +414,13 @@ def _kernel_common_args(
     return args, ref.study
 
 
+def _count_kernel_args(tas: xr.DataArray, threshold) -> tuple[tuple, xr.DataArray]:
+    args, study = _kernel_common_args(tas, threshold)
+    nominal_thresholds = _build_nominal_full_thresholds(study, threshold)
+    count_args = (args[0], args[1], args[2], nominal_thresholds, *args[3:])
+    return count_args, study
+
+
 @pytest.mark.parametrize(
     ("kernel", "wrapper"),
     [
@@ -435,7 +443,10 @@ def _kernel_common_args(
 def test_numba_python_kernels_match_wrapper_outputs(kernel, wrapper) -> None:
     tas = stub_tas(300.0).chunk({"time": 365, "lat": 1, "lon": 1})
     threshold = build_threshold(">= 90 doy_per")
-    args, _study = _kernel_common_args(tas, threshold)
+    if kernel is _bootstrap_count_kernel:
+        args, _study = _count_kernel_args(tas, threshold)
+    else:
+        args, _study = _kernel_common_args(tas, threshold)
 
     kernel_result = kernel.py_func(*args)
     wrapper_result = wrapper(tas, threshold, "YS")

--- a/tests/test_bootstrap_primitives.py
+++ b/tests/test_bootstrap_primitives.py
@@ -84,10 +84,11 @@ def _build_cftime_overlap_case(case_name: str) -> xr.DataArray:
             tas.loc[{"time": timestamp}] = 250.0
         return tas.chunk({"time": 365, "lat": 1, "lon": 1})
     if case_name == "reference_overlap_shift":
+
         def _timestamp(year: int, month: int, day: int) -> object:
-            return time[(time.year == year) & (time.month == month) & (time.day == day)][
-                0
-            ]
+            return time[
+                (time.year == year) & (time.month == month) & (time.day == day)
+            ][0]
 
         tas.loc[{"time": _timestamp(2042, 2, 28)}] = 305.0
         tas.loc[{"time": _timestamp(2043, 2, 28)}] = 295.0
@@ -527,13 +528,15 @@ def test_numba_python_count_kernel_matches_constant_cftime_monthly_counts() -> N
         min_threshold,
     )
 
-    expected = tas.resample(time="MS").count(dim="time").values.reshape(
-        kernel_result.shape
+    expected = (
+        tas.resample(time="MS").count(dim="time").values.reshape(kernel_result.shape)
     )
     np.testing.assert_allclose(kernel_result, expected)
 
 
-def test_count_kernel_uses_full_nominal_thresholds_for_leap_non_reference_year() -> None:
+def test_count_kernel_uses_full_nominal_thresholds_for_leap_non_reference_year() -> (
+    None
+):
     kernel_result = _bootstrap_count_kernel.py_func(
         np.zeros((1, 1), dtype=np.float64),
         np.zeros((1, 1), dtype=np.float64),
@@ -613,10 +616,12 @@ def test_compiled_threshold_bank_prototype_matches_forced_compiled_cftime_counts
 
     with _force_compiled_cftime_count():
         current = compute_doy_percentile_bootstrap_count(tas, threshold, freq)
-    prototype = compute_doy_percentile_bootstrap_count_threshold_bank_compiled_prototype(
-        tas,
-        threshold,
-        freq,
+    prototype = (
+        compute_doy_percentile_bootstrap_count_threshold_bank_compiled_prototype(
+            tas,
+            threshold,
+            freq,
+        )
     )
 
     assert current is not None

--- a/tests/test_generic_functions.py
+++ b/tests/test_generic_functions.py
@@ -4,8 +4,8 @@ import xarray as xr
 
 from icclim._core.climate_variable import ClimateVariable
 from icclim._core.constants import GROUP_BY_METHOD
-from icclim._core.generic import functions as generic_functions_module
 from icclim._core.generic import bootstrap_primitives
+from icclim._core.generic import functions as generic_functions_module
 from icclim._core.generic.bootstrap_capability import (
     BootstrapCapability,
     BootstrapComputationFamily,

--- a/tests/test_generic_functions.py
+++ b/tests/test_generic_functions.py
@@ -4,7 +4,13 @@ import xarray as xr
 
 from icclim._core.climate_variable import ClimateVariable
 from icclim._core.constants import GROUP_BY_METHOD
+from icclim._core.generic import functions as generic_functions_module
 from icclim._core.generic import bootstrap_primitives
+from icclim._core.generic.bootstrap_capability import (
+    BootstrapCapability,
+    BootstrapComputationFamily,
+    BootstrapExecutionKind,
+)
 from icclim._core.generic.functions import (
     _compute_threshold_exceedance_mask,
     _safe_to_agg_units,
@@ -16,6 +22,7 @@ from icclim._core.generic.functions import (
     maximum,
     minimum,
     percentile,
+    sum_of_spell_lengths,
 )
 from icclim._core.model.logical_link import LogicalLinkRegistry
 from icclim._core.model.standard_variable import StandardVariableRegistry
@@ -342,3 +349,120 @@ def test_compound_value_aggregate_materializes_stable_study(
     assert result is not None
     assert materialize_calls["count"] >= 1
     assert True in materialize_calls["prefer_file_reopen"]
+
+
+def test_spell_bootstrap_materializes_stable_study_without_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tas = stub_tas(27.0, lat_length=2, lon_length=2).chunk(
+        {"time": 365, "lat": 1, "lon": 1}
+    )
+    threshold = build_threshold(
+        "> 95 doy_per",
+        reference_period=("2042-01-01", "2043-12-31"),
+    )
+    climate_var = ClimateVariable(
+        name="tas",
+        standard_var=StandardVariableRegistry.TAS,
+        studied_data=tas,
+        threshold=threshold,
+        source_frequency=FrequencyRegistry.DAY,
+        global_metadata={},
+    )
+    materialize_calls = {"count": 0, "prefer_file_reopen": []}
+
+    original_materialize = bootstrap_primitives._materialize_bootstrap_study
+
+    def counted_materialize(study, *, prefer_file_reopen=False):
+        materialize_calls["count"] += 1
+        materialize_calls["prefer_file_reopen"].append(prefer_file_reopen)
+        return original_materialize(study, prefer_file_reopen=prefer_file_reopen)
+
+    monkeypatch.setenv("ICCLIM_BOOTSTRAP_FAST_TILE_CELLS", "1")
+    monkeypatch.setattr(
+        bootstrap_primitives,
+        "_materialize_bootstrap_study",
+        counted_materialize,
+    )
+
+    result = sum_of_spell_lengths(
+        climate_vars=[climate_var],
+        resample_freq=FrequencyRegistry.YEAR,
+        logical_link=LogicalLinkRegistry.LOGICAL_AND,
+        min_spell_length=6,
+    )
+
+    assert result is not None
+    assert materialize_calls["count"] >= 1
+    assert True in materialize_calls["prefer_file_reopen"]
+
+
+@pytest.mark.parametrize(
+    "reducer",
+    [average, generic_sum, fraction_of_total],
+)
+def test_compound_value_aggregate_uses_stabilized_study_for_mask(
+    monkeypatch: pytest.MonkeyPatch,
+    reducer,
+) -> None:
+    tas = stub_tas(27.0, lat_length=2, lon_length=2).chunk(
+        {"time": 365, "lat": 1, "lon": 1}
+    )
+    threshold = build_threshold(
+        thresholds=["> 95 doy_per", "<= 10 doy_per"],
+        logical_link="or",
+        reference_period=("2042-01-01", "2043-12-31"),
+    )
+    climate_var = ClimateVariable(
+        name="tas",
+        standard_var=StandardVariableRegistry.TAS,
+        studied_data=tas,
+        threshold=threshold,
+        source_frequency=FrequencyRegistry.DAY,
+        global_metadata={},
+    )
+    stabilized = tas.copy()
+    stabilized.attrs = dict(tas.attrs)
+    seen = {"study": None}
+
+    monkeypatch.setattr(
+        generic_functions_module,
+        "_note_generic_bootstrap_capability",
+        lambda **kwargs: BootstrapCapability(
+            family=BootstrapComputationFamily.DAY_OF_YEAR_PERCENTILE_COMPOUND,
+            execution_kind=BootstrapExecutionKind.OPTIMIZED_BOOTSTRAP,
+            bootstrap_required=True,
+            reason_code="optimized_compound_value_aggregate_bootstrap_supported",
+        ),
+    )
+    monkeypatch.setattr(
+        generic_functions_module,
+        "_materialize_study_for_optimized_compound_value_aggregate",
+        lambda **kwargs: stabilized,
+    )
+
+    def fake_threshold_exceedance_mask(
+        *,
+        climate_var,
+        threshold,
+        resample_freq,
+        prepared_inputs_cache=None,
+    ):
+        seen["study"] = climate_var.studied_data
+        return xr.ones_like(stabilized, dtype=bool)
+
+    monkeypatch.setattr(
+        generic_functions_module,
+        "_compute_threshold_exceedance_mask",
+        fake_threshold_exceedance_mask,
+    )
+
+    kwargs = {"to_percent": False} if reducer is fraction_of_total else {}
+    result = reducer(
+        climate_vars=[climate_var],
+        resample_freq=FrequencyRegistry.YEAR,
+        **kwargs,
+    )
+
+    assert result is not None
+    assert seen["study"] is stabilized

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1646,7 +1646,7 @@ class TestIntegration:
         assert profile["bootstrap_optimized_tile_count"] == 4
         xr.testing.assert_allclose(default.TX90p.load(), eager.TX90p)
 
-    def test_index_tx90p__cftime_dask_bootstrap_falls_back_to_safe_tiled_path(
+    def test_index_tx90p__cftime_dask_bootstrap_uses_optimized_tiled_path(
         self,
         monkeypatch,
     ) -> None:
@@ -1671,13 +1671,10 @@ class TestIntegration:
         default = icclim.index(**common_kwargs)
         profile = generic_functions.get_bootstrap_profile()
 
-        assert profile["bootstrap_count_execution_kind"] == "exact_tiled_bootstrap"
-        assert (
-            profile["bootstrap_count_reason_code"]
-            == "calendar_requires_exact_tiled_bootstrap"
-        )
-        assert "bootstrap_optimized_tile_count" not in profile
-        assert profile["bootstrap_safe_tile_count"] == 4
+        assert profile["bootstrap_count_execution_kind"] == "optimized_bootstrap"
+        assert profile["bootstrap_count_reason_code"] == "optimized_bootstrap_supported"
+        assert profile["bootstrap_optimized_tile_count"] == 4
+        assert "bootstrap_safe_tile_count" not in profile
         xr.testing.assert_allclose(default.TX90p.load(), eager.TX90p)
 
     def test_index_tx90p__safe_bootstrap_uses_memory_budget(self, monkeypatch) -> None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1646,7 +1646,7 @@ class TestIntegration:
         assert profile["bootstrap_optimized_tile_count"] == 4
         xr.testing.assert_allclose(default.TX90p.load(), eager.TX90p)
 
-    def test_index_tx90p__cftime_dask_bootstrap_uses_optimized_tiled_path(
+    def test_index_tx90p__cftime_dask_bootstrap_uses_optimized_path(
         self,
         monkeypatch,
     ) -> None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1077,7 +1077,7 @@ class TestIntegration:
         monkeypatch.delenv("ICCLIM_BOOTSTRAP_MODE")
 
         generic_functions.reset_bootstrap_profile()
-        exact = icclim.index(**common_kwargs).compute()
+        optimized = icclim.index(**common_kwargs).compute()
         profile = generic_functions.get_bootstrap_profile()
 
         assert profile["bootstrap_execution_kind"] == "exact_tiled_bootstrap"
@@ -1086,7 +1086,7 @@ class TestIntegration:
             == "filtered_average_requires_exact_tiled_bootstrap"
         )
         xr.testing.assert_allclose(
-            exact.average,
+            optimized.average,
             reference.average,
         )
 

--- a/tests/test_real_data_validation_tools.py
+++ b/tests/test_real_data_validation_tools.py
@@ -171,6 +171,15 @@ def test_summarize_notes_cover_new_compound_workloads() -> None:
     assert "bootstrap leaf masks" in note
 
 
+def test_summarize_notes_cover_new_cftime_and_filtered_average_workloads() -> None:
+    assert "cftime monthly" in summarize_real_data_validation._workload_notes(
+        "tx90p_cftime_monthly"
+    )
+    assert "drier regional subset" in summarize_real_data_validation._workload_notes(
+        "generic_pr_average_bootstrap_dry_yearly"
+    )
+
+
 class _FakeIcclim:
     def __init__(self) -> None:
         self.calls: list[tuple[str, dict]] = []
@@ -252,6 +261,9 @@ class _FakeIcclim:
         ("generic_pr_count_bootstrap_yearly", "count_occurrences", "threshold"),
         ("generic_pr_sum_bootstrap_yearly", "sum", "threshold"),
         ("generic_pr_average_bootstrap_yearly", "average", "threshold"),
+        ("generic_pr_average_bootstrap_monthly", "average", "threshold"),
+        ("generic_pr_average_bootstrap_dry_yearly", "average", "threshold"),
+        ("generic_pr_average_bootstrap_99_yearly", "average", "threshold"),
         ("generic_tas_fraction_bootstrap_yearly", "fraction_of_total", "threshold"),
         ("generic_tas_sum_bootstrap_yearly", "sum", "threshold"),
         ("generic_tas_average_bootstrap_yearly", "average", "threshold"),
@@ -263,6 +275,8 @@ class _FakeIcclim:
         ("wsdi_yearly", "index", "index_name"),
         ("csdi_yearly", "index", "index_name"),
         ("tg90p_save_thresholds_monthly", "index", "save_thresholds"),
+        ("tx90p_cftime_yearly", "index", "index_name"),
+        ("tx90p_cftime_monthly", "index", "index_name"),
         ("combined_cd_yearly", "index", "index_name"),
         ("indices_mixed_yearly", "indices", "index_group"),
         ("indices_mixed_with_cd_yearly", "indices", "index_group"),
@@ -285,11 +299,31 @@ def test_run_real_data_validation_build_workload_routes_expected_call(
         "_open_combined_dataset",
         lambda *args, **kwargs: {"source": "combined", "kwargs": kwargs},
     )
+    monkeypatch.setattr(
+        run_real_data_validation,
+        "_as_cftime_gregorian",
+        lambda da: da,
+    )
 
     result = run_real_data_validation._build_workload(fake, workload)
 
     assert result["method"] == expected_method
     assert expected_key in result["kwargs"]
+
+
+def test_run_real_data_validation_converts_time_to_cftime_gregorian() -> None:
+    time = xr.date_range("2000-01-01", periods=3, freq="D")
+    tas = xr.DataArray(
+        [1.0, 2.0, 3.0],
+        dims=["time"],
+        coords={"time": time},
+        name="tas",
+    )
+
+    converted = run_real_data_validation._as_cftime_gregorian(tas)
+
+    assert converted.time.dtype == object
+    assert converted.indexes["time"][0].calendar == "standard"
 
 
 def test_summarize_format_helpers_cover_pending_and_numeric_paths() -> None:

--- a/tests/test_tool_helpers.py
+++ b/tests/test_tool_helpers.py
@@ -4,11 +4,15 @@ import inspect
 import json
 from types import ModuleType, SimpleNamespace
 
+import numpy as np
 import pytest
 import xarray as xr
 
 from icclim._core.constants import NEEDS_NORMAL, QUANTILE_BASED, REFERENCE_PERIOD_INDEX
+from tools import prototype_cftime_exact_order_stat_quantile as order_quantile_tools
+from tools import prototype_cftime_exact_order_stat_count as order_count_tools
 from tools import compare_real_data_validation as compare_tools
+from tools import analyze_cftime_exact_order_stat_design as order_stat_tools
 from tools import debug_real_data_validation as debug_tools
 from tools import extract_icclim_funs as extract_tools
 from tools import update_logo_version as logo_tools
@@ -42,6 +46,94 @@ def test_compare_variable_reports_shape_or_dim_mismatch() -> None:
     )
     assert shape_mismatch["equal"] is False
     assert "shape differ" in shape_mismatch["reason"]
+
+
+def test_order_stat_replacement_summary_counts_target_and_substitute_slots() -> None:
+    sample_indices = np.asarray(
+        [
+            [0, 2, 4, -1],
+            [1, 3, 5, -1],
+        ],
+        dtype=np.int64,
+    )
+    index_year = np.asarray([0, 0, 1, 1, 2, 2], dtype=np.int64)
+    index_pos = np.asarray([0, 1, 0, 1, 0, 1], dtype=np.int64)
+    substitute_aligned = np.full((3, 3, 2), -1, dtype=np.int64)
+    substitute_aligned[0, 1, :] = np.asarray([2, 3])
+    substitute_aligned[0, 2, :] = np.asarray([4, -1])
+    substitute_aligned[1, 0, :] = np.asarray([0, 1])
+    substitute_aligned[1, 2, :] = np.asarray([4, 5])
+    substitute_aligned[2, 0, :] = np.asarray([0, -1])
+    substitute_aligned[2, 1, :] = np.asarray([2, 3])
+
+    summary = order_stat_tools._summarize_replacement_structure(
+        sample_indices,
+        index_year,
+        index_pos,
+        substitute_aligned,
+    )
+
+    assert summary.max_samples_per_doy == 3
+    assert summary.min_samples_per_doy == 3
+    assert summary.max_target_year_slots_per_doy == 1
+    assert summary.min_target_year_slots_per_doy == 1
+    assert summary.max_effective_substitute_slots_per_doy == 1
+    assert summary.min_effective_substitute_slots_per_doy == 0
+
+
+def test_order_stat_quantile_matches_simple_adjusted_multiset() -> None:
+    base_sorted = np.asarray([1.0, 2.0, 2.0, 5.0], dtype=np.float64)
+    removed_sorted = np.asarray([2.0], dtype=np.float64)
+    inserted_sorted = np.asarray([3.0], dtype=np.float64)
+
+    quantile = order_quantile_tools._method8_quantile_from_adjusted_sorted(
+        base_sorted,
+        removed_sorted,
+        inserted_sorted,
+        0.5,
+        1.0 / 3.0,
+        1.0 / 3.0,
+    )
+
+    np.testing.assert_allclose(quantile, 2.5)
+
+
+@pytest.mark.parametrize(
+    ("case_name", "freq"),
+    [
+        ("constant", "MS"),
+        ("leap_day_cold_spike", "MS"),
+        ("reference_overlap_shift", "YS"),
+    ],
+)
+def test_order_stat_threshold_series_prototype_matches_current_builder(
+    case_name: str,
+    freq: str,
+) -> None:
+    comparison = order_quantile_tools.compare_order_stat_threshold_series(
+        case_name,
+        freq,
+    )
+
+    assert comparison.changed_doys == 0
+    assert comparison.max_abs_diff == 0.0
+
+
+@pytest.mark.parametrize(
+    ("case_name", "freq"),
+    [
+        ("constant", "MS"),
+        ("leap_day_cold_spike", "YS"),
+    ],
+)
+def test_order_stat_count_prototype_matches_current_output(
+    case_name: str,
+    freq: str,
+) -> None:
+    comparison = order_count_tools.compare_count_prototypes(case_name, freq)
+
+    assert comparison.changed_cells == 0
+    assert comparison.max_abs_diff == 0.0
 
 
 def test_compare_datasets_collects_shared_vars_and_attrs(tmp_path: Path) -> None:

--- a/tests/test_tool_helpers.py
+++ b/tests/test_tool_helpers.py
@@ -9,12 +9,12 @@ import pytest
 import xarray as xr
 
 from icclim._core.constants import NEEDS_NORMAL, QUANTILE_BASED, REFERENCE_PERIOD_INDEX
-from tools import prototype_cftime_exact_order_stat_quantile as order_quantile_tools
-from tools import prototype_cftime_exact_order_stat_count as order_count_tools
-from tools import compare_real_data_validation as compare_tools
 from tools import analyze_cftime_exact_order_stat_design as order_stat_tools
+from tools import compare_real_data_validation as compare_tools
 from tools import debug_real_data_validation as debug_tools
 from tools import extract_icclim_funs as extract_tools
+from tools import prototype_cftime_exact_order_stat_count as order_count_tools
+from tools import prototype_cftime_exact_order_stat_quantile as order_quantile_tools
 from tools import update_logo_version as logo_tools
 
 

--- a/tools/analyze_cftime_exact_count_algorithm.py
+++ b/tools/analyze_cftime_exact_count_algorithm.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict, dataclass
+
+import numpy as np
+import xarray as xr
+
+from icclim._core.constants import UNITS_KEY
+from icclim._core.generic.bootstrap_primitives import (
+    build_bootstrap_prepared_inputs,
+)
+from icclim.threshold.factory import build_threshold
+
+NON_LEAP_DAY_COUNT = 365
+
+
+@dataclass(frozen=True)
+class ThresholdBankEstimate:
+    name: str
+    threshold_series_per_cell: int
+    bytes_per_cell_float64: int
+    bytes_per_cell_float32: int
+    bytes_total_float64: int
+    bytes_total_float32: int
+
+
+@dataclass(frozen=True)
+class CountAlgorithmAnalysis:
+    study_year_count: int
+    reference_year_count: int
+    overlap_year_count: int
+    non_overlap_year_count: int
+    output_group_count: int
+    spatial_cell_count: int
+    current_threshold_series_per_cell: int
+    nominal_series_per_cell: int
+    overlap_series_per_cell: int
+    reusable_nominal_series_savings_per_cell: int
+    estimates: list[ThresholdBankEstimate]
+
+
+def _build_synthetic_cftime_tas(
+    *,
+    start_year: int,
+    study_year_count: int,
+    lat_length: int,
+    lon_length: int,
+) -> xr.DataArray:
+    end_year = start_year + study_year_count - 1
+    time = xr.date_range(
+        f"{start_year}-01-01",
+        f"{end_year}-12-31",
+        freq="D",
+        use_cftime=True,
+    )
+    values = np.full(
+        (len(time), lat_length, lon_length),
+        300.0,
+        dtype=np.float32,
+    )
+    return xr.DataArray(
+        values,
+        dims=["time", "lat", "lon"],
+        coords={
+            "time": time,
+            "lat": np.arange(lat_length),
+            "lon": np.arange(lon_length),
+        },
+        attrs={UNITS_KEY: "K"},
+        name="tas",
+    )
+
+
+def _estimate_bank(
+    *,
+    name: str,
+    threshold_series_per_cell: int,
+    spatial_cell_count: int,
+) -> ThresholdBankEstimate:
+    bytes_per_cell_float64 = threshold_series_per_cell * NON_LEAP_DAY_COUNT * 8
+    bytes_per_cell_float32 = threshold_series_per_cell * NON_LEAP_DAY_COUNT * 4
+    return ThresholdBankEstimate(
+        name=name,
+        threshold_series_per_cell=threshold_series_per_cell,
+        bytes_per_cell_float64=bytes_per_cell_float64,
+        bytes_per_cell_float32=bytes_per_cell_float32,
+        bytes_total_float64=bytes_per_cell_float64 * spatial_cell_count,
+        bytes_total_float32=bytes_per_cell_float32 * spatial_cell_count,
+    )
+
+
+def analyze_count_algorithm(
+    *,
+    start_year: int,
+    study_year_count: int,
+    reference_start_year: int,
+    reference_year_count: int,
+    lat_length: int,
+    lon_length: int,
+    freq: str,
+) -> CountAlgorithmAnalysis:
+    tas = _build_synthetic_cftime_tas(
+        start_year=start_year,
+        study_year_count=study_year_count,
+        lat_length=lat_length,
+        lon_length=lon_length,
+    )
+    reference_end_year = reference_start_year + reference_year_count - 1
+    threshold = build_threshold(
+        query="> 90 doy_per",
+        reference_period=(
+            f"{reference_start_year}-01-01",
+            f"{reference_end_year}-12-31",
+        ),
+    )
+    prepared = build_bootstrap_prepared_inputs(
+        tas,
+        threshold,
+        freq,
+        dtype=np.float64,
+    )
+    indexing = prepared.temporal_indexing
+    spatial_cell_count = int(np.prod(prepared.array_inputs.spatial_shape))
+    overlap_year_count = int(np.count_nonzero(indexing.year_to_reference_index >= 0))
+    non_overlap_year_count = len(indexing.bootstrap_years) - overlap_year_count
+    nominal_series_per_cell = 1
+    overlap_series_per_cell = overlap_year_count * (reference_year_count - 1)
+    current_threshold_series_per_cell = (
+        non_overlap_year_count + overlap_series_per_cell
+    )
+    full_bank_series_per_cell = nominal_series_per_cell + overlap_series_per_cell
+    per_target_bank_series_per_cell = max(1, reference_year_count - 1)
+    estimates = [
+        _estimate_bank(
+            name="current_full_rebuild_work",
+            threshold_series_per_cell=current_threshold_series_per_cell,
+            spatial_cell_count=spatial_cell_count,
+        ),
+        _estimate_bank(
+            name="full_threshold_bank",
+            threshold_series_per_cell=full_bank_series_per_cell,
+            spatial_cell_count=spatial_cell_count,
+        ),
+        _estimate_bank(
+            name="single_target_threshold_bank",
+            threshold_series_per_cell=per_target_bank_series_per_cell,
+            spatial_cell_count=spatial_cell_count,
+        ),
+        _estimate_bank(
+            name="nominal_only_cache",
+            threshold_series_per_cell=nominal_series_per_cell,
+            spatial_cell_count=spatial_cell_count,
+        ),
+    ]
+    return CountAlgorithmAnalysis(
+        study_year_count=len(indexing.bootstrap_years),
+        reference_year_count=reference_year_count,
+        overlap_year_count=overlap_year_count,
+        non_overlap_year_count=non_overlap_year_count,
+        output_group_count=len(indexing.output_group_labels),
+        spatial_cell_count=spatial_cell_count,
+        current_threshold_series_per_cell=current_threshold_series_per_cell,
+        nominal_series_per_cell=nominal_series_per_cell,
+        overlap_series_per_cell=overlap_series_per_cell,
+        reusable_nominal_series_savings_per_cell=max(0, non_overlap_year_count - 1),
+        estimates=estimates,
+    )
+
+
+def _as_json_ready(analysis: CountAlgorithmAnalysis) -> dict[str, object]:
+    payload = asdict(analysis)
+    payload["estimates"] = [asdict(item) for item in analysis.estimates]
+    return payload
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--start-year", type=int, default=1950)
+    parser.add_argument("--study-years", type=int, default=65)
+    parser.add_argument("--reference-start-year", type=int, default=1961)
+    parser.add_argument("--reference-years", type=int, default=30)
+    parser.add_argument("--lat-length", type=int, default=28)
+    parser.add_argument("--lon-length", type=int, default=21)
+    parser.add_argument("--freq", default="MS")
+    args = parser.parse_args()
+
+    analysis = analyze_count_algorithm(
+        start_year=args.start_year,
+        study_year_count=args.study_years,
+        reference_start_year=args.reference_start_year,
+        reference_year_count=args.reference_years,
+        lat_length=args.lat_length,
+        lon_length=args.lon_length,
+        freq=args.freq,
+    )
+    print(json.dumps(_as_json_ready(analysis), indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/analyze_cftime_exact_count_algorithm.py
+++ b/tools/analyze_cftime_exact_count_algorithm.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 from dataclasses import asdict, dataclass
 from pathlib import Path
-import sys
 
 import numpy as np
 import xarray as xr
@@ -105,10 +105,10 @@ def analyze_count_algorithm(
     lon_length: int,
     freq: str,
 ) -> CountAlgorithmAnalysis:
-    from icclim._core.generic.bootstrap_primitives import (  # noqa: PLC0415
+    from icclim._core.generic.bootstrap_primitives import (
         build_bootstrap_prepared_inputs,
     )
-    from icclim.threshold.factory import build_threshold  # noqa: PLC0415
+    from icclim.threshold.factory import build_threshold
 
     tas = _build_synthetic_cftime_tas(
         start_year=start_year,
@@ -136,9 +136,7 @@ def analyze_count_algorithm(
     non_overlap_year_count = len(indexing.bootstrap_years) - overlap_year_count
     nominal_series_per_cell = 1
     overlap_series_per_cell = overlap_year_count * (reference_year_count - 1)
-    current_threshold_series_per_cell = (
-        non_overlap_year_count + overlap_series_per_cell
-    )
+    current_threshold_series_per_cell = non_overlap_year_count + overlap_series_per_cell
     full_bank_series_per_cell = nominal_series_per_cell + overlap_series_per_cell
     per_target_bank_series_per_cell = max(1, reference_year_count - 1)
     estimates = [

--- a/tools/analyze_cftime_exact_count_algorithm.py
+++ b/tools/analyze_cftime_exact_count_algorithm.py
@@ -3,15 +3,11 @@ from __future__ import annotations
 import argparse
 import json
 from dataclasses import asdict, dataclass
+from pathlib import Path
+import sys
 
 import numpy as np
 import xarray as xr
-
-from icclim._core.constants import UNITS_KEY
-from icclim._core.generic.bootstrap_primitives import (
-    build_bootstrap_prepared_inputs,
-)
-from icclim.threshold.factory import build_threshold
 
 NON_LEAP_DAY_COUNT = 365
 
@@ -41,6 +37,14 @@ class CountAlgorithmAnalysis:
     estimates: list[ThresholdBankEstimate]
 
 
+def _resolve_import_root(repo: Path) -> Path:
+    for candidate in (repo / "src", repo):
+        if (candidate / "icclim" / "__init__.py").is_file():
+            return candidate
+    msg = f"Could not locate icclim import root under {repo}"
+    raise FileNotFoundError(msg)
+
+
 def _build_synthetic_cftime_tas(
     *,
     start_year: int,
@@ -68,7 +72,7 @@ def _build_synthetic_cftime_tas(
             "lat": np.arange(lat_length),
             "lon": np.arange(lon_length),
         },
-        attrs={UNITS_KEY: "K"},
+        attrs={"units": "K"},
         name="tas",
     )
 
@@ -101,6 +105,11 @@ def analyze_count_algorithm(
     lon_length: int,
     freq: str,
 ) -> CountAlgorithmAnalysis:
+    from icclim._core.generic.bootstrap_primitives import (  # noqa: PLC0415
+        build_bootstrap_prepared_inputs,
+    )
+    from icclim.threshold.factory import build_threshold  # noqa: PLC0415
+
     tas = _build_synthetic_cftime_tas(
         start_year=start_year,
         study_year_count=study_year_count,
@@ -177,6 +186,7 @@ def _as_json_ready(analysis: CountAlgorithmAnalysis) -> dict[str, object]:
 
 def main() -> None:
     parser = argparse.ArgumentParser()
+    parser.add_argument("--repo", default=Path(__file__).resolve().parents[1])
     parser.add_argument("--start-year", type=int, default=1950)
     parser.add_argument("--study-years", type=int, default=65)
     parser.add_argument("--reference-start-year", type=int, default=1961)
@@ -185,6 +195,9 @@ def main() -> None:
     parser.add_argument("--lon-length", type=int, default=21)
     parser.add_argument("--freq", default="MS")
     args = parser.parse_args()
+
+    repo = Path(args.repo).resolve()
+    sys.path.insert(0, str(_resolve_import_root(repo)))
 
     analysis = analyze_count_algorithm(
         start_year=args.start_year,

--- a/tools/analyze_cftime_exact_order_stat_design.py
+++ b/tools/analyze_cftime_exact_order_stat_design.py
@@ -1,0 +1,244 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+import numpy as np
+import xarray as xr
+
+NON_LEAP_DAY_COUNT = 365
+
+
+@dataclass(frozen=True)
+class ReplacementStructureSummary:
+    max_samples_per_doy: int
+    min_samples_per_doy: int
+    mean_samples_per_doy: float
+    max_target_year_slots_per_doy: int
+    min_target_year_slots_per_doy: int
+    mean_target_year_slots_per_doy: float
+    max_effective_substitute_slots_per_doy: int
+    min_effective_substitute_slots_per_doy: int
+    mean_effective_substitute_slots_per_doy: float
+
+
+@dataclass(frozen=True)
+class OrderStatDesignAnalysis:
+    study_year_count: int
+    reference_year_count: int
+    overlap_year_count: int
+    non_overlap_year_count: int
+    output_group_count: int
+    spatial_cell_count: int
+    current_threshold_series_per_cell: int
+    overlap_series_per_cell: int
+    replacement_structure: ReplacementStructureSummary
+
+
+def _resolve_import_root(repo: Path) -> Path:
+    for candidate in (repo / "src", repo):
+        if (candidate / "icclim" / "__init__.py").is_file():
+            return candidate
+    msg = f"Could not locate icclim import root under {repo}"
+    raise FileNotFoundError(msg)
+
+
+def _build_synthetic_cftime_tas(
+    *,
+    start_year: int,
+    study_year_count: int,
+    lat_length: int,
+    lon_length: int,
+) -> xr.DataArray:
+    end_year = start_year + study_year_count - 1
+    time = xr.date_range(
+        f"{start_year}-01-01",
+        f"{end_year}-12-31",
+        freq="D",
+        use_cftime=True,
+    )
+    values = np.full((len(time), lat_length, lon_length), 300.0, dtype=np.float32)
+    return xr.DataArray(
+        values,
+        dims=["time", "lat", "lon"],
+        coords={
+            "time": time,
+            "lat": np.arange(lat_length),
+            "lon": np.arange(lon_length),
+        },
+        attrs={"units": "K"},
+        name="tas",
+    )
+
+
+def _summarize_replacement_structure(
+    sample_indices: np.ndarray,
+    index_year: np.ndarray,
+    index_pos: np.ndarray,
+    substitute_aligned: np.ndarray,
+) -> ReplacementStructureSummary:
+    n_doys = sample_indices.shape[0]
+    n_ref_years = substitute_aligned.shape[1]
+    sample_count_per_doy = np.count_nonzero(sample_indices >= 0, axis=1)
+    target_year_slots = np.zeros((n_ref_years, n_doys), dtype=np.int64)
+    effective_substitute_slots = []
+
+    for doy_i in range(n_doys):
+        for sample_i in range(sample_indices.shape[1]):
+            ref_i = sample_indices[doy_i, sample_i]
+            if ref_i < 0:
+                continue
+            target_ref_i = index_year[ref_i]
+            if target_ref_i < 0:
+                continue
+            target_year_slots[target_ref_i, doy_i] += 1
+
+    for target_ref_i in range(n_ref_years):
+        for substitute_i in range(n_ref_years):
+            if substitute_i == target_ref_i:
+                continue
+            for doy_i in range(n_doys):
+                count = 0
+                for sample_i in range(sample_indices.shape[1]):
+                    ref_i = sample_indices[doy_i, sample_i]
+                    if ref_i < 0 or index_year[ref_i] != target_ref_i:
+                        continue
+                    mapped_i = substitute_aligned[
+                        target_ref_i,
+                        substitute_i,
+                        index_pos[ref_i],
+                    ]
+                    if mapped_i >= 0:
+                        count += 1
+                effective_substitute_slots.append(count)
+
+    non_zero_target_slots = target_year_slots[target_year_slots > 0]
+    effective_substitute_slots_array = np.asarray(
+        effective_substitute_slots,
+        dtype=np.int64,
+    )
+    max_samples_per_doy = int(sample_count_per_doy.max()) if sample_count_per_doy.size else 0
+    min_samples_per_doy = int(sample_count_per_doy.min()) if sample_count_per_doy.size else 0
+    max_target_year_slots_per_doy = (
+        int(non_zero_target_slots.max()) if non_zero_target_slots.size else 0
+    )
+    min_target_year_slots_per_doy = (
+        int(non_zero_target_slots.min()) if non_zero_target_slots.size else 0
+    )
+    max_effective_substitute_slots_per_doy = (
+        int(effective_substitute_slots_array.max())
+        if effective_substitute_slots_array.size
+        else 0
+    )
+    min_effective_substitute_slots_per_doy = (
+        int(effective_substitute_slots_array.min())
+        if effective_substitute_slots_array.size
+        else 0
+    )
+    return ReplacementStructureSummary(
+        max_samples_per_doy=max_samples_per_doy,
+        min_samples_per_doy=min_samples_per_doy,
+        mean_samples_per_doy=float(sample_count_per_doy.mean()),
+        max_target_year_slots_per_doy=max_target_year_slots_per_doy,
+        min_target_year_slots_per_doy=min_target_year_slots_per_doy,
+        mean_target_year_slots_per_doy=float(non_zero_target_slots.mean()),
+        max_effective_substitute_slots_per_doy=max_effective_substitute_slots_per_doy,
+        min_effective_substitute_slots_per_doy=min_effective_substitute_slots_per_doy,
+        mean_effective_substitute_slots_per_doy=float(
+            effective_substitute_slots_array.mean()
+        ),
+    )
+
+
+def analyze_order_stat_design(
+    *,
+    start_year: int,
+    study_year_count: int,
+    reference_start_year: int,
+    reference_year_count: int,
+    lat_length: int,
+    lon_length: int,
+    freq: str,
+) -> OrderStatDesignAnalysis:
+    from icclim._core.generic.bootstrap_primitives import (  # noqa: PLC0415
+        build_bootstrap_prepared_inputs,
+    )
+    from icclim.threshold.factory import build_threshold  # noqa: PLC0415
+
+    tas = _build_synthetic_cftime_tas(
+        start_year=start_year,
+        study_year_count=study_year_count,
+        lat_length=lat_length,
+        lon_length=lon_length,
+    )
+    reference_end_year = reference_start_year + reference_year_count - 1
+    threshold = build_threshold(
+        query="> 90 doy_per",
+        reference_period=(
+            f"{reference_start_year}-01-01",
+            f"{reference_end_year}-12-31",
+        ),
+    )
+    prepared = build_bootstrap_prepared_inputs(
+        tas,
+        threshold,
+        freq,
+        dtype=np.float64,
+    )
+    indexing = prepared.temporal_indexing
+    overlap_year_count = int(np.count_nonzero(indexing.year_to_reference_index >= 0))
+    non_overlap_year_count = len(indexing.bootstrap_years) - overlap_year_count
+    overlap_series_per_cell = overlap_year_count * (reference_year_count - 1)
+    replacement_structure = _summarize_replacement_structure(
+        indexing.sample_indices_by_day_of_year,
+        indexing.reference_index_year,
+        indexing.reference_index_position,
+        indexing.substitute_alignment,
+    )
+    return OrderStatDesignAnalysis(
+        study_year_count=len(indexing.bootstrap_years),
+        reference_year_count=reference_year_count,
+        overlap_year_count=overlap_year_count,
+        non_overlap_year_count=non_overlap_year_count,
+        output_group_count=len(indexing.output_group_labels),
+        spatial_cell_count=int(np.prod(prepared.array_inputs.spatial_shape)),
+        current_threshold_series_per_cell=(
+            non_overlap_year_count + overlap_series_per_cell
+        ),
+        overlap_series_per_cell=overlap_series_per_cell,
+        replacement_structure=replacement_structure,
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo", default=Path(__file__).resolve().parents[1])
+    parser.add_argument("--start-year", type=int, default=1950)
+    parser.add_argument("--study-years", type=int, default=65)
+    parser.add_argument("--reference-start-year", type=int, default=1961)
+    parser.add_argument("--reference-years", type=int, default=30)
+    parser.add_argument("--lat-length", type=int, default=28)
+    parser.add_argument("--lon-length", type=int, default=21)
+    parser.add_argument("--freq", default="MS")
+    args = parser.parse_args()
+
+    repo = Path(args.repo).resolve()
+    sys.path.insert(0, str(_resolve_import_root(repo)))
+
+    analysis = analyze_order_stat_design(
+        start_year=args.start_year,
+        study_year_count=args.study_years,
+        reference_start_year=args.reference_start_year,
+        reference_year_count=args.reference_years,
+        lat_length=args.lat_length,
+        lon_length=args.lon_length,
+        freq=args.freq,
+    )
+    print(json.dumps(asdict(analysis), indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/analyze_cftime_exact_order_stat_design.py
+++ b/tools/analyze_cftime_exact_order_stat_design.py
@@ -120,8 +120,12 @@ def _summarize_replacement_structure(
         effective_substitute_slots,
         dtype=np.int64,
     )
-    max_samples_per_doy = int(sample_count_per_doy.max()) if sample_count_per_doy.size else 0
-    min_samples_per_doy = int(sample_count_per_doy.min()) if sample_count_per_doy.size else 0
+    max_samples_per_doy = (
+        int(sample_count_per_doy.max()) if sample_count_per_doy.size else 0
+    )
+    min_samples_per_doy = (
+        int(sample_count_per_doy.min()) if sample_count_per_doy.size else 0
+    )
     max_target_year_slots_per_doy = (
         int(non_zero_target_slots.max()) if non_zero_target_slots.size else 0
     )
@@ -163,10 +167,10 @@ def analyze_order_stat_design(
     lon_length: int,
     freq: str,
 ) -> OrderStatDesignAnalysis:
-    from icclim._core.generic.bootstrap_primitives import (  # noqa: PLC0415
+    from icclim._core.generic.bootstrap_primitives import (
         build_bootstrap_prepared_inputs,
     )
-    from icclim.threshold.factory import build_threshold  # noqa: PLC0415
+    from icclim.threshold.factory import build_threshold
 
     tas = _build_synthetic_cftime_tas(
         start_year=start_year,

--- a/tools/benchmark_cftime_count_prototypes.py
+++ b/tools/benchmark_cftime_count_prototypes.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import argparse
+import json
+from contextlib import contextmanager
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from time import perf_counter
+
+import cftime
+import numpy as np
+import xarray as xr
+
+
+def _resolve_import_root(repo: Path) -> Path:
+    for candidate in (repo / "src", repo):
+        if (candidate / "icclim" / "__init__.py").is_file():
+            return candidate
+    msg = f"Could not locate icclim import root under {repo}"
+    raise FileNotFoundError(msg)
+
+
+def _build_time_coord(start_year: int, study_year_count: int) -> list[cftime.DatetimeGregorian]:
+    end_year = start_year + study_year_count - 1
+    time = xr.date_range(
+        f"{start_year}-01-01",
+        f"{end_year}-12-31",
+        freq="D",
+        use_cftime=True,
+    )
+    return [
+        cftime.DatetimeGregorian(int(ts.year), int(ts.month), int(ts.day))
+        for ts in time
+    ]
+
+
+def _build_case(
+    case_name: str,
+    *,
+    start_year: int,
+    study_year_count: int,
+    lat_length: int,
+    lon_length: int,
+) -> xr.DataArray:
+    time = _build_time_coord(start_year, study_year_count)
+    data = np.full((len(time), lat_length, lon_length), 300.0, dtype=np.float64)
+    tas = xr.DataArray(
+        data,
+        dims=["time", "lat", "lon"],
+        coords={
+            "time": time,
+            "lat": np.arange(lat_length, dtype=np.float64),
+            "lon": np.arange(lon_length, dtype=np.float64),
+        },
+        attrs={"units": "K"},
+        name="tas",
+    )
+    if case_name == "constant":
+        return tas.chunk({"time": 365, "lat": max(1, lat_length), "lon": max(1, lon_length)})
+    if case_name == "leap_day_cold_spike":
+        for timestamp in (
+            cftime.DatetimeGregorian(2044, 2, 28),
+            cftime.DatetimeGregorian(2044, 2, 29),
+            cftime.DatetimeGregorian(2044, 3, 1),
+        ):
+            if timestamp in tas.indexes["time"]:
+                tas.loc[{"time": timestamp}] = 250.0
+        return tas.chunk({"time": 365, "lat": max(1, lat_length), "lon": max(1, lon_length)})
+    if case_name == "reference_overlap_shift":
+        for year, month, day, value in (
+            (2042, 2, 28, 305.0),
+            (2043, 2, 28, 295.0),
+            (2044, 2, 29, 285.0),
+            (2045, 2, 28, 310.0),
+            (2045, 3, 1, 280.0),
+        ):
+            timestamp = cftime.DatetimeGregorian(year, month, day)
+            if timestamp in tas.indexes["time"]:
+                tas.loc[{"time": timestamp}] = value
+        return tas.chunk({"time": 365, "lat": max(1, lat_length), "lon": max(1, lon_length)})
+    msg = f"Unsupported case: {case_name}"
+    raise ValueError(msg)
+
+
+def _build_threshold(reference_start_year: int, reference_year_count: int):
+    from icclim.threshold.factory import build_threshold  # noqa: PLC0415
+
+    reference_end_year = reference_start_year + reference_year_count - 1
+    return build_threshold(
+        "> 90 doy_per",
+        doy_window_width=1,
+        reference_period=(
+            f"{reference_start_year}-01-01",
+            f"{reference_end_year}-12-31",
+        ),
+    )
+
+
+@contextmanager
+def _force_compiled_cftime_count():
+    from icclim._core.generic import bootstrap as bootstrap_module  # noqa: PLC0415
+
+    original = bootstrap_module.is_optimized_doy_percentile_count_supported
+    bootstrap_module.is_optimized_doy_percentile_count_supported = lambda *_: True
+    try:
+        yield
+    finally:
+        bootstrap_module.is_optimized_doy_percentile_count_supported = original
+
+
+@dataclass(frozen=True)
+class BenchmarkResult:
+    case_name: str
+    freq: str
+    lat_length: int
+    lon_length: int
+    study_year_count: int
+    reference_year_count: int
+    current_seconds: float
+    prototype_seconds: float
+    speed_ratio_current_over_prototype: float
+    changed_cells: int
+    max_abs_diff: float
+
+
+def _benchmark_one(
+    *,
+    case_name: str,
+    freq: str,
+    start_year: int,
+    study_year_count: int,
+    reference_start_year: int,
+    reference_year_count: int,
+    lat_length: int,
+    lon_length: int,
+) -> BenchmarkResult:
+    from icclim._core.generic.bootstrap import (  # noqa: PLC0415
+        compute_doy_percentile_bootstrap_count,
+        compute_doy_percentile_bootstrap_count_threshold_bank_prototype,
+    )
+
+    tas = _build_case(
+        case_name,
+        start_year=start_year,
+        study_year_count=study_year_count,
+        lat_length=lat_length,
+        lon_length=lon_length,
+    )
+    threshold = _build_threshold(reference_start_year, reference_year_count)
+
+    current_start = perf_counter()
+    with _force_compiled_cftime_count():
+        current = compute_doy_percentile_bootstrap_count(tas, threshold, freq)
+    current_seconds = perf_counter() - current_start
+    if current is None:
+        msg = f"Current compiled count returned None for case={case_name} freq={freq}"
+        raise RuntimeError(msg)
+    current = current.load()
+
+    prototype_start = perf_counter()
+    prototype = compute_doy_percentile_bootstrap_count_threshold_bank_prototype(
+        tas,
+        threshold,
+        freq,
+    )
+    prototype_seconds = perf_counter() - prototype_start
+    if prototype is None:
+        msg = f"Threshold-bank prototype returned None for case={case_name} freq={freq}"
+        raise RuntimeError(msg)
+    prototype = prototype.load()
+
+    diff = np.abs(np.asarray(current.values) - np.asarray(prototype.values))
+    changed_cells = int(np.count_nonzero(diff > 1.0e-9))
+    max_abs_diff = float(np.nanmax(diff)) if diff.size else 0.0
+    speed_ratio = (
+        current_seconds / prototype_seconds
+        if prototype_seconds > 0.0
+        else float("inf")
+    )
+    return BenchmarkResult(
+        case_name=case_name,
+        freq=freq,
+        lat_length=lat_length,
+        lon_length=lon_length,
+        study_year_count=study_year_count,
+        reference_year_count=reference_year_count,
+        current_seconds=current_seconds,
+        prototype_seconds=prototype_seconds,
+        speed_ratio_current_over_prototype=speed_ratio,
+        changed_cells=changed_cells,
+        max_abs_diff=max_abs_diff,
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo", required=True)
+    parser.add_argument(
+        "--case",
+        choices=("constant", "leap_day_cold_spike", "reference_overlap_shift"),
+        default="reference_overlap_shift",
+    )
+    parser.add_argument("--freq", choices=("MS", "YS"), default="MS")
+    parser.add_argument("--start-year", type=int, default=1950)
+    parser.add_argument("--study-years", type=int, default=65)
+    parser.add_argument("--reference-start-year", type=int, default=1961)
+    parser.add_argument("--reference-years", type=int, default=30)
+    parser.add_argument("--lat-length", type=int, default=4)
+    parser.add_argument("--lon-length", type=int, default=4)
+    args = parser.parse_args()
+
+    repo = Path(args.repo).resolve()
+    import_root = _resolve_import_root(repo)
+
+    import sys
+
+    sys.path.insert(0, str(import_root))
+
+    result = _benchmark_one(
+        case_name=args.case,
+        freq=args.freq,
+        start_year=args.start_year,
+        study_year_count=args.study_years,
+        reference_start_year=args.reference_start_year,
+        reference_year_count=args.reference_years,
+        lat_length=args.lat_length,
+        lon_length=args.lon_length,
+    )
+    print(json.dumps(asdict(result), indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/benchmark_cftime_count_prototypes.py
+++ b/tools/benchmark_cftime_count_prototypes.py
@@ -1,3 +1,5 @@
+# ruff: noqa: PLR2004
+
 from __future__ import annotations
 
 import argparse

--- a/tools/benchmark_cftime_count_prototypes.py
+++ b/tools/benchmark_cftime_count_prototypes.py
@@ -117,10 +117,14 @@ class BenchmarkResult:
     study_year_count: int
     reference_year_count: int
     current_seconds: float
-    prototype_seconds: float
-    speed_ratio_current_over_prototype: float
+    python_prototype_seconds: float
+    compiled_prototype_seconds: float
+    speed_ratio_current_over_python: float
+    speed_ratio_current_over_compiled: float
     changed_cells: int
     max_abs_diff: float
+    compiled_changed_cells: int
+    compiled_max_abs_diff: float
 
 
 def _benchmark_one(
@@ -136,6 +140,7 @@ def _benchmark_one(
 ) -> BenchmarkResult:
     from icclim._core.generic.bootstrap import (  # noqa: PLC0415
         compute_doy_percentile_bootstrap_count,
+        compute_doy_percentile_bootstrap_count_threshold_bank_compiled_prototype,
         compute_doy_percentile_bootstrap_count_threshold_bank_prototype,
     )
 
@@ -163,18 +168,47 @@ def _benchmark_one(
         threshold,
         freq,
     )
-    prototype_seconds = perf_counter() - prototype_start
+    python_prototype_seconds = perf_counter() - prototype_start
     if prototype is None:
         msg = f"Threshold-bank prototype returned None for case={case_name} freq={freq}"
         raise RuntimeError(msg)
     prototype = prototype.load()
 
+    compiled_start = perf_counter()
+    compiled_prototype = (
+        compute_doy_percentile_bootstrap_count_threshold_bank_compiled_prototype(
+            tas,
+            threshold,
+            freq,
+        )
+    )
+    compiled_prototype_seconds = perf_counter() - compiled_start
+    if compiled_prototype is None:
+        msg = (
+            "Compiled threshold-bank prototype returned None for "
+            f"case={case_name} freq={freq}"
+        )
+        raise RuntimeError(msg)
+    compiled_prototype = compiled_prototype.load()
+
     diff = np.abs(np.asarray(current.values) - np.asarray(prototype.values))
     changed_cells = int(np.count_nonzero(diff > 1.0e-9))
     max_abs_diff = float(np.nanmax(diff)) if diff.size else 0.0
-    speed_ratio = (
-        current_seconds / prototype_seconds
-        if prototype_seconds > 0.0
+    compiled_diff = np.abs(
+        np.asarray(current.values) - np.asarray(compiled_prototype.values)
+    )
+    compiled_changed_cells = int(np.count_nonzero(compiled_diff > 1.0e-9))
+    compiled_max_abs_diff = (
+        float(np.nanmax(compiled_diff)) if compiled_diff.size else 0.0
+    )
+    speed_ratio_current_over_python = (
+        current_seconds / python_prototype_seconds
+        if python_prototype_seconds > 0.0
+        else float("inf")
+    )
+    speed_ratio_current_over_compiled = (
+        current_seconds / compiled_prototype_seconds
+        if compiled_prototype_seconds > 0.0
         else float("inf")
     )
     return BenchmarkResult(
@@ -185,10 +219,14 @@ def _benchmark_one(
         study_year_count=study_year_count,
         reference_year_count=reference_year_count,
         current_seconds=current_seconds,
-        prototype_seconds=prototype_seconds,
-        speed_ratio_current_over_prototype=speed_ratio,
+        python_prototype_seconds=python_prototype_seconds,
+        compiled_prototype_seconds=compiled_prototype_seconds,
+        speed_ratio_current_over_python=speed_ratio_current_over_python,
+        speed_ratio_current_over_compiled=speed_ratio_current_over_compiled,
         changed_cells=changed_cells,
         max_abs_diff=max_abs_diff,
+        compiled_changed_cells=compiled_changed_cells,
+        compiled_max_abs_diff=compiled_max_abs_diff,
     )
 
 

--- a/tools/benchmark_cftime_count_prototypes.py
+++ b/tools/benchmark_cftime_count_prototypes.py
@@ -20,7 +20,9 @@ def _resolve_import_root(repo: Path) -> Path:
     raise FileNotFoundError(msg)
 
 
-def _build_time_coord(start_year: int, study_year_count: int) -> list[cftime.DatetimeGregorian]:
+def _build_time_coord(
+    start_year: int, study_year_count: int
+) -> list[cftime.DatetimeGregorian]:
     end_year = start_year + study_year_count - 1
     time = xr.date_range(
         f"{start_year}-01-01",
@@ -56,7 +58,9 @@ def _build_case(
         name="tas",
     )
     if case_name == "constant":
-        return tas.chunk({"time": 365, "lat": max(1, lat_length), "lon": max(1, lon_length)})
+        return tas.chunk(
+            {"time": 365, "lat": max(1, lat_length), "lon": max(1, lon_length)}
+        )
     if case_name == "leap_day_cold_spike":
         for timestamp in (
             cftime.DatetimeGregorian(2044, 2, 28),
@@ -65,7 +69,9 @@ def _build_case(
         ):
             if timestamp in tas.indexes["time"]:
                 tas.loc[{"time": timestamp}] = 250.0
-        return tas.chunk({"time": 365, "lat": max(1, lat_length), "lon": max(1, lon_length)})
+        return tas.chunk(
+            {"time": 365, "lat": max(1, lat_length), "lon": max(1, lon_length)}
+        )
     if case_name == "reference_overlap_shift":
         for year, month, day, value in (
             (2042, 2, 28, 305.0),
@@ -77,13 +83,15 @@ def _build_case(
             timestamp = cftime.DatetimeGregorian(year, month, day)
             if timestamp in tas.indexes["time"]:
                 tas.loc[{"time": timestamp}] = value
-        return tas.chunk({"time": 365, "lat": max(1, lat_length), "lon": max(1, lon_length)})
+        return tas.chunk(
+            {"time": 365, "lat": max(1, lat_length), "lon": max(1, lon_length)}
+        )
     msg = f"Unsupported case: {case_name}"
     raise ValueError(msg)
 
 
 def _build_threshold(reference_start_year: int, reference_year_count: int):
-    from icclim.threshold.factory import build_threshold  # noqa: PLC0415
+    from icclim.threshold.factory import build_threshold
 
     reference_end_year = reference_start_year + reference_year_count - 1
     return build_threshold(
@@ -98,7 +106,7 @@ def _build_threshold(reference_start_year: int, reference_year_count: int):
 
 @contextmanager
 def _force_compiled_cftime_count():
-    from icclim._core.generic import bootstrap as bootstrap_module  # noqa: PLC0415
+    from icclim._core.generic import bootstrap as bootstrap_module
 
     original = bootstrap_module.is_optimized_doy_percentile_count_supported
     bootstrap_module.is_optimized_doy_percentile_count_supported = lambda *_: True
@@ -138,7 +146,7 @@ def _benchmark_one(
     lat_length: int,
     lon_length: int,
 ) -> BenchmarkResult:
-    from icclim._core.generic.bootstrap import (  # noqa: PLC0415
+    from icclim._core.generic.bootstrap import (
         compute_doy_percentile_bootstrap_count,
         compute_doy_percentile_bootstrap_count_threshold_bank_compiled_prototype,
         compute_doy_percentile_bootstrap_count_threshold_bank_prototype,

--- a/tools/benchmark_cftime_order_stat_compiled.py
+++ b/tools/benchmark_cftime_order_stat_compiled.py
@@ -60,7 +60,9 @@ def _build_case(
         name="tas",
     )
     if case_name == "constant":
-        return tas.chunk({"time": 365, "lat": max(1, lat_length), "lon": max(1, lon_length)})
+        return tas.chunk(
+            {"time": 365, "lat": max(1, lat_length), "lon": max(1, lon_length)}
+        )
     if case_name == "leap_day_cold_spike":
         for timestamp in (
             cftime.DatetimeGregorian(2044, 2, 28),
@@ -69,7 +71,9 @@ def _build_case(
         ):
             if timestamp in tas.indexes["time"]:
                 tas.loc[{"time": timestamp}] = 250.0
-        return tas.chunk({"time": 365, "lat": max(1, lat_length), "lon": max(1, lon_length)})
+        return tas.chunk(
+            {"time": 365, "lat": max(1, lat_length), "lon": max(1, lon_length)}
+        )
     if case_name == "reference_overlap_shift":
         for year, month, day, value in (
             (2042, 2, 28, 305.0),
@@ -81,13 +85,15 @@ def _build_case(
             timestamp = cftime.DatetimeGregorian(year, month, day)
             if timestamp in tas.indexes["time"]:
                 tas.loc[{"time": timestamp}] = value
-        return tas.chunk({"time": 365, "lat": max(1, lat_length), "lon": max(1, lon_length)})
+        return tas.chunk(
+            {"time": 365, "lat": max(1, lat_length), "lon": max(1, lon_length)}
+        )
     msg = f"Unsupported case: {case_name}"
     raise ValueError(msg)
 
 
 def _build_threshold(reference_start_year: int, reference_year_count: int):
-    from icclim.threshold.factory import build_threshold  # noqa: PLC0415
+    from icclim.threshold.factory import build_threshold
 
     reference_end_year = reference_start_year + reference_year_count - 1
     return build_threshold(
@@ -102,7 +108,7 @@ def _build_threshold(reference_start_year: int, reference_year_count: int):
 
 @contextmanager
 def _force_compiled_cftime_count():
-    from icclim._core.generic import bootstrap as bootstrap_module  # noqa: PLC0415
+    from icclim._core.generic import bootstrap as bootstrap_module
 
     original = bootstrap_module.is_optimized_doy_percentile_count_supported
     bootstrap_module.is_optimized_doy_percentile_count_supported = lambda *_: True
@@ -215,7 +221,9 @@ def _build_compiled_order_stat_kernel():
         return n
 
     @njit(cache=True)
-    def _value_at_adjusted_rank(base_buf, base_n, removed_buf, removed_n, inserted_buf, inserted_n, rank):
+    def _value_at_adjusted_rank(
+        base_buf, base_n, removed_buf, removed_n, inserted_buf, inserted_n, rank
+    ):
         base_i = 0
         removed_i = 0
         inserted_i = 0
@@ -232,7 +240,9 @@ def _build_compiled_order_stat_kernel():
             has_inserted = inserted_i < inserted_n
             if not has_base and not has_inserted:
                 return np.nan
-            if has_inserted and (not has_base or inserted_buf[inserted_i] <= base_buf[base_i]):
+            if has_inserted and (
+                not has_base or inserted_buf[inserted_i] <= base_buf[base_i]
+            ):
                 value = inserted_buf[inserted_i]
                 inserted_i += 1
             else:
@@ -546,7 +556,7 @@ def _compute_compiled_order_stat(
     lat_length: int,
     lon_length: int,
 ) -> tuple[xr.DataArray, float]:
-    from icclim._core.generic.bootstrap_primitives import (  # noqa: PLC0415
+    from icclim._core.generic.bootstrap_primitives import (
         build_bootstrap_output,
         build_bootstrap_prepared_inputs,
     )
@@ -626,7 +636,9 @@ def _compute_current(
     lat_length: int,
     lon_length: int,
 ) -> tuple[xr.DataArray, float]:
-    from icclim._core.generic.bootstrap import compute_doy_percentile_bootstrap_count  # noqa: PLC0415
+    from icclim._core.generic.bootstrap import (
+        compute_doy_percentile_bootstrap_count,
+    )
 
     tas = _build_case(
         case_name,
@@ -657,7 +669,7 @@ def _compute_compiled_bank(
     lat_length: int,
     lon_length: int,
 ) -> tuple[xr.DataArray, float]:
-    from icclim._core.generic.bootstrap import (  # noqa: PLC0415
+    from icclim._core.generic.bootstrap import (
         compute_doy_percentile_bootstrap_count_threshold_bank_compiled_prototype,
     )
 

--- a/tools/benchmark_cftime_order_stat_compiled.py
+++ b/tools/benchmark_cftime_order_stat_compiled.py
@@ -1,0 +1,794 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from contextlib import contextmanager
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from time import perf_counter
+
+import cftime
+import numpy as np
+import xarray as xr
+
+
+def _resolve_import_root(repo: Path) -> Path:
+    for candidate in (repo / "src", repo):
+        if (candidate / "icclim" / "__init__.py").is_file():
+            return candidate
+    msg = f"Could not locate icclim import root under {repo}"
+    raise FileNotFoundError(msg)
+
+
+def _build_time_coord(
+    start_year: int,
+    study_year_count: int,
+) -> list[cftime.DatetimeGregorian]:
+    end_year = start_year + study_year_count - 1
+    time = xr.date_range(
+        f"{start_year}-01-01",
+        f"{end_year}-12-31",
+        freq="D",
+        use_cftime=True,
+    )
+    return [
+        cftime.DatetimeGregorian(int(ts.year), int(ts.month), int(ts.day))
+        for ts in time
+    ]
+
+
+def _build_case(
+    case_name: str,
+    *,
+    start_year: int,
+    study_year_count: int,
+    lat_length: int,
+    lon_length: int,
+) -> xr.DataArray:
+    time = _build_time_coord(start_year, study_year_count)
+    data = np.full((len(time), lat_length, lon_length), 300.0, dtype=np.float64)
+    tas = xr.DataArray(
+        data,
+        dims=["time", "lat", "lon"],
+        coords={
+            "time": time,
+            "lat": np.arange(lat_length, dtype=np.float64),
+            "lon": np.arange(lon_length, dtype=np.float64),
+        },
+        attrs={"units": "K"},
+        name="tas",
+    )
+    if case_name == "constant":
+        return tas.chunk({"time": 365, "lat": max(1, lat_length), "lon": max(1, lon_length)})
+    if case_name == "leap_day_cold_spike":
+        for timestamp in (
+            cftime.DatetimeGregorian(2044, 2, 28),
+            cftime.DatetimeGregorian(2044, 2, 29),
+            cftime.DatetimeGregorian(2044, 3, 1),
+        ):
+            if timestamp in tas.indexes["time"]:
+                tas.loc[{"time": timestamp}] = 250.0
+        return tas.chunk({"time": 365, "lat": max(1, lat_length), "lon": max(1, lon_length)})
+    if case_name == "reference_overlap_shift":
+        for year, month, day, value in (
+            (2042, 2, 28, 305.0),
+            (2043, 2, 28, 295.0),
+            (2044, 2, 29, 285.0),
+            (2045, 2, 28, 310.0),
+            (2045, 3, 1, 280.0),
+        ):
+            timestamp = cftime.DatetimeGregorian(year, month, day)
+            if timestamp in tas.indexes["time"]:
+                tas.loc[{"time": timestamp}] = value
+        return tas.chunk({"time": 365, "lat": max(1, lat_length), "lon": max(1, lon_length)})
+    msg = f"Unsupported case: {case_name}"
+    raise ValueError(msg)
+
+
+def _build_threshold(reference_start_year: int, reference_year_count: int):
+    from icclim.threshold.factory import build_threshold  # noqa: PLC0415
+
+    reference_end_year = reference_start_year + reference_year_count - 1
+    return build_threshold(
+        "> 90 doy_per",
+        doy_window_width=1,
+        reference_period=(
+            f"{reference_start_year}-01-01",
+            f"{reference_end_year}-12-31",
+        ),
+    )
+
+
+@contextmanager
+def _force_compiled_cftime_count():
+    from icclim._core.generic import bootstrap as bootstrap_module  # noqa: PLC0415
+
+    original = bootstrap_module.is_optimized_doy_percentile_count_supported
+    bootstrap_module.is_optimized_doy_percentile_count_supported = lambda *_: True
+    try:
+        yield
+    finally:
+        bootstrap_module.is_optimized_doy_percentile_count_supported = original
+
+
+@dataclass(frozen=True)
+class CompiledOrderStatBenchmark:
+    case_name: str
+    freq: str
+    lat_length: int
+    lon_length: int
+    current_seconds: float
+    compiled_bank_seconds: float
+    compiled_order_stat_seconds: float
+    changed_cells_vs_current: int
+    max_abs_diff_vs_current: float
+    speed_ratio_current_over_compiled_order_stat: float
+    speed_ratio_compiled_bank_over_compiled_order_stat: float
+
+
+def _load_numba():
+    from numba import njit, prange
+
+    return njit, prange
+
+
+def _build_compiled_order_stat_kernel():
+    njit, prange = _load_numba()
+    NON_LEAP_DAY_COUNT = 365
+
+    @njit(cache=True)
+    def _fill_sorted_nominal_values(
+        flat_ref,
+        sample_indices,
+        doy_i,
+        cell,
+        base_buf,
+    ):
+        n = 0
+        for sample_i in range(sample_indices.shape[1]):
+            ref_i = sample_indices[doy_i, sample_i]
+            if ref_i < 0:
+                continue
+            value = flat_ref[ref_i, cell]
+            if not np.isnan(value):
+                base_buf[n] = value
+                n += 1
+        if n > 1:
+            base_buf[:n].sort()
+        return n
+
+    @njit(cache=True)
+    def _fill_sorted_removed_values(
+        flat_ref,
+        sample_indices,
+        index_year,
+        doy_i,
+        cell,
+        target_ref_i,
+        removed_buf,
+    ):
+        if target_ref_i < 0:
+            return 0
+        n = 0
+        for sample_i in range(sample_indices.shape[1]):
+            ref_i = sample_indices[doy_i, sample_i]
+            if ref_i < 0 or index_year[ref_i] != target_ref_i:
+                continue
+            value = flat_ref[ref_i, cell]
+            if not np.isnan(value):
+                removed_buf[n] = value
+                n += 1
+        if n > 1:
+            removed_buf[:n].sort()
+        return n
+
+    @njit(cache=True)
+    def _fill_sorted_inserted_values(
+        flat_ref,
+        sample_indices,
+        index_year,
+        index_pos,
+        substitute_aligned,
+        doy_i,
+        cell,
+        target_ref_i,
+        substitute_i,
+        inserted_buf,
+    ):
+        if target_ref_i < 0 or substitute_i < 0:
+            return 0
+        n = 0
+        for sample_i in range(sample_indices.shape[1]):
+            ref_i = sample_indices[doy_i, sample_i]
+            if ref_i < 0 or index_year[ref_i] != target_ref_i:
+                continue
+            mapped_i = substitute_aligned[target_ref_i, substitute_i, index_pos[ref_i]]
+            if mapped_i < 0:
+                continue
+            value = flat_ref[mapped_i, cell]
+            if not np.isnan(value):
+                inserted_buf[n] = value
+                n += 1
+        if n > 1:
+            inserted_buf[:n].sort()
+        return n
+
+    @njit(cache=True)
+    def _value_at_adjusted_rank(base_buf, base_n, removed_buf, removed_n, inserted_buf, inserted_n, rank):
+        base_i = 0
+        removed_i = 0
+        inserted_i = 0
+        current_rank = -1
+        while True:
+            while (
+                base_i < base_n
+                and removed_i < removed_n
+                and base_buf[base_i] == removed_buf[removed_i]
+            ):
+                base_i += 1
+                removed_i += 1
+            has_base = base_i < base_n
+            has_inserted = inserted_i < inserted_n
+            if not has_base and not has_inserted:
+                return np.nan
+            if has_inserted and (not has_base or inserted_buf[inserted_i] <= base_buf[base_i]):
+                value = inserted_buf[inserted_i]
+                inserted_i += 1
+            else:
+                value = base_buf[base_i]
+                base_i += 1
+            current_rank += 1
+            if current_rank == rank:
+                return value
+
+    @njit(cache=True)
+    def _method8_adjusted_quantile(
+        base_buf,
+        base_n,
+        removed_buf,
+        removed_n,
+        inserted_buf,
+        inserted_n,
+        quantile,
+        alpha,
+        beta,
+    ):
+        n = base_n - removed_n + inserted_n
+        if n <= 0:
+            return np.nan
+        if n == 1:
+            return _value_at_adjusted_rank(
+                base_buf,
+                base_n,
+                removed_buf,
+                removed_n,
+                inserted_buf,
+                inserted_n,
+                0,
+            )
+        virtual = n * quantile + (alpha + quantile * (1.0 - alpha - beta)) - 1.0
+        if virtual >= n - 1:
+            return _value_at_adjusted_rank(
+                base_buf,
+                base_n,
+                removed_buf,
+                removed_n,
+                inserted_buf,
+                inserted_n,
+                n - 1,
+            )
+        if virtual < 0.0:
+            return _value_at_adjusted_rank(
+                base_buf,
+                base_n,
+                removed_buf,
+                removed_n,
+                inserted_buf,
+                inserted_n,
+                0,
+            )
+        previous = int(np.floor(virtual))
+        gamma = virtual - previous
+        left = _value_at_adjusted_rank(
+            base_buf,
+            base_n,
+            removed_buf,
+            removed_n,
+            inserted_buf,
+            inserted_n,
+            previous,
+        )
+        right = _value_at_adjusted_rank(
+            base_buf,
+            base_n,
+            removed_buf,
+            removed_n,
+            inserted_buf,
+            inserted_n,
+            previous + 1,
+        )
+        diff = right - left
+        if gamma >= 0.5:
+            return right - diff * (1.0 - gamma)
+        return left + diff * gamma
+
+    @njit(cache=True)
+    def _adjusted_threshold(thresholds, doy, max_target_doy):
+        if max_target_doy == NON_LEAP_DAY_COUNT:
+            return thresholds[doy - 1]
+        position = (doy - 1.0) * 364.0 / 365.0
+        lower = int(np.floor(position))
+        if lower >= 364:
+            return thresholds[364]
+        gamma = position - lower
+        diff = thresholds[lower + 1] - thresholds[lower]
+        if gamma >= 0.5:
+            return thresholds[lower + 1] - diff * (1.0 - gamma)
+        return thresholds[lower] + diff * gamma
+
+    @njit(cache=True)
+    def _compare(value, threshold, op_code):
+        if op_code == 0:
+            return value > threshold
+        if op_code == 1:
+            return value >= threshold
+        if op_code == 2:
+            return value < threshold
+        return value <= threshold
+
+    @njit(cache=True)
+    def _count_exceedances(
+        flat_study,
+        thresholds,
+        study_doys,
+        start,
+        length,
+        cell,
+        max_target_doy,
+        op_code,
+    ):
+        count = 0.0
+        for offset in range(length):
+            doy = study_doys[start + offset]
+            threshold = _adjusted_threshold(thresholds, doy, max_target_doy)
+            value = flat_study[start + offset, cell]
+            if _compare(value, threshold, op_code):
+                count += 1.0
+        return count
+
+    @njit(cache=True)
+    def _build_thresholds_for_cell(
+        flat_ref,
+        sample_indices,
+        index_year,
+        index_pos,
+        substitute_aligned,
+        target_ref_i,
+        substitute_i,
+        cell,
+        quantile,
+        alpha,
+        beta,
+        min_threshold,
+        max_samples,
+    ):
+        thresholds = np.empty(NON_LEAP_DAY_COUNT, dtype=np.float64)
+        base_buf = np.empty(max_samples, dtype=np.float64)
+        removed_buf = np.empty(max_samples, dtype=np.float64)
+        inserted_buf = np.empty(max_samples, dtype=np.float64)
+        for doy_i in range(NON_LEAP_DAY_COUNT):
+            base_n = _fill_sorted_nominal_values(
+                flat_ref,
+                sample_indices,
+                doy_i,
+                cell,
+                base_buf,
+            )
+            removed_n = _fill_sorted_removed_values(
+                flat_ref,
+                sample_indices,
+                index_year,
+                doy_i,
+                cell,
+                target_ref_i,
+                removed_buf,
+            )
+            inserted_n = _fill_sorted_inserted_values(
+                flat_ref,
+                sample_indices,
+                index_year,
+                index_pos,
+                substitute_aligned,
+                doy_i,
+                cell,
+                target_ref_i,
+                substitute_i,
+                inserted_buf,
+            )
+            threshold_value = _method8_adjusted_quantile(
+                base_buf,
+                base_n,
+                removed_buf,
+                removed_n,
+                inserted_buf,
+                inserted_n,
+                quantile,
+                alpha,
+                beta,
+            )
+            if not np.isnan(min_threshold) and (
+                np.isnan(threshold_value) or threshold_value <= min_threshold
+            ):
+                threshold_value = min_threshold
+            thresholds[doy_i] = threshold_value
+        return thresholds
+
+    @njit(parallel=True, cache=True)
+    def _compiled_order_stat_count_kernel(
+        flat_ref,
+        flat_study,
+        sample_indices,
+        index_year,
+        index_pos,
+        substitute_aligned,
+        study_starts,
+        study_lengths,
+        year_group_starts,
+        year_group_stops,
+        year_max_doys,
+        year_to_ref,
+        study_doys,
+        quantile,
+        alpha,
+        beta,
+        op_code,
+        min_threshold,
+    ):
+        n_years = len(year_to_ref)
+        n_groups = len(study_starts)
+        n_cells = flat_study.shape[1]
+        n_ref_years = substitute_aligned.shape[1]
+        max_samples = sample_indices.shape[1]
+        out = np.empty((n_groups, n_cells), dtype=np.float64)
+        for flat_i in prange(n_years * n_cells):
+            year_i = flat_i // n_cells
+            cell = flat_i % n_cells
+            target_ref_i = year_to_ref[year_i]
+            group_start = year_group_starts[year_i]
+            group_stop = year_group_stops[year_i]
+            if target_ref_i < 0:
+                thresholds = _build_thresholds_for_cell(
+                    flat_ref,
+                    sample_indices,
+                    index_year,
+                    index_pos,
+                    substitute_aligned,
+                    -1,
+                    -1,
+                    cell,
+                    quantile,
+                    alpha,
+                    beta,
+                    min_threshold,
+                    max_samples,
+                )
+                for group_i in range(group_start, group_stop):
+                    out[group_i, cell] = _count_exceedances(
+                        flat_study,
+                        thresholds,
+                        study_doys,
+                        study_starts[group_i],
+                        study_lengths[group_i],
+                        cell,
+                        year_max_doys[year_i],
+                        op_code,
+                    )
+                continue
+            for group_i in range(group_start, group_stop):
+                out[group_i, cell] = 0.0
+            substitute_count = 0
+            for substitute_i in range(n_ref_years):
+                if substitute_i == target_ref_i:
+                    continue
+                thresholds = _build_thresholds_for_cell(
+                    flat_ref,
+                    sample_indices,
+                    index_year,
+                    index_pos,
+                    substitute_aligned,
+                    target_ref_i,
+                    substitute_i,
+                    cell,
+                    quantile,
+                    alpha,
+                    beta,
+                    min_threshold,
+                    max_samples,
+                )
+                for group_i in range(group_start, group_stop):
+                    out[group_i, cell] += _count_exceedances(
+                        flat_study,
+                        thresholds,
+                        study_doys,
+                        study_starts[group_i],
+                        study_lengths[group_i],
+                        cell,
+                        year_max_doys[year_i],
+                        op_code,
+                    )
+                substitute_count += 1
+            for group_i in range(group_start, group_stop):
+                out[group_i, cell] /= substitute_count
+        return out
+
+    return _compiled_order_stat_count_kernel
+
+
+_COMPILED_ORDER_STAT_COUNT_KERNEL = None
+
+
+def _compiled_order_stat_count_kernel():
+    global _COMPILED_ORDER_STAT_COUNT_KERNEL
+    if _COMPILED_ORDER_STAT_COUNT_KERNEL is None:
+        _COMPILED_ORDER_STAT_COUNT_KERNEL = _build_compiled_order_stat_kernel()
+    return _COMPILED_ORDER_STAT_COUNT_KERNEL
+
+
+def _compute_compiled_order_stat(
+    case_name: str,
+    freq: str,
+    *,
+    start_year: int,
+    study_year_count: int,
+    reference_start_year: int,
+    reference_year_count: int,
+    lat_length: int,
+    lon_length: int,
+) -> tuple[xr.DataArray, float]:
+    from icclim._core.generic.bootstrap_primitives import (  # noqa: PLC0415
+        build_bootstrap_output,
+        build_bootstrap_prepared_inputs,
+    )
+
+    tas = _build_case(
+        case_name,
+        start_year=start_year,
+        study_year_count=study_year_count,
+        lat_length=lat_length,
+        lon_length=lon_length,
+    )
+    threshold = _build_threshold(reference_start_year, reference_year_count)
+    prepared = build_bootstrap_prepared_inputs(
+        tas,
+        threshold,
+        freq,
+        dtype=np.float64,
+    )
+    ref = prepared.reference_sample
+    idx = prepared.temporal_indexing
+    arr = prepared.array_inputs
+    min_threshold = (
+        np.nan
+        if ref.threshold_floor_in_reference_units is None
+        else float(ref.threshold_floor_in_reference_units)
+    )
+    quantile = float(threshold.percentile_coord().item()) / 100.0
+    alpha = float(threshold.interpolation.alpha)
+    beta = float(threshold.interpolation.beta)
+    op_code = 0 if threshold.operator.operand == ">" else 1
+    flat_ref = (
+        arr.flat_reference_filtered
+        if not np.isnan(min_threshold)
+        else arr.flat_reference_raw
+    )
+    kernel = _compiled_order_stat_count_kernel()
+    start = perf_counter()
+    out = kernel(
+        flat_ref,
+        arr.flat_study,
+        idx.sample_indices_by_day_of_year,
+        idx.reference_index_year,
+        idx.reference_index_position,
+        idx.substitute_alignment,
+        idx.output_starts,
+        idx.output_lengths,
+        idx.year_group_starts,
+        idx.year_group_stops,
+        idx.year_max_day_of_years,
+        idx.year_to_reference_index,
+        idx.study_day_of_years,
+        quantile,
+        alpha,
+        beta,
+        op_code,
+        min_threshold,
+    )
+    seconds = perf_counter() - start
+    result = build_bootstrap_output(
+        flat_result=out,
+        reference_sample=ref,
+        temporal_indexing=idx,
+        spatial_shape=arr.spatial_shape,
+        units="d",
+    ).assign_coords(percentiles=threshold.percentile_coord().item())
+    return result.load(), seconds
+
+
+def _compute_current(
+    case_name: str,
+    freq: str,
+    *,
+    start_year: int,
+    study_year_count: int,
+    reference_start_year: int,
+    reference_year_count: int,
+    lat_length: int,
+    lon_length: int,
+) -> tuple[xr.DataArray, float]:
+    from icclim._core.generic.bootstrap import compute_doy_percentile_bootstrap_count  # noqa: PLC0415
+
+    tas = _build_case(
+        case_name,
+        start_year=start_year,
+        study_year_count=study_year_count,
+        lat_length=lat_length,
+        lon_length=lon_length,
+    )
+    threshold = _build_threshold(reference_start_year, reference_year_count)
+    start = perf_counter()
+    with _force_compiled_cftime_count():
+        result = compute_doy_percentile_bootstrap_count(tas, threshold, freq)
+    seconds = perf_counter() - start
+    if result is None:
+        msg = f"Current compiled count returned None for case={case_name} freq={freq}"
+        raise RuntimeError(msg)
+    return result.load(), seconds
+
+
+def _compute_compiled_bank(
+    case_name: str,
+    freq: str,
+    *,
+    start_year: int,
+    study_year_count: int,
+    reference_start_year: int,
+    reference_year_count: int,
+    lat_length: int,
+    lon_length: int,
+) -> tuple[xr.DataArray, float]:
+    from icclim._core.generic.bootstrap import (  # noqa: PLC0415
+        compute_doy_percentile_bootstrap_count_threshold_bank_compiled_prototype,
+    )
+
+    tas = _build_case(
+        case_name,
+        start_year=start_year,
+        study_year_count=study_year_count,
+        lat_length=lat_length,
+        lon_length=lon_length,
+    )
+    threshold = _build_threshold(reference_start_year, reference_year_count)
+    start = perf_counter()
+    result = compute_doy_percentile_bootstrap_count_threshold_bank_compiled_prototype(
+        tas,
+        threshold,
+        freq,
+    )
+    seconds = perf_counter() - start
+    if result is None:
+        msg = (
+            "Compiled threshold-bank prototype returned None for "
+            f"case={case_name} freq={freq}"
+        )
+        raise RuntimeError(msg)
+    return result.load(), seconds
+
+
+def _compare(a: xr.DataArray, b: xr.DataArray) -> tuple[int, float]:
+    diff = np.abs(np.asarray(a.values) - np.asarray(b.values))
+    return (
+        int(np.count_nonzero(diff > 1.0e-9)),
+        float(np.nanmax(diff)) if diff.size else 0.0,
+    )
+
+
+def _benchmark_one(
+    *,
+    case_name: str,
+    freq: str,
+    start_year: int,
+    study_year_count: int,
+    reference_start_year: int,
+    reference_year_count: int,
+    lat_length: int,
+    lon_length: int,
+) -> CompiledOrderStatBenchmark:
+    current, current_seconds = _compute_current(
+        case_name,
+        freq,
+        start_year=start_year,
+        study_year_count=study_year_count,
+        reference_start_year=reference_start_year,
+        reference_year_count=reference_year_count,
+        lat_length=lat_length,
+        lon_length=lon_length,
+    )
+    compiled_bank, compiled_bank_seconds = _compute_compiled_bank(
+        case_name,
+        freq,
+        start_year=start_year,
+        study_year_count=study_year_count,
+        reference_start_year=reference_start_year,
+        reference_year_count=reference_year_count,
+        lat_length=lat_length,
+        lon_length=lon_length,
+    )
+    compiled_order_stat, compiled_order_stat_seconds = _compute_compiled_order_stat(
+        case_name,
+        freq,
+        start_year=start_year,
+        study_year_count=study_year_count,
+        reference_start_year=reference_start_year,
+        reference_year_count=reference_year_count,
+        lat_length=lat_length,
+        lon_length=lon_length,
+    )
+    changed_cells, max_abs_diff = _compare(current, compiled_order_stat)
+    return CompiledOrderStatBenchmark(
+        case_name=case_name,
+        freq=freq,
+        lat_length=lat_length,
+        lon_length=lon_length,
+        current_seconds=current_seconds,
+        compiled_bank_seconds=compiled_bank_seconds,
+        compiled_order_stat_seconds=compiled_order_stat_seconds,
+        changed_cells_vs_current=changed_cells,
+        max_abs_diff_vs_current=max_abs_diff,
+        speed_ratio_current_over_compiled_order_stat=(
+            current_seconds / compiled_order_stat_seconds
+            if compiled_order_stat_seconds > 0.0
+            else float("inf")
+        ),
+        speed_ratio_compiled_bank_over_compiled_order_stat=(
+            compiled_bank_seconds / compiled_order_stat_seconds
+            if compiled_order_stat_seconds > 0.0
+            else float("inf")
+        ),
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo", required=True)
+    parser.add_argument(
+        "--case",
+        choices=("constant", "leap_day_cold_spike", "reference_overlap_shift"),
+        default="reference_overlap_shift",
+    )
+    parser.add_argument("--freq", choices=("MS", "YS"), default="MS")
+    parser.add_argument("--start-year", type=int, default=1950)
+    parser.add_argument("--study-years", type=int, default=65)
+    parser.add_argument("--reference-start-year", type=int, default=1961)
+    parser.add_argument("--reference-years", type=int, default=30)
+    parser.add_argument("--lat-length", type=int, default=4)
+    parser.add_argument("--lon-length", type=int, default=4)
+    args = parser.parse_args()
+
+    repo = Path(args.repo).resolve()
+    sys.path.insert(0, str(_resolve_import_root(repo)))
+    result = _benchmark_one(
+        case_name=args.case,
+        freq=args.freq,
+        start_year=args.start_year,
+        study_year_count=args.study_years,
+        reference_start_year=args.reference_start_year,
+        reference_year_count=args.reference_years,
+        lat_length=args.lat_length,
+        lon_length=args.lon_length,
+    )
+    print(json.dumps(asdict(result), indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/benchmark_cftime_order_stat_compiled.py
+++ b/tools/benchmark_cftime_order_stat_compiled.py
@@ -1,3 +1,5 @@
+# ruff: noqa: N806, PLR2004, PLW0603, RUF059
+
 from __future__ import annotations
 
 import argparse

--- a/tools/benchmark_cftime_order_stat_compiled_real_data.py
+++ b/tools/benchmark_cftime_order_stat_compiled_real_data.py
@@ -1,3 +1,5 @@
+# ruff: noqa: PLR2004
+
 from __future__ import annotations
 
 import argparse

--- a/tools/benchmark_cftime_order_stat_compiled_real_data.py
+++ b/tools/benchmark_cftime_order_stat_compiled_real_data.py
@@ -1,0 +1,343 @@
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+from contextlib import contextmanager
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from time import perf_counter
+
+import numpy as np
+import xarray as xr
+
+
+LAT_VALUE = 51.875
+LON_VALUE = 30.9375
+BASE_PERIOD = ("1961-01-01", "1990-12-31")
+TIME_RANGE = ("1950-01-01", "2014-12-31")
+
+
+def _resolve_import_root(repo: Path) -> Path:
+    for candidate in (repo / "src", repo):
+        if (candidate / "icclim" / "__init__.py").is_file():
+            return candidate
+    msg = f"Could not locate icclim import root under {repo}"
+    raise FileNotFoundError(msg)
+
+
+def _load_validation_module():
+    script_path = Path(__file__).with_name("run_real_data_validation.py")
+    spec = importlib.util.spec_from_file_location(
+        "run_real_data_validation",
+        script_path,
+    )
+    if spec is None or spec.loader is None:
+        msg = f"Cannot load validation module from {script_path}"
+        raise RuntimeError(msg)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_compiled_tool():
+    script_path = Path(__file__).with_name("benchmark_cftime_order_stat_compiled.py")
+    spec = importlib.util.spec_from_file_location(
+        "benchmark_cftime_order_stat_compiled",
+        script_path,
+    )
+    if spec is None or spec.loader is None:
+        msg = f"Cannot load compiled order-stat tool from {script_path}"
+        raise RuntimeError(msg)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _build_threshold():
+    from icclim.threshold.factory import build_threshold  # noqa: PLC0415
+
+    return build_threshold(
+        "> 90 doy_per",
+        doy_window_width=5,
+        reference_period=BASE_PERIOD,
+    )
+
+
+@contextmanager
+def _force_compiled_cftime_count():
+    from icclim._core.generic import bootstrap as bootstrap_module  # noqa: PLC0415
+
+    original = bootstrap_module.is_optimized_doy_percentile_count_supported
+    bootstrap_module.is_optimized_doy_percentile_count_supported = lambda *_: True
+    try:
+        yield
+    finally:
+        bootstrap_module.is_optimized_doy_percentile_count_supported = original
+
+
+@dataclass(frozen=True)
+class RealDataCompiledBenchmark:
+    freq: str
+    lat_length: int
+    lon_length: int
+    changed_cells_vs_current: int
+    max_abs_diff_vs_current: float
+    compiled_bank_changed_cells_vs_current: int
+    compiled_bank_max_abs_diff_vs_current: float
+    current_seconds: float
+    compiled_order_stat_seconds: float
+    compiled_bank_seconds: float
+    speed_ratio_current_over_compiled_order_stat: float
+    speed_ratio_current_over_compiled_bank: float
+
+
+def _parse_shape(shape: str) -> tuple[int, int]:
+    try:
+        lat_length_str, lon_length_str = shape.lower().split("x", maxsplit=1)
+        lat_length = int(lat_length_str)
+        lon_length = int(lon_length_str)
+    except Exception as exc:
+        msg = f"Invalid shape {shape!r}. Expected format like '1x1' or '2x2'."
+        raise ValueError(msg) from exc
+    if lat_length <= 0 or lon_length <= 0:
+        msg = f"Shape lengths must be positive, got {shape!r}."
+        raise ValueError(msg)
+    return lat_length, lon_length
+
+
+def _subset_centered_on_point(
+    tas: xr.DataArray,
+    *,
+    lat_value: float,
+    lon_value: float,
+    lat_length: int,
+    lon_length: int,
+) -> xr.DataArray:
+    lat_index = int(np.abs(tas["lat"].values - lat_value).argmin())
+    lon_index = int(np.abs(tas["lon"].values - lon_value).argmin())
+    lat_start = max(0, lat_index - lat_length // 2)
+    lon_start = max(0, lon_index - lon_length // 2)
+    lat_stop = min(tas.sizes["lat"], lat_start + lat_length)
+    lon_stop = min(tas.sizes["lon"], lon_start + lon_length)
+    lat_start = max(0, lat_stop - lat_length)
+    lon_start = max(0, lon_stop - lon_length)
+    return tas.isel(
+        lat=slice(lat_start, lat_stop),
+        lon=slice(lon_start, lon_stop),
+    )
+
+
+def _open_real_subset(validation_module, *, lat_length: int, lon_length: int) -> xr.DataArray:
+    tas = validation_module._open_var(validation_module.TAS_GLOB, "tas")
+    tas = validation_module._as_cftime_gregorian(tas)
+    tas = tas.sel(time=slice(*TIME_RANGE))
+    tas = _subset_centered_on_point(
+        tas,
+        lat_value=LAT_VALUE,
+        lon_value=LON_VALUE,
+        lat_length=lat_length,
+        lon_length=lon_length,
+    )
+    return tas.chunk(
+        {
+            "time": 365,
+            "lat": max(1, min(8, lat_length)),
+            "lon": max(1, min(8, lon_length)),
+        }
+    )
+
+
+def _compare(a: xr.DataArray, b: xr.DataArray) -> tuple[int, float]:
+    a_aligned, b_aligned = xr.align(a, b, join="outer", copy=False)
+    diff = np.abs(np.asarray(a_aligned.values) - np.asarray(b_aligned.values))
+    return (
+        int(np.count_nonzero(diff > 1.0e-9)),
+        float(np.nanmax(diff)) if diff.size else 0.0,
+    )
+
+
+def _compute_current(tas: xr.DataArray, freq: str) -> tuple[xr.DataArray, float]:
+    from icclim._core.generic.bootstrap import compute_doy_percentile_bootstrap_count  # noqa: PLC0415
+
+    threshold = _build_threshold()
+    start = perf_counter()
+    with _force_compiled_cftime_count():
+        result = compute_doy_percentile_bootstrap_count(tas, threshold, freq)
+    seconds = perf_counter() - start
+    if result is None:
+        msg = f"Current compiled count returned None for freq={freq}"
+        raise RuntimeError(msg)
+    return result.load(), seconds
+
+
+def _compute_compiled_bank(tas: xr.DataArray, freq: str) -> tuple[xr.DataArray, float]:
+    from icclim._core.generic.bootstrap import (  # noqa: PLC0415
+        compute_doy_percentile_bootstrap_count_threshold_bank_compiled_prototype,
+    )
+
+    threshold = _build_threshold()
+    start = perf_counter()
+    result = compute_doy_percentile_bootstrap_count_threshold_bank_compiled_prototype(
+        tas,
+        threshold,
+        freq,
+    )
+    seconds = perf_counter() - start
+    if result is None:
+        msg = f"Compiled threshold-bank prototype returned None for freq={freq}"
+        raise RuntimeError(msg)
+    return result.load(), seconds
+
+
+def _compute_compiled_order_stat(
+    tas: xr.DataArray,
+    freq: str,
+) -> tuple[xr.DataArray, float]:
+    from icclim._core.generic.bootstrap_primitives import (  # noqa: PLC0415
+        build_bootstrap_output,
+        build_bootstrap_prepared_inputs,
+    )
+
+    compiled_tool = _load_compiled_tool()
+    threshold = _build_threshold()
+    prepared = build_bootstrap_prepared_inputs(
+        tas,
+        threshold,
+        freq,
+        dtype=np.float64,
+    )
+    ref = prepared.reference_sample
+    idx = prepared.temporal_indexing
+    arr = prepared.array_inputs
+    min_threshold = (
+        np.nan
+        if ref.threshold_floor_in_reference_units is None
+        else float(ref.threshold_floor_in_reference_units)
+    )
+    quantile = float(threshold.percentile_coord().item()) / 100.0
+    alpha = float(threshold.interpolation.alpha)
+    beta = float(threshold.interpolation.beta)
+    op_code = 0 if threshold.operator.operand == ">" else 1
+    flat_ref = (
+        arr.flat_reference_filtered
+        if not np.isnan(min_threshold)
+        else arr.flat_reference_raw
+    )
+    kernel = compiled_tool._compiled_order_stat_count_kernel()
+    start = perf_counter()
+    out = kernel(
+        flat_ref,
+        arr.flat_study,
+        idx.sample_indices_by_day_of_year,
+        idx.reference_index_year,
+        idx.reference_index_position,
+        idx.substitute_alignment,
+        idx.output_starts,
+        idx.output_lengths,
+        idx.year_group_starts,
+        idx.year_group_stops,
+        idx.year_max_day_of_years,
+        idx.year_to_reference_index,
+        idx.study_day_of_years,
+        quantile,
+        alpha,
+        beta,
+        op_code,
+        min_threshold,
+    )
+    seconds = perf_counter() - start
+    result = build_bootstrap_output(
+        flat_result=out,
+        reference_sample=ref,
+        temporal_indexing=idx,
+        spatial_shape=arr.spatial_shape,
+        units="d",
+    ).assign_coords(percentiles=threshold.percentile_coord().item())
+    return result.load(), seconds
+
+
+def _benchmark_one(
+    validation_module,
+    *,
+    freq: str,
+    lat_length: int,
+    lon_length: int,
+) -> RealDataCompiledBenchmark:
+    tas = _open_real_subset(
+        validation_module,
+        lat_length=lat_length,
+        lon_length=lon_length,
+    )
+    current, current_seconds = _compute_current(tas, freq)
+    compiled_order_stat, compiled_order_stat_seconds = _compute_compiled_order_stat(
+        tas,
+        freq,
+    )
+    compiled_bank, compiled_bank_seconds = _compute_compiled_bank(tas, freq)
+    changed_cells_vs_current, max_abs_diff_vs_current = _compare(
+        current,
+        compiled_order_stat,
+    )
+    compiled_bank_changed_cells_vs_current, compiled_bank_max_abs_diff_vs_current = _compare(
+        current,
+        compiled_bank,
+    )
+    return RealDataCompiledBenchmark(
+        freq=freq,
+        lat_length=lat_length,
+        lon_length=lon_length,
+        changed_cells_vs_current=changed_cells_vs_current,
+        max_abs_diff_vs_current=max_abs_diff_vs_current,
+        compiled_bank_changed_cells_vs_current=compiled_bank_changed_cells_vs_current,
+        compiled_bank_max_abs_diff_vs_current=compiled_bank_max_abs_diff_vs_current,
+        current_seconds=current_seconds,
+        compiled_order_stat_seconds=compiled_order_stat_seconds,
+        compiled_bank_seconds=compiled_bank_seconds,
+        speed_ratio_current_over_compiled_order_stat=(
+            current_seconds / compiled_order_stat_seconds
+            if compiled_order_stat_seconds > 0.0
+            else float("inf")
+        ),
+        speed_ratio_current_over_compiled_bank=(
+            current_seconds / compiled_bank_seconds
+            if compiled_bank_seconds > 0.0
+            else float("inf")
+        ),
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--freq", choices=("MS", "YS", "both"), default="both")
+    parser.add_argument("--shape", default="1x1")
+    args = parser.parse_args()
+
+    repo = Path(args.repo).resolve()
+    sys.path.insert(0, str(_resolve_import_root(repo)))
+    validation_module = _load_validation_module()
+    lat_length, lon_length = _parse_shape(args.shape)
+    frequencies = ("MS", "YS") if args.freq == "both" else (args.freq,)
+    payload: dict[str, object] = {
+        "repo": str(repo),
+        "shape": args.shape,
+        "frequencies": {},
+    }
+    for freq in frequencies:
+        payload["frequencies"][freq] = asdict(
+            _benchmark_one(
+                validation_module,
+                freq=freq,
+                lat_length=lat_length,
+                lon_length=lon_length,
+            )
+        )
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/benchmark_cftime_order_stat_compiled_real_data.py
+++ b/tools/benchmark_cftime_order_stat_compiled_real_data.py
@@ -12,7 +12,6 @@ from time import perf_counter
 import numpy as np
 import xarray as xr
 
-
 LAT_VALUE = 51.875
 LON_VALUE = 30.9375
 BASE_PERIOD = ("1961-01-01", "1990-12-31")
@@ -58,7 +57,7 @@ def _load_compiled_tool():
 
 
 def _build_threshold():
-    from icclim.threshold.factory import build_threshold  # noqa: PLC0415
+    from icclim.threshold.factory import build_threshold
 
     return build_threshold(
         "> 90 doy_per",
@@ -69,7 +68,7 @@ def _build_threshold():
 
 @contextmanager
 def _force_compiled_cftime_count():
-    from icclim._core.generic import bootstrap as bootstrap_module  # noqa: PLC0415
+    from icclim._core.generic import bootstrap as bootstrap_module
 
     original = bootstrap_module.is_optimized_doy_percentile_count_supported
     bootstrap_module.is_optimized_doy_percentile_count_supported = lambda *_: True
@@ -131,7 +130,9 @@ def _subset_centered_on_point(
     )
 
 
-def _open_real_subset(validation_module, *, lat_length: int, lon_length: int) -> xr.DataArray:
+def _open_real_subset(
+    validation_module, *, lat_length: int, lon_length: int
+) -> xr.DataArray:
     tas = validation_module._open_var(validation_module.TAS_GLOB, "tas")
     tas = validation_module._as_cftime_gregorian(tas)
     tas = tas.sel(time=slice(*TIME_RANGE))
@@ -161,7 +162,9 @@ def _compare(a: xr.DataArray, b: xr.DataArray) -> tuple[int, float]:
 
 
 def _compute_current(tas: xr.DataArray, freq: str) -> tuple[xr.DataArray, float]:
-    from icclim._core.generic.bootstrap import compute_doy_percentile_bootstrap_count  # noqa: PLC0415
+    from icclim._core.generic.bootstrap import (
+        compute_doy_percentile_bootstrap_count,
+    )
 
     threshold = _build_threshold()
     start = perf_counter()
@@ -175,7 +178,7 @@ def _compute_current(tas: xr.DataArray, freq: str) -> tuple[xr.DataArray, float]
 
 
 def _compute_compiled_bank(tas: xr.DataArray, freq: str) -> tuple[xr.DataArray, float]:
-    from icclim._core.generic.bootstrap import (  # noqa: PLC0415
+    from icclim._core.generic.bootstrap import (
         compute_doy_percentile_bootstrap_count_threshold_bank_compiled_prototype,
     )
 
@@ -197,7 +200,7 @@ def _compute_compiled_order_stat(
     tas: xr.DataArray,
     freq: str,
 ) -> tuple[xr.DataArray, float]:
-    from icclim._core.generic.bootstrap_primitives import (  # noqa: PLC0415
+    from icclim._core.generic.bootstrap_primitives import (
         build_bootstrap_output,
         build_bootstrap_prepared_inputs,
     )
@@ -282,9 +285,11 @@ def _benchmark_one(
         current,
         compiled_order_stat,
     )
-    compiled_bank_changed_cells_vs_current, compiled_bank_max_abs_diff_vs_current = _compare(
-        current,
-        compiled_bank,
+    compiled_bank_changed_cells_vs_current, compiled_bank_max_abs_diff_vs_current = (
+        _compare(
+            current,
+            compiled_bank,
+        )
     )
     return RealDataCompiledBenchmark(
         freq=freq,

--- a/tools/benchmark_cftime_order_stat_real_data.py
+++ b/tools/benchmark_cftime_order_stat_real_data.py
@@ -1,3 +1,5 @@
+# ruff: noqa: PLR2004
+
 from __future__ import annotations
 
 import argparse

--- a/tools/benchmark_cftime_order_stat_real_data.py
+++ b/tools/benchmark_cftime_order_stat_real_data.py
@@ -1,0 +1,392 @@
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+from contextlib import contextmanager
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from time import perf_counter
+
+import numpy as np
+import xarray as xr
+
+
+LAT_VALUE = 51.875
+LON_VALUE = 30.9375
+BASE_PERIOD = ("1961-01-01", "1990-12-31")
+TIME_RANGE = ("1950-01-01", "2014-12-31")
+
+
+def _resolve_import_root(repo: Path) -> Path:
+    for candidate in (repo / "src", repo):
+        if (candidate / "icclim" / "__init__.py").is_file():
+            return candidate
+    msg = f"Could not locate icclim import root under {repo}"
+    raise FileNotFoundError(msg)
+
+
+def _load_validation_module():
+    script_path = Path(__file__).with_name("run_real_data_validation.py")
+    spec = importlib.util.spec_from_file_location(
+        "run_real_data_validation",
+        script_path,
+    )
+    if spec is None or spec.loader is None:
+        msg = f"Cannot load validation module from {script_path}"
+        raise RuntimeError(msg)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_quantile_tool():
+    script_path = Path(__file__).with_name("prototype_cftime_exact_order_stat_quantile.py")
+    spec = importlib.util.spec_from_file_location(
+        "prototype_cftime_exact_order_stat_quantile",
+        script_path,
+    )
+    if spec is None or spec.loader is None:
+        msg = f"Cannot load quantile tool from {script_path}"
+        raise RuntimeError(msg)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _build_threshold():
+    from icclim.threshold.factory import build_threshold  # noqa: PLC0415
+
+    return build_threshold(
+        "> 90 doy_per",
+        doy_window_width=5,
+        reference_period=BASE_PERIOD,
+    )
+
+
+@contextmanager
+def _force_compiled_cftime_count():
+    from icclim._core.generic import bootstrap as bootstrap_module  # noqa: PLC0415
+
+    original = bootstrap_module.is_optimized_doy_percentile_count_supported
+    bootstrap_module.is_optimized_doy_percentile_count_supported = lambda *_: True
+    try:
+        yield
+    finally:
+        bootstrap_module.is_optimized_doy_percentile_count_supported = original
+
+
+@dataclass(frozen=True)
+class RealDataBenchmark:
+    label: str
+    freq: str
+    lat_length: int
+    lon_length: int
+    changed_cells_vs_current: int
+    max_abs_diff_vs_current: float
+    compiled_bank_changed_cells_vs_current: int
+    compiled_bank_max_abs_diff_vs_current: float
+    current_seconds: float
+    order_stat_seconds: float
+    compiled_bank_seconds: float
+    speed_ratio_current_over_order_stat: float
+    speed_ratio_current_over_compiled_bank: float
+
+
+def _subset_centered_on_point(
+    tas: xr.DataArray,
+    *,
+    lat_value: float,
+    lon_value: float,
+    lat_length: int,
+    lon_length: int,
+) -> xr.DataArray:
+    lat_index = int(np.abs(tas["lat"].values - lat_value).argmin())
+    lon_index = int(np.abs(tas["lon"].values - lon_value).argmin())
+    lat_start = max(0, lat_index - lat_length // 2)
+    lon_start = max(0, lon_index - lon_length // 2)
+    lat_stop = min(tas.sizes["lat"], lat_start + lat_length)
+    lon_stop = min(tas.sizes["lon"], lon_start + lon_length)
+    lat_start = max(0, lat_stop - lat_length)
+    lon_start = max(0, lon_stop - lon_length)
+    return tas.isel(
+        lat=slice(lat_start, lat_stop),
+        lon=slice(lon_start, lon_stop),
+    )
+
+
+def _open_real_subset(
+    validation_module,
+    *,
+    lat_length: int,
+    lon_length: int,
+) -> xr.DataArray:
+    tas = validation_module._open_var(validation_module.TAS_GLOB, "tas")
+    tas = validation_module._as_cftime_gregorian(tas)
+    tas = tas.sel(time=slice(*TIME_RANGE))
+    tas = _subset_centered_on_point(
+        tas,
+        lat_value=LAT_VALUE,
+        lon_value=LON_VALUE,
+        lat_length=lat_length,
+        lon_length=lon_length,
+    )
+    return tas.chunk(
+        {
+            "time": 365,
+            "lat": max(1, min(8, lat_length)),
+            "lon": max(1, min(8, lon_length)),
+        }
+    )
+
+
+def _compare(a: xr.DataArray, b: xr.DataArray) -> tuple[int, float]:
+    a_aligned, b_aligned = xr.align(a, b, join="outer", copy=False)
+    diff = np.abs(np.asarray(a_aligned.values) - np.asarray(b_aligned.values))
+    return (
+        int(np.count_nonzero(diff > 1.0e-9)),
+        float(np.nanmax(diff)) if diff.size else 0.0,
+    )
+
+
+def _compute_current(tas: xr.DataArray, freq: str) -> tuple[xr.DataArray, float]:
+    from icclim._core.generic.bootstrap import compute_doy_percentile_bootstrap_count  # noqa: PLC0415
+
+    threshold = _build_threshold()
+    start = perf_counter()
+    with _force_compiled_cftime_count():
+        result = compute_doy_percentile_bootstrap_count(tas, threshold, freq)
+    seconds = perf_counter() - start
+    if result is None:
+        msg = f"Current compiled count returned None for freq={freq}"
+        raise RuntimeError(msg)
+    return result.load(), seconds
+
+
+def _compute_compiled_bank(tas: xr.DataArray, freq: str) -> tuple[xr.DataArray, float]:
+    from icclim._core.generic.bootstrap import (  # noqa: PLC0415
+        compute_doy_percentile_bootstrap_count_threshold_bank_compiled_prototype,
+    )
+
+    threshold = _build_threshold()
+    start = perf_counter()
+    result = compute_doy_percentile_bootstrap_count_threshold_bank_compiled_prototype(
+        tas,
+        threshold,
+        freq,
+    )
+    seconds = perf_counter() - start
+    if result is None:
+        msg = f"Compiled threshold-bank prototype returned None for freq={freq}"
+        raise RuntimeError(msg)
+    return result.load(), seconds
+
+
+def _compute_order_stat(tas: xr.DataArray, freq: str) -> tuple[xr.DataArray, float]:
+    from icclim._core.generic.bootstrap import _count_exceedances  # noqa: PLC0415
+    from icclim._core.generic.bootstrap_primitives import (  # noqa: PLC0415
+        build_bootstrap_output,
+        build_bootstrap_prepared_inputs,
+    )
+
+    quantile_tool = _load_quantile_tool()
+    threshold = _build_threshold()
+    prepared = build_bootstrap_prepared_inputs(
+        tas,
+        threshold,
+        freq,
+        dtype=np.float64,
+    )
+    ref = prepared.reference_sample
+    idx = prepared.temporal_indexing
+    arr = prepared.array_inputs
+    min_threshold = (
+        np.nan
+        if ref.threshold_floor_in_reference_units is None
+        else float(ref.threshold_floor_in_reference_units)
+    )
+    quantile = float(threshold.percentile_coord().item()) / 100.0
+    alpha = float(threshold.interpolation.alpha)
+    beta = float(threshold.interpolation.beta)
+    op_code = 0 if threshold.operator.operand == ">" else 1
+    count_exceedances = _count_exceedances.py_func
+    n_years = len(idx.bootstrap_years)
+    n_groups = len(idx.output_group_labels)
+    n_cells = arr.flat_study.shape[1]
+    n_ref_years = idx.substitute_alignment.shape[1]
+    flat_ref = (
+        arr.flat_reference_filtered
+        if not np.isnan(min_threshold)
+        else arr.flat_reference_raw
+    )
+    out = np.empty((n_groups, n_cells), dtype=np.float64)
+
+    start = perf_counter()
+    nominal_thresholds_by_cell: list[np.ndarray] = []
+    for cell in range(n_cells):
+        thresholds, _, _ = quantile_tool._build_order_stat_threshold_series_for_cell(
+            flat_ref,
+            idx.sample_indices_by_day_of_year,
+            idx.reference_index_year,
+            idx.reference_index_position,
+            idx.substitute_alignment,
+            -1,
+            -1,
+            cell,
+            quantile,
+            alpha,
+            beta,
+            min_threshold,
+        )
+        nominal_thresholds_by_cell.append(thresholds)
+
+    for year_i in range(n_years):
+        target_ref_i = idx.year_to_reference_index[year_i]
+        group_start = idx.year_group_starts[year_i]
+        group_stop = idx.year_group_stops[year_i]
+        for cell in range(n_cells):
+            if target_ref_i < 0:
+                thresholds = nominal_thresholds_by_cell[cell]
+                for group_i in range(group_start, group_stop):
+                    out[group_i, cell] = count_exceedances(
+                        arr.flat_study,
+                        thresholds,
+                        idx.study_day_of_years,
+                        idx.output_starts[group_i],
+                        idx.output_lengths[group_i],
+                        cell,
+                        idx.year_max_day_of_years[year_i],
+                        op_code,
+                    )
+                continue
+            for group_i in range(group_start, group_stop):
+                out[group_i, cell] = 0.0
+            substitute_count = 0
+            for substitute_i in range(n_ref_years):
+                if substitute_i == target_ref_i:
+                    continue
+                thresholds, _, _ = quantile_tool._build_order_stat_threshold_series_for_cell(
+                    flat_ref,
+                    idx.sample_indices_by_day_of_year,
+                    idx.reference_index_year,
+                    idx.reference_index_position,
+                    idx.substitute_alignment,
+                    target_ref_i,
+                    substitute_i,
+                    cell,
+                    quantile,
+                    alpha,
+                    beta,
+                    min_threshold,
+                )
+                for group_i in range(group_start, group_stop):
+                    out[group_i, cell] += count_exceedances(
+                        arr.flat_study,
+                        thresholds,
+                        idx.study_day_of_years,
+                        idx.output_starts[group_i],
+                        idx.output_lengths[group_i],
+                        cell,
+                        idx.year_max_day_of_years[year_i],
+                        op_code,
+                    )
+                substitute_count += 1
+            for group_i in range(group_start, group_stop):
+                out[group_i, cell] /= substitute_count
+    seconds = perf_counter() - start
+
+    result = build_bootstrap_output(
+        flat_result=out,
+        reference_sample=ref,
+        temporal_indexing=idx,
+        spatial_shape=arr.spatial_shape,
+        units="d",
+    ).assign_coords(percentiles=threshold.percentile_coord().item())
+    return result.load(), seconds
+
+
+def _benchmark_one(
+    validation_module,
+    *,
+    label: str,
+    freq: str,
+    lat_length: int,
+    lon_length: int,
+) -> RealDataBenchmark:
+    tas = _open_real_subset(
+        validation_module,
+        lat_length=lat_length,
+        lon_length=lon_length,
+    )
+    current, current_seconds = _compute_current(tas, freq)
+    order_stat, order_stat_seconds = _compute_order_stat(tas, freq)
+    compiled_bank, compiled_bank_seconds = _compute_compiled_bank(tas, freq)
+    changed_cells_vs_current, max_abs_diff_vs_current = _compare(current, order_stat)
+    compiled_bank_changed_cells_vs_current, compiled_bank_max_abs_diff_vs_current = _compare(
+        current,
+        compiled_bank,
+    )
+    return RealDataBenchmark(
+        label=label,
+        freq=freq,
+        lat_length=lat_length,
+        lon_length=lon_length,
+        changed_cells_vs_current=changed_cells_vs_current,
+        max_abs_diff_vs_current=max_abs_diff_vs_current,
+        compiled_bank_changed_cells_vs_current=compiled_bank_changed_cells_vs_current,
+        compiled_bank_max_abs_diff_vs_current=compiled_bank_max_abs_diff_vs_current,
+        current_seconds=current_seconds,
+        order_stat_seconds=order_stat_seconds,
+        compiled_bank_seconds=compiled_bank_seconds,
+        speed_ratio_current_over_order_stat=(
+            current_seconds / order_stat_seconds
+            if order_stat_seconds > 0.0
+            else float("inf")
+        ),
+        speed_ratio_current_over_compiled_bank=(
+            current_seconds / compiled_bank_seconds
+            if compiled_bank_seconds > 0.0
+            else float("inf")
+        ),
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--freq", choices=("MS", "YS", "both"), default="both")
+    parser.add_argument(
+        "--shape",
+        choices=("1x1", "4x4", "8x8"),
+        default="4x4",
+    )
+    args = parser.parse_args()
+
+    repo = Path(args.repo).resolve()
+    sys.path.insert(0, str(_resolve_import_root(repo)))
+
+    validation_module = _load_validation_module()
+    frequencies = ("MS", "YS") if args.freq == "both" else (args.freq,)
+    lat_length, lon_length = map(int, args.shape.split("x"))
+    payload: dict[str, object] = {
+        "repo": str(repo),
+        "shape": args.shape,
+        "frequencies": {},
+    }
+    for freq in frequencies:
+        result = _benchmark_one(
+            validation_module,
+            label=f"real-{args.shape.lower()}",
+            freq=freq,
+            lat_length=lat_length,
+            lon_length=lon_length,
+        )
+        payload["frequencies"][freq] = asdict(result)
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/benchmark_cftime_order_stat_real_data.py
+++ b/tools/benchmark_cftime_order_stat_real_data.py
@@ -354,15 +354,25 @@ def _benchmark_one(
     )
 
 
+def _parse_shape(shape: str) -> tuple[int, int]:
+    try:
+        lat_length_str, lon_length_str = shape.lower().split("x", maxsplit=1)
+        lat_length = int(lat_length_str)
+        lon_length = int(lon_length_str)
+    except Exception as exc:
+        msg = f"Invalid shape {shape!r}. Expected format like '1x1' or '2x2'."
+        raise ValueError(msg) from exc
+    if lat_length <= 0 or lon_length <= 0:
+        msg = f"Shape lengths must be positive, got {shape!r}."
+        raise ValueError(msg)
+    return lat_length, lon_length
+
+
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--repo", required=True)
     parser.add_argument("--freq", choices=("MS", "YS", "both"), default="both")
-    parser.add_argument(
-        "--shape",
-        choices=("1x1", "4x4", "8x8"),
-        default="4x4",
-    )
+    parser.add_argument("--shape", default="4x4")
     args = parser.parse_args()
 
     repo = Path(args.repo).resolve()
@@ -370,7 +380,7 @@ def main() -> None:
 
     validation_module = _load_validation_module()
     frequencies = ("MS", "YS") if args.freq == "both" else (args.freq,)
-    lat_length, lon_length = map(int, args.shape.split("x"))
+    lat_length, lon_length = _parse_shape(args.shape)
     payload: dict[str, object] = {
         "repo": str(repo),
         "shape": args.shape,

--- a/tools/benchmark_cftime_order_stat_real_data.py
+++ b/tools/benchmark_cftime_order_stat_real_data.py
@@ -12,7 +12,6 @@ from time import perf_counter
 import numpy as np
 import xarray as xr
 
-
 LAT_VALUE = 51.875
 LON_VALUE = 30.9375
 BASE_PERIOD = ("1961-01-01", "1990-12-31")
@@ -43,7 +42,9 @@ def _load_validation_module():
 
 
 def _load_quantile_tool():
-    script_path = Path(__file__).with_name("prototype_cftime_exact_order_stat_quantile.py")
+    script_path = Path(__file__).with_name(
+        "prototype_cftime_exact_order_stat_quantile.py"
+    )
     spec = importlib.util.spec_from_file_location(
         "prototype_cftime_exact_order_stat_quantile",
         script_path,
@@ -58,7 +59,7 @@ def _load_quantile_tool():
 
 
 def _build_threshold():
-    from icclim.threshold.factory import build_threshold  # noqa: PLC0415
+    from icclim.threshold.factory import build_threshold
 
     return build_threshold(
         "> 90 doy_per",
@@ -69,7 +70,7 @@ def _build_threshold():
 
 @contextmanager
 def _force_compiled_cftime_count():
-    from icclim._core.generic import bootstrap as bootstrap_module  # noqa: PLC0415
+    from icclim._core.generic import bootstrap as bootstrap_module
 
     original = bootstrap_module.is_optimized_doy_percentile_count_supported
     bootstrap_module.is_optimized_doy_percentile_count_supported = lambda *_: True
@@ -153,7 +154,9 @@ def _compare(a: xr.DataArray, b: xr.DataArray) -> tuple[int, float]:
 
 
 def _compute_current(tas: xr.DataArray, freq: str) -> tuple[xr.DataArray, float]:
-    from icclim._core.generic.bootstrap import compute_doy_percentile_bootstrap_count  # noqa: PLC0415
+    from icclim._core.generic.bootstrap import (
+        compute_doy_percentile_bootstrap_count,
+    )
 
     threshold = _build_threshold()
     start = perf_counter()
@@ -167,7 +170,7 @@ def _compute_current(tas: xr.DataArray, freq: str) -> tuple[xr.DataArray, float]
 
 
 def _compute_compiled_bank(tas: xr.DataArray, freq: str) -> tuple[xr.DataArray, float]:
-    from icclim._core.generic.bootstrap import (  # noqa: PLC0415
+    from icclim._core.generic.bootstrap import (
         compute_doy_percentile_bootstrap_count_threshold_bank_compiled_prototype,
     )
 
@@ -186,8 +189,8 @@ def _compute_compiled_bank(tas: xr.DataArray, freq: str) -> tuple[xr.DataArray, 
 
 
 def _compute_order_stat(tas: xr.DataArray, freq: str) -> tuple[xr.DataArray, float]:
-    from icclim._core.generic.bootstrap import _count_exceedances  # noqa: PLC0415
-    from icclim._core.generic.bootstrap_primitives import (  # noqa: PLC0415
+    from icclim._core.generic.bootstrap import _count_exceedances
+    from icclim._core.generic.bootstrap_primitives import (
         build_bootstrap_output,
         build_bootstrap_prepared_inputs,
     )
@@ -268,19 +271,21 @@ def _compute_order_stat(tas: xr.DataArray, freq: str) -> tuple[xr.DataArray, flo
             for substitute_i in range(n_ref_years):
                 if substitute_i == target_ref_i:
                     continue
-                thresholds, _, _ = quantile_tool._build_order_stat_threshold_series_for_cell(
-                    flat_ref,
-                    idx.sample_indices_by_day_of_year,
-                    idx.reference_index_year,
-                    idx.reference_index_position,
-                    idx.substitute_alignment,
-                    target_ref_i,
-                    substitute_i,
-                    cell,
-                    quantile,
-                    alpha,
-                    beta,
-                    min_threshold,
+                thresholds, _, _ = (
+                    quantile_tool._build_order_stat_threshold_series_for_cell(
+                        flat_ref,
+                        idx.sample_indices_by_day_of_year,
+                        idx.reference_index_year,
+                        idx.reference_index_position,
+                        idx.substitute_alignment,
+                        target_ref_i,
+                        substitute_i,
+                        cell,
+                        quantile,
+                        alpha,
+                        beta,
+                        min_threshold,
+                    )
                 )
                 for group_i in range(group_start, group_stop):
                     out[group_i, cell] += count_exceedances(
@@ -325,9 +330,11 @@ def _benchmark_one(
     order_stat, order_stat_seconds = _compute_order_stat(tas, freq)
     compiled_bank, compiled_bank_seconds = _compute_compiled_bank(tas, freq)
     changed_cells_vs_current, max_abs_diff_vs_current = _compare(current, order_stat)
-    compiled_bank_changed_cells_vs_current, compiled_bank_max_abs_diff_vs_current = _compare(
-        current,
-        compiled_bank,
+    compiled_bank_changed_cells_vs_current, compiled_bank_max_abs_diff_vs_current = (
+        _compare(
+            current,
+            compiled_bank,
+        )
     )
     return RealDataBenchmark(
         label=label,

--- a/tools/kraken_compare_real_data_validation.slurm
+++ b/tools/kraken_compare_real_data_validation.slurm
@@ -1,10 +1,11 @@
 #!/bin/bash
 #SBATCH --job-name=icclim-compare
+#SBATCH --partition=debug
 #SBATCH --output=%x-%j.out
 #SBATCH --error=%x-%j.err
-#SBATCH --time=00:30:00
-#SBATCH --cpus-per-task=2
-#SBATCH --mem=16G
+#SBATCH --time=00:05:00
+#SBATCH --cpus-per-task=1
+#SBATCH --mem=2G
 
 set -euo pipefail
 

--- a/tools/kraken_compare_real_data_validation.slurm
+++ b/tools/kraken_compare_real_data_validation.slurm
@@ -9,7 +9,7 @@
 set -euo pipefail
 
 PYTHON_BIN=/scratch/globc/page/.conda/envs/icclimv7/bin/python
-SCRIPT=/scratch/globc/page/icclim-bench/compare_real_data_validation.py
+SCRIPT="$REPO_PATH/tools/compare_real_data_validation.py"
 
 mkdir -p "$(dirname "$OUT_PATH")"
 cd "$(dirname "$OUT_PATH")"

--- a/tools/kraken_debug_real_data_validation.slurm
+++ b/tools/kraken_debug_real_data_validation.slurm
@@ -9,7 +9,7 @@
 set -euo pipefail
 
 PYTHON_BIN=/scratch/globc/page/.conda/envs/icclimv7/bin/python
-SCRIPT=/scratch/globc/page/icclim-bench/debug_real_data_validation.py
+SCRIPT="$REPO_PATH/tools/debug_real_data_validation.py"
 
 mkdir -p "$OUT_DIR"
 cd "$OUT_DIR"

--- a/tools/kraken_debug_real_data_validation.slurm
+++ b/tools/kraken_debug_real_data_validation.slurm
@@ -1,10 +1,11 @@
 #!/bin/bash
 #SBATCH --job-name=icclim-realval-debug
+#SBATCH --partition=debug
 #SBATCH --output=%x-%j.out
 #SBATCH --error=%x-%j.err
-#SBATCH --time=00:30:00
-#SBATCH --cpus-per-task=4
-#SBATCH --mem=32G
+#SBATCH --time=00:10:00
+#SBATCH --cpus-per-task=1
+#SBATCH --mem=4G
 
 set -euo pipefail
 

--- a/tools/kraken_run_real_data_validation.slurm
+++ b/tools/kraken_run_real_data_validation.slurm
@@ -1,10 +1,11 @@
 #!/bin/bash
 #SBATCH --job-name=icclim-realval
+#SBATCH --partition=miniprod
 #SBATCH --output=%x-%j.out
 #SBATCH --error=%x-%j.err
 #SBATCH --time=02:00:00
-#SBATCH --cpus-per-task=8
-#SBATCH --mem=64G
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=32G
 
 set -euo pipefail
 

--- a/tools/kraken_run_real_data_validation.slurm
+++ b/tools/kraken_run_real_data_validation.slurm
@@ -9,7 +9,7 @@
 set -euo pipefail
 
 PYTHON_BIN=/scratch/globc/page/.conda/envs/icclimv7/bin/python
-SCRIPT=/scratch/globc/page/icclim-bench/run_real_data_validation.py
+SCRIPT="$REPO_PATH/tools/run_real_data_validation.py"
 
 mkdir -p "$OUT_DIR"
 cd "$OUT_DIR"

--- a/tools/profile_bootstrap_phases.py
+++ b/tools/profile_bootstrap_phases.py
@@ -250,6 +250,7 @@ def main() -> None:
     sys.path.insert(0, str(_resolve_import_root(repo)))
 
     import icclim
+
     bootstrap_module = None
     primitives_module = None
     functions_module = importlib.import_module("icclim._core.generic.functions")
@@ -263,8 +264,10 @@ def main() -> None:
         )
     except ModuleNotFoundError:
         pass
-    get_bootstrap_profile = getattr(functions_module, "get_bootstrap_profile", lambda: {})
-    reset_bootstrap_profile = getattr(functions_module, "reset_bootstrap_profile", lambda: None)
+    get_bootstrap_profile = getattr(functions_module, "get_bootstrap_profile", dict)
+    reset_bootstrap_profile = getattr(
+        functions_module, "reset_bootstrap_profile", lambda: None
+    )
 
     chunk_profile = DEFAULT_CHUNKS if args.chunk_profile == "default" else ALT_CHUNKS
     phase_stats: dict[str, dict[str, float]] = {}
@@ -307,32 +310,44 @@ def main() -> None:
             primitives_module,
             "_normalize_bootstrap_chunks",
             phase_stats,
-        ) if primitives_module is not None else nullcontext(),
+        )
+        if primitives_module is not None
+        else nullcontext(),
         _timed_patch_if_present(
             primitives_module,
             "build_bootstrap_reference_sample",
             phase_stats,
-        ) if primitives_module is not None else nullcontext(),
+        )
+        if primitives_module is not None
+        else nullcontext(),
         _timed_patch_if_present(
             primitives_module,
             "build_bootstrap_prepared_inputs",
             phase_stats,
-        ) if primitives_module is not None else nullcontext(),
+        )
+        if primitives_module is not None
+        else nullcontext(),
         _timed_patch_if_present(
             bootstrap_module,
             "compute_doy_percentile_bootstrap_count",
             phase_stats,
-        ) if bootstrap_module is not None else nullcontext(),
+        )
+        if bootstrap_module is not None
+        else nullcontext(),
         _timed_patch_if_present(
             bootstrap_module,
             "build_bootstrap_temporal_indexing",
             phase_stats,
-        ) if bootstrap_module is not None else nullcontext(),
+        )
+        if bootstrap_module is not None
+        else nullcontext(),
         _timed_patch_if_present(
             bootstrap_module,
             "build_bootstrap_array_inputs",
             phase_stats,
-        ) if bootstrap_module is not None else nullcontext(),
+        )
+        if bootstrap_module is not None
+        else nullcontext(),
     ):
         ds = _build_workload(icclim, args.workload, chunks=chunk_profile).load()
     elapsed = time.perf_counter() - started

--- a/tools/profile_bootstrap_phases.py
+++ b/tools/profile_bootstrap_phases.py
@@ -1,19 +1,24 @@
 from __future__ import annotations
 
 import argparse
+import importlib
 import json
 import sys
 import time
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 from pathlib import Path
 from typing import Any
 
+import cftime
 import numpy as np
 import xarray as xr
 
 TAS_GLOB = "/scratch/globc/page/models/tas_day_ACCESS-CM2_historical_*.nc"
+PR_GLOB = "/scratch/globc/page/models/pr_day_ACCESS-CM2_historical_*.nc"
 LAT_SLICE = slice(35.0, 70.0)
 LON_SLICE = slice(0.0, 40.0)
+DRY_PR_LAT_SLICE = slice(35.0, 45.0)
+DRY_PR_LON_SLICE = slice(0.0, 30.0)
 BASE_PERIOD = ("1961-01-01", "1990-12-31")
 TIME_RANGE = ("1950-01-01", "2014-12-31")
 DEFAULT_CHUNKS = {"time": 365, "lat": 24, "lon": 32}
@@ -43,8 +48,41 @@ def _open_var(
     return ds[var_name].sel(lat=LAT_SLICE, lon=LON_SLICE)
 
 
+def _as_cftime_gregorian(da: xr.DataArray) -> xr.DataArray:
+    time_values = da.indexes["time"]
+    cftime_time = [
+        cftime.DatetimeGregorian(
+            int(ts.year),
+            int(ts.month),
+            int(ts.day),
+            int(getattr(ts, "hour", 0)),
+            int(getattr(ts, "minute", 0)),
+            int(getattr(ts, "second", 0)),
+        )
+        for ts in time_values
+    ]
+    return da.assign_coords(time=cftime_time)
+
+
 def _build_workload(icclim, workload: str, *, chunks: dict[str, int]) -> xr.Dataset:
     tas = _open_var(TAS_GLOB, "tas", chunks=chunks)
+    if workload == "generic_pr_average_bootstrap_yearly":
+        pr = _open_var(
+            PR_GLOB,
+            "pr",
+            chunks=chunks,
+        ).sel(lat=DRY_PR_LAT_SLICE, lon=DRY_PR_LON_SLICE)
+        return icclim.average(
+            in_files=pr,
+            var_name="pr",
+            threshold=icclim.build_threshold(
+                "> 95 doy_per",
+                reference_period=BASE_PERIOD,
+                threshold_min_value="1 mm/day",
+            ),
+            time_range=TIME_RANGE,
+            slice_mode="year",
+        )
     if workload == "generic_tas_compound_percentile_or_count_yearly":
         return icclim.count_occurrences(
             in_files=tas,
@@ -123,6 +161,26 @@ def _build_workload(icclim, workload: str, *, chunks: dict[str, int]) -> xr.Data
             time_range=TIME_RANGE,
             slice_mode="year",
         )
+    if workload == "tx90p_cftime_yearly":
+        tas = _as_cftime_gregorian(tas)
+        return icclim.index(
+            index_name="TX90p",
+            in_files=tas,
+            var_name="tas",
+            base_period_time_range=BASE_PERIOD,
+            time_range=TIME_RANGE,
+            slice_mode="year",
+        )
+    if workload == "tx90p_cftime_monthly":
+        tas = _as_cftime_gregorian(tas)
+        return icclim.index(
+            index_name="TX90p",
+            in_files=tas,
+            var_name="tas",
+            base_period_time_range=BASE_PERIOD,
+            time_range=TIME_RANGE,
+            slice_mode="month",
+        )
     msg = f"Unsupported workload: {workload}"
     raise ValueError(msg)
 
@@ -192,12 +250,21 @@ def main() -> None:
     sys.path.insert(0, str(_resolve_import_root(repo)))
 
     import icclim
-    import icclim._core.generic.bootstrap as bootstrap_module
-    import icclim._core.generic.bootstrap_primitives as primitives_module
-    from icclim._core.generic.functions import (
-        get_bootstrap_profile,
-        reset_bootstrap_profile,
-    )
+    bootstrap_module = None
+    primitives_module = None
+    functions_module = importlib.import_module("icclim._core.generic.functions")
+    try:
+        bootstrap_module = importlib.import_module("icclim._core.generic.bootstrap")
+    except ModuleNotFoundError:
+        pass
+    try:
+        primitives_module = importlib.import_module(
+            "icclim._core.generic.bootstrap_primitives"
+        )
+    except ModuleNotFoundError:
+        pass
+    get_bootstrap_profile = getattr(functions_module, "get_bootstrap_profile", lambda: {})
+    reset_bootstrap_profile = getattr(functions_module, "reset_bootstrap_profile", lambda: None)
 
     chunk_profile = DEFAULT_CHUNKS if args.chunk_profile == "default" else ALT_CHUNKS
     phase_stats: dict[str, dict[str, float]] = {}
@@ -207,24 +274,65 @@ def main() -> None:
     started = time.perf_counter()
     with (
         _timed_patch_if_present(
+            functions_module,
+            "_compute_threshold_exceedance_mask",
+            phase_stats,
+        ),
+        _timed_patch_if_present(
+            functions_module,
+            "_compute_exceedance_mask",
+            phase_stats,
+        ),
+        _timed_patch_if_present(
+            functions_module,
+            "_compute_safe_tiled_count_occurrences",
+            phase_stats,
+        ),
+        _timed_patch_if_present(
+            functions_module,
+            "_compute_safe_tiled_count_occurrences_with_max_cells",
+            phase_stats,
+        ),
+        _timed_patch_if_present(
+            functions_module,
+            "_compute_exact_tiled_bootstrap_spell_mask",
+            phase_stats,
+        ),
+        _timed_patch_if_present(
+            functions_module,
+            "_compute_fast_tiled_count_occurrences",
+            phase_stats,
+        ),
+        _timed_patch_if_present(
             primitives_module,
             "_normalize_bootstrap_chunks",
             phase_stats,
-        ),
-        _timed_patch(
+        ) if primitives_module is not None else nullcontext(),
+        _timed_patch_if_present(
             primitives_module,
             "build_bootstrap_reference_sample",
             phase_stats,
-        ),
-        _timed_patch(
+        ) if primitives_module is not None else nullcontext(),
+        _timed_patch_if_present(
             primitives_module,
             "build_bootstrap_prepared_inputs",
             phase_stats,
-        ),
-        _timed_patch(
-            bootstrap_module, "build_bootstrap_temporal_indexing", phase_stats
-        ),
-        _timed_patch(bootstrap_module, "build_bootstrap_array_inputs", phase_stats),
+        ) if primitives_module is not None else nullcontext(),
+        _timed_patch_if_present(
+            bootstrap_module,
+            "compute_doy_percentile_bootstrap_count",
+            phase_stats,
+        ) if bootstrap_module is not None else nullcontext(),
+        _timed_patch_if_present(
+            bootstrap_module,
+            "build_bootstrap_temporal_indexing",
+            phase_stats,
+        ) if bootstrap_module is not None else nullcontext(),
+        _timed_patch_if_present(
+            bootstrap_module,
+            "build_bootstrap_array_inputs",
+            phase_stats,
+        ) if bootstrap_module is not None else nullcontext(),
     ):
         ds = _build_workload(icclim, args.workload, chunks=chunk_profile).load()
     elapsed = time.perf_counter() - started

--- a/tools/prototype_cftime_exact_count_threshold_bank.py
+++ b/tools/prototype_cftime_exact_count_threshold_bank.py
@@ -65,7 +65,7 @@ def _build_case(case_name: str) -> xr.DataArray:
 
 
 def _build_threshold():
-    from icclim.threshold.factory import build_threshold  # noqa: PLC0415
+    from icclim.threshold.factory import build_threshold
 
     return build_threshold(
         "> 90 doy_per",
@@ -76,7 +76,7 @@ def _build_threshold():
 
 @contextmanager
 def _force_compiled_cftime_count():
-    from icclim._core.generic import bootstrap as bootstrap_module  # noqa: PLC0415
+    from icclim._core.generic import bootstrap as bootstrap_module
 
     original = bootstrap_module.is_optimized_doy_percentile_count_supported
     bootstrap_module.is_optimized_doy_percentile_count_supported = lambda *_: True
@@ -97,7 +97,7 @@ class PrototypeMetrics:
 
 
 def _compute_current_compiled(case_name: str, freq: str) -> xr.DataArray:
-    from icclim._core.generic.bootstrap import (  # noqa: PLC0415
+    from icclim._core.generic.bootstrap import (
         compute_doy_percentile_bootstrap_count,
     )
 
@@ -119,11 +119,11 @@ def _compute_threshold_bank_prototype(
     case_name: str,
     freq: str,
 ) -> tuple[xr.DataArray, PrototypeMetrics]:
-    from icclim._core.generic.bootstrap import (  # noqa: PLC0415
+    from icclim._core.generic.bootstrap import (
         _build_bootstrap_threshold_series_for_cell,
         _count_exceedances,
     )
-    from icclim._core.generic.bootstrap_primitives import (  # noqa: PLC0415
+    from icclim._core.generic.bootstrap_primitives import (
         build_bootstrap_output,
         build_bootstrap_prepared_inputs,
     )

--- a/tools/prototype_cftime_exact_count_threshold_bank.py
+++ b/tools/prototype_cftime_exact_count_threshold_bank.py
@@ -1,3 +1,5 @@
+# ruff: noqa: PERF401, PLR2004
+
 from __future__ import annotations
 
 import argparse

--- a/tools/prototype_cftime_exact_count_threshold_bank.py
+++ b/tools/prototype_cftime_exact_count_threshold_bank.py
@@ -1,0 +1,325 @@
+from __future__ import annotations
+
+import argparse
+import json
+from contextlib import contextmanager
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from time import perf_counter
+
+import cftime
+import numpy as np
+import xarray as xr
+
+
+def _resolve_import_root(repo: Path) -> Path:
+    for candidate in (repo / "src", repo):
+        if (candidate / "icclim" / "__init__.py").is_file():
+            return candidate
+    msg = f"Could not locate icclim import root under {repo}"
+    raise FileNotFoundError(msg)
+
+
+def _build_time_coord() -> list[cftime.DatetimeGregorian]:
+    time = xr.date_range(
+        "2042-01-01",
+        periods=365 * 5 + 1,
+        freq="D",
+        use_cftime=True,
+    )
+    return [
+        cftime.DatetimeGregorian(int(ts.year), int(ts.month), int(ts.day))
+        for ts in time
+    ]
+
+
+def _build_case(case_name: str) -> xr.DataArray:
+    time = _build_time_coord()
+    data = np.full((len(time), 1, 1), 300.0, dtype=np.float64)
+    tas = xr.DataArray(
+        data,
+        dims=["time", "lat", "lon"],
+        coords={"time": time, "lat": [0.0], "lon": [0.0]},
+        attrs={"units": "K"},
+        name="tas",
+    )
+    if case_name == "constant":
+        return tas.chunk({"time": 365, "lat": 1, "lon": 1})
+    if case_name == "leap_day_cold_spike":
+        for timestamp in (
+            cftime.DatetimeGregorian(2044, 2, 28),
+            cftime.DatetimeGregorian(2044, 2, 29),
+            cftime.DatetimeGregorian(2044, 3, 1),
+        ):
+            tas.loc[{"time": timestamp}] = 250.0
+        return tas.chunk({"time": 365, "lat": 1, "lon": 1})
+    if case_name == "reference_overlap_shift":
+        tas.loc[{"time": cftime.DatetimeGregorian(2042, 2, 28)}] = 305.0
+        tas.loc[{"time": cftime.DatetimeGregorian(2043, 2, 28)}] = 295.0
+        tas.loc[{"time": cftime.DatetimeGregorian(2044, 2, 29)}] = 285.0
+        tas.loc[{"time": cftime.DatetimeGregorian(2045, 2, 28)}] = 310.0
+        tas.loc[{"time": cftime.DatetimeGregorian(2045, 3, 1)}] = 280.0
+        return tas.chunk({"time": 365, "lat": 1, "lon": 1})
+    msg = f"Unsupported case: {case_name}"
+    raise ValueError(msg)
+
+
+def _build_threshold():
+    from icclim.threshold.factory import build_threshold  # noqa: PLC0415
+
+    return build_threshold(
+        "> 90 doy_per",
+        doy_window_width=1,
+        reference_period=("2042-01-01", "2044-12-31"),
+    )
+
+
+@contextmanager
+def _force_compiled_cftime_count():
+    from icclim._core.generic import bootstrap as bootstrap_module  # noqa: PLC0415
+
+    original = bootstrap_module.is_optimized_doy_percentile_count_supported
+    bootstrap_module.is_optimized_doy_percentile_count_supported = lambda *_: True
+    try:
+        yield
+    finally:
+        bootstrap_module.is_optimized_doy_percentile_count_supported = original
+
+
+@dataclass(frozen=True)
+class PrototypeMetrics:
+    nominal_series_built: int
+    bank_series_built: int
+    bank_bytes_float64: int
+    bank_build_seconds: float
+    evaluation_seconds: float
+    total_seconds: float
+
+
+def _compute_current_compiled(case_name: str, freq: str) -> xr.DataArray:
+    from icclim._core.generic.bootstrap import (  # noqa: PLC0415
+        compute_doy_percentile_bootstrap_count,
+    )
+
+    tas = _build_case(case_name)
+    threshold = _build_threshold()
+    with _force_compiled_cftime_count():
+        result = compute_doy_percentile_bootstrap_count(
+            tas,
+            threshold,
+            freq,
+        )
+    if result is None:
+        msg = f"Compiled bootstrap count returned None for case={case_name} freq={freq}"
+        raise RuntimeError(msg)
+    return result.load()
+
+
+def _compute_threshold_bank_prototype(
+    case_name: str,
+    freq: str,
+) -> tuple[xr.DataArray, PrototypeMetrics]:
+    from icclim._core.generic.bootstrap import (  # noqa: PLC0415
+        _build_bootstrap_threshold_series_for_cell,
+        _count_exceedances,
+    )
+    from icclim._core.generic.bootstrap_primitives import (  # noqa: PLC0415
+        build_bootstrap_output,
+        build_bootstrap_prepared_inputs,
+    )
+
+    tas = _build_case(case_name)
+    threshold = _build_threshold()
+    prepared = build_bootstrap_prepared_inputs(
+        tas,
+        threshold,
+        freq,
+        dtype=np.float64,
+    )
+    ref = prepared.reference_sample
+    idx = prepared.temporal_indexing
+    arr = prepared.array_inputs
+    min_threshold = (
+        np.nan
+        if ref.threshold_floor_in_reference_units is None
+        else float(ref.threshold_floor_in_reference_units)
+    )
+    quantile = float(threshold.percentile_coord().item()) / 100.0
+    alpha = float(threshold.interpolation.alpha)
+    beta = float(threshold.interpolation.beta)
+    op_code = 0 if threshold.operator.operand == ">" else 1
+    build_thresholds = _build_bootstrap_threshold_series_for_cell.py_func
+    count_exceedances = _count_exceedances.py_func
+    max_samples = idx.sample_indices_by_day_of_year.shape[1]
+    n_years = len(idx.bootstrap_years)
+    n_groups = len(idx.output_group_labels)
+    n_cells = arr.flat_study.shape[1]
+    n_ref_years = idx.substitute_alignment.shape[1]
+    out = np.empty((n_groups, n_cells), dtype=np.float64)
+
+    total_start = perf_counter()
+    build_start = perf_counter()
+    nominal_thresholds_by_cell: list[np.ndarray] = []
+    for cell in range(n_cells):
+        nominal_thresholds_by_cell.append(
+            build_thresholds(
+                arr.flat_reference_filtered,
+                idx.sample_indices_by_day_of_year,
+                idx.reference_index_year,
+                idx.reference_index_position,
+                idx.substitute_alignment,
+                -1,
+                -1,
+                cell,
+                max_samples,
+                quantile,
+                alpha,
+                beta,
+                min_threshold,
+            )
+        )
+    threshold_bank = np.full(
+        (n_ref_years, n_ref_years, 365, n_cells),
+        np.nan,
+        dtype=np.float64,
+    )
+    bank_series_built = 0
+    for target_ref_i in range(n_ref_years):
+        for substitute_i in range(n_ref_years):
+            if substitute_i == target_ref_i:
+                continue
+            for cell in range(n_cells):
+                threshold_bank[target_ref_i, substitute_i, :, cell] = build_thresholds(
+                    arr.flat_reference_raw,
+                    idx.sample_indices_by_day_of_year,
+                    idx.reference_index_year,
+                    idx.reference_index_position,
+                    idx.substitute_alignment,
+                    target_ref_i,
+                    substitute_i,
+                    cell,
+                    max_samples,
+                    quantile,
+                    alpha,
+                    beta,
+                    min_threshold,
+                )
+                bank_series_built += 1
+    bank_build_seconds = perf_counter() - build_start
+
+    evaluation_start = perf_counter()
+    for year_i in range(n_years):
+        target_ref_i = idx.year_to_reference_index[year_i]
+        group_start = idx.year_group_starts[year_i]
+        group_stop = idx.year_group_stops[year_i]
+        for cell in range(n_cells):
+            if target_ref_i < 0:
+                thresholds = nominal_thresholds_by_cell[cell]
+                for group_i in range(group_start, group_stop):
+                    out[group_i, cell] = count_exceedances(
+                        arr.flat_study,
+                        thresholds,
+                        idx.study_day_of_years,
+                        idx.output_starts[group_i],
+                        idx.output_lengths[group_i],
+                        cell,
+                        idx.year_max_day_of_years[year_i],
+                        op_code,
+                    )
+                continue
+            for group_i in range(group_start, group_stop):
+                out[group_i, cell] = 0.0
+            substitute_count = 0
+            for substitute_i in range(n_ref_years):
+                if substitute_i == target_ref_i:
+                    continue
+                thresholds = threshold_bank[target_ref_i, substitute_i, :, cell]
+                for group_i in range(group_start, group_stop):
+                    out[group_i, cell] += count_exceedances(
+                        arr.flat_study,
+                        thresholds,
+                        idx.study_day_of_years,
+                        idx.output_starts[group_i],
+                        idx.output_lengths[group_i],
+                        cell,
+                        idx.year_max_day_of_years[year_i],
+                        op_code,
+                    )
+                substitute_count += 1
+            for group_i in range(group_start, group_stop):
+                out[group_i, cell] /= substitute_count
+    evaluation_seconds = perf_counter() - evaluation_start
+    total_seconds = perf_counter() - total_start
+    result = build_bootstrap_output(
+        flat_result=out,
+        reference_sample=ref,
+        temporal_indexing=idx,
+        spatial_shape=arr.spatial_shape,
+        units="d",
+    ).assign_coords(percentiles=threshold.percentile_coord().item())
+    return result.load(), PrototypeMetrics(
+        nominal_series_built=n_cells,
+        bank_series_built=bank_series_built,
+        bank_bytes_float64=int(threshold_bank.nbytes),
+        bank_build_seconds=bank_build_seconds,
+        evaluation_seconds=evaluation_seconds,
+        total_seconds=total_seconds,
+    )
+
+
+def _compare(current: xr.DataArray, prototype: xr.DataArray) -> dict[str, object]:
+    current_values = np.asarray(current.values)
+    prototype_values = np.asarray(prototype.values)
+    diff = np.abs(current_values - prototype_values)
+    return {
+        "changed_cells": int(np.count_nonzero(diff > 1.0e-9)),
+        "max_abs_diff": float(np.nanmax(diff)) if diff.size else 0.0,
+        "current_shape": list(current.shape),
+        "prototype_shape": list(prototype.shape),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo", required=True)
+    parser.add_argument(
+        "--case",
+        choices=("constant", "leap_day_cold_spike", "reference_overlap_shift", "all"),
+        default="all",
+    )
+    parser.add_argument(
+        "--freq",
+        choices=("YS", "MS", "both"),
+        default="both",
+    )
+    args = parser.parse_args()
+
+    repo = Path(args.repo).resolve()
+    import_root = _resolve_import_root(repo)
+
+    import sys
+
+    sys.path.insert(0, str(import_root))
+
+    case_names = (
+        ("constant", "leap_day_cold_spike", "reference_overlap_shift")
+        if args.case == "all"
+        else (args.case,)
+    )
+    frequencies = ("YS", "MS") if args.freq == "both" else (args.freq,)
+    payload: dict[str, object] = {"repo": str(repo), "cases": {}}
+    for case_name in case_names:
+        case_payload: dict[str, object] = {}
+        for freq in frequencies:
+            current = _compute_current_compiled(case_name, freq)
+            prototype, metrics = _compute_threshold_bank_prototype(case_name, freq)
+            case_payload[freq] = {
+                "comparison": _compare(current, prototype),
+                "metrics": asdict(metrics),
+            }
+        payload["cases"][case_name] = case_payload
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/prototype_cftime_exact_order_stat_count.py
+++ b/tools/prototype_cftime_exact_order_stat_count.py
@@ -1,3 +1,5 @@
+# ruff: noqa: PLR2004
+
 from __future__ import annotations
 
 import argparse

--- a/tools/prototype_cftime_exact_order_stat_count.py
+++ b/tools/prototype_cftime_exact_order_stat_count.py
@@ -1,0 +1,368 @@
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+from contextlib import contextmanager
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from time import perf_counter
+
+import cftime
+import numpy as np
+import xarray as xr
+
+
+def _resolve_import_root(repo: Path) -> Path:
+    for candidate in (repo / "src", repo):
+        if (candidate / "icclim" / "__init__.py").is_file():
+            return candidate
+    msg = f"Could not locate icclim import root under {repo}"
+    raise FileNotFoundError(msg)
+
+
+def _load_quantile_tool(repo: Path):
+    module_path = repo / "tools" / "prototype_cftime_exact_order_stat_quantile.py"
+    spec = importlib.util.spec_from_file_location(
+        "prototype_cftime_exact_order_stat_quantile",
+        module_path,
+    )
+    if spec is None or spec.loader is None:
+        msg = f"Cannot load quantile tool from {module_path}"
+        raise RuntimeError(msg)
+    quantile_tool = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = quantile_tool
+    spec.loader.exec_module(quantile_tool)
+
+    return quantile_tool
+
+
+def _build_time_coord() -> list[cftime.DatetimeGregorian]:
+    time = xr.date_range(
+        "2042-01-01",
+        periods=365 * 5 + 1,
+        freq="D",
+        use_cftime=True,
+    )
+    return [
+        cftime.DatetimeGregorian(int(ts.year), int(ts.month), int(ts.day))
+        for ts in time
+    ]
+
+
+def _build_case(case_name: str) -> xr.DataArray:
+    time = _build_time_coord()
+    data = np.full((len(time), 1, 1), 300.0, dtype=np.float64)
+    tas = xr.DataArray(
+        data,
+        dims=["time", "lat", "lon"],
+        coords={"time": time, "lat": [0.0], "lon": [0.0]},
+        attrs={"units": "K"},
+        name="tas",
+    )
+    if case_name == "constant":
+        return tas.chunk({"time": 365, "lat": 1, "lon": 1})
+    if case_name == "leap_day_cold_spike":
+        for timestamp in (
+            cftime.DatetimeGregorian(2044, 2, 28),
+            cftime.DatetimeGregorian(2044, 2, 29),
+            cftime.DatetimeGregorian(2044, 3, 1),
+        ):
+            tas.loc[{"time": timestamp}] = 250.0
+        return tas.chunk({"time": 365, "lat": 1, "lon": 1})
+    if case_name == "reference_overlap_shift":
+        tas.loc[{"time": cftime.DatetimeGregorian(2042, 2, 28)}] = 305.0
+        tas.loc[{"time": cftime.DatetimeGregorian(2043, 2, 28)}] = 295.0
+        tas.loc[{"time": cftime.DatetimeGregorian(2044, 2, 29)}] = 285.0
+        tas.loc[{"time": cftime.DatetimeGregorian(2045, 2, 28)}] = 310.0
+        tas.loc[{"time": cftime.DatetimeGregorian(2045, 3, 1)}] = 280.0
+        return tas.chunk({"time": 365, "lat": 1, "lon": 1})
+    msg = f"Unsupported case: {case_name}"
+    raise ValueError(msg)
+
+
+def _build_threshold():
+    from icclim.threshold.factory import build_threshold  # noqa: PLC0415
+
+    return build_threshold(
+        "> 90 doy_per",
+        doy_window_width=1,
+        reference_period=("2042-01-01", "2044-12-31"),
+    )
+
+
+@contextmanager
+def _force_compiled_cftime_count():
+    from icclim._core.generic import bootstrap as bootstrap_module  # noqa: PLC0415
+
+    original = bootstrap_module.is_optimized_doy_percentile_count_supported
+    bootstrap_module.is_optimized_doy_percentile_count_supported = lambda *_: True
+    try:
+        yield
+    finally:
+        bootstrap_module.is_optimized_doy_percentile_count_supported = original
+
+
+@dataclass(frozen=True)
+class CountPrototypeComparison:
+    changed_cells: int
+    max_abs_diff: float
+    current_seconds: float
+    order_stat_seconds: float
+    compiled_bank_seconds: float
+    speed_ratio_current_over_order_stat: float
+    speed_ratio_compiled_bank_over_order_stat: float
+
+
+def _compare(a: xr.DataArray, b: xr.DataArray) -> tuple[int, float]:
+    diff = np.abs(np.asarray(a.values) - np.asarray(b.values))
+    return (
+        int(np.count_nonzero(diff > 1.0e-9)),
+        float(np.nanmax(diff)) if diff.size else 0.0,
+    )
+
+
+def _compute_current(case_name: str, freq: str) -> tuple[xr.DataArray, float]:
+    from icclim._core.generic.bootstrap import (  # noqa: PLC0415
+        compute_doy_percentile_bootstrap_count,
+    )
+
+    tas = _build_case(case_name)
+    threshold = _build_threshold()
+    start = perf_counter()
+    with _force_compiled_cftime_count():
+        result = compute_doy_percentile_bootstrap_count(tas, threshold, freq)
+    seconds = perf_counter() - start
+    if result is None:
+        msg = f"Current compiled count returned None for case={case_name} freq={freq}"
+        raise RuntimeError(msg)
+    return result.load(), seconds
+
+
+def _compute_compiled_bank(case_name: str, freq: str) -> tuple[xr.DataArray, float]:
+    from icclim._core.generic.bootstrap import (  # noqa: PLC0415
+        compute_doy_percentile_bootstrap_count_threshold_bank_compiled_prototype,
+    )
+
+    tas = _build_case(case_name)
+    threshold = _build_threshold()
+    start = perf_counter()
+    result = compute_doy_percentile_bootstrap_count_threshold_bank_compiled_prototype(
+        tas,
+        threshold,
+        freq,
+    )
+    seconds = perf_counter() - start
+    if result is None:
+        msg = (
+            "Compiled threshold-bank prototype returned None for "
+            f"case={case_name} freq={freq}"
+        )
+        raise RuntimeError(msg)
+    return result.load(), seconds
+
+
+def _compute_order_stat(
+    case_name: str,
+    freq: str,
+    repo: Path,
+) -> tuple[xr.DataArray, float]:
+    from icclim._core.generic.bootstrap import _count_exceedances  # noqa: PLC0415
+    from icclim._core.generic.bootstrap_primitives import (  # noqa: PLC0415
+        build_bootstrap_output,
+        build_bootstrap_prepared_inputs,
+    )
+
+    tas = _build_case(case_name)
+    threshold = _build_threshold()
+    prepared = build_bootstrap_prepared_inputs(
+        tas,
+        threshold,
+        freq,
+        dtype=np.float64,
+    )
+    ref = prepared.reference_sample
+    idx = prepared.temporal_indexing
+    arr = prepared.array_inputs
+    min_threshold = (
+        np.nan
+        if ref.threshold_floor_in_reference_units is None
+        else float(ref.threshold_floor_in_reference_units)
+    )
+    quantile = float(threshold.percentile_coord().item()) / 100.0
+    alpha = float(threshold.interpolation.alpha)
+    beta = float(threshold.interpolation.beta)
+    op_code = 0 if threshold.operator.operand == ">" else 1
+    count_exceedances = _count_exceedances.py_func
+    n_years = len(idx.bootstrap_years)
+    n_groups = len(idx.output_group_labels)
+    n_cells = arr.flat_study.shape[1]
+    n_ref_years = idx.substitute_alignment.shape[1]
+    flat_ref = (
+        arr.flat_reference_filtered
+        if not np.isnan(min_threshold)
+        else arr.flat_reference_raw
+    )
+    quantile_tool = _load_quantile_tool(repo)
+    out = np.empty((n_groups, n_cells), dtype=np.float64)
+
+    start = perf_counter()
+    nominal_thresholds_by_cell: list[np.ndarray] = []
+    for cell in range(n_cells):
+        thresholds, _, _ = quantile_tool._build_order_stat_threshold_series_for_cell(
+            flat_ref,
+            idx.sample_indices_by_day_of_year,
+            idx.reference_index_year,
+            idx.reference_index_position,
+            idx.substitute_alignment,
+            -1,
+            -1,
+            cell,
+            quantile,
+            alpha,
+            beta,
+            min_threshold,
+        )
+        nominal_thresholds_by_cell.append(thresholds)
+
+    for year_i in range(n_years):
+        target_ref_i = idx.year_to_reference_index[year_i]
+        group_start = idx.year_group_starts[year_i]
+        group_stop = idx.year_group_stops[year_i]
+        for cell in range(n_cells):
+            if target_ref_i < 0:
+                thresholds = nominal_thresholds_by_cell[cell]
+                for group_i in range(group_start, group_stop):
+                    out[group_i, cell] = count_exceedances(
+                        arr.flat_study,
+                        thresholds,
+                        idx.study_day_of_years,
+                        idx.output_starts[group_i],
+                        idx.output_lengths[group_i],
+                        cell,
+                        idx.year_max_day_of_years[year_i],
+                        op_code,
+                    )
+                continue
+            for group_i in range(group_start, group_stop):
+                out[group_i, cell] = 0.0
+            substitute_count = 0
+            for substitute_i in range(n_ref_years):
+                if substitute_i == target_ref_i:
+                    continue
+                thresholds, _, _ = (
+                    quantile_tool._build_order_stat_threshold_series_for_cell(
+                        flat_ref,
+                        idx.sample_indices_by_day_of_year,
+                        idx.reference_index_year,
+                        idx.reference_index_position,
+                        idx.substitute_alignment,
+                        target_ref_i,
+                        substitute_i,
+                        cell,
+                        quantile,
+                        alpha,
+                        beta,
+                        min_threshold,
+                    )
+                )
+                for group_i in range(group_start, group_stop):
+                    out[group_i, cell] += count_exceedances(
+                        arr.flat_study,
+                        thresholds,
+                        idx.study_day_of_years,
+                        idx.output_starts[group_i],
+                        idx.output_lengths[group_i],
+                        cell,
+                        idx.year_max_day_of_years[year_i],
+                        op_code,
+                    )
+                substitute_count += 1
+            for group_i in range(group_start, group_stop):
+                out[group_i, cell] /= substitute_count
+    seconds = perf_counter() - start
+
+    result = build_bootstrap_output(
+        flat_result=out,
+        reference_sample=ref,
+        temporal_indexing=idx,
+        spatial_shape=arr.spatial_shape,
+        units="d",
+    ).assign_coords(percentiles=threshold.percentile_coord().item())
+    return result.load(), seconds
+
+
+def compare_count_prototypes(
+    case_name: str,
+    freq: str,
+    *,
+    repo: Path | None = None,
+) -> CountPrototypeComparison:
+    if repo is None:
+        repo = Path(__file__).resolve().parents[1]
+    current, current_seconds = _compute_current(case_name, freq)
+    order_stat, order_stat_seconds = _compute_order_stat(case_name, freq, repo)
+    compiled_bank, compiled_bank_seconds = _compute_compiled_bank(case_name, freq)
+    changed_cells, max_abs_diff = _compare(current, order_stat)
+    bank_changed_cells, bank_max_abs_diff = _compare(current, compiled_bank)
+    if bank_changed_cells != 0 or bank_max_abs_diff != 0.0:
+        msg = "Compiled threshold-bank prototype no longer matches current output"
+        raise RuntimeError(msg)
+    return CountPrototypeComparison(
+        changed_cells=changed_cells,
+        max_abs_diff=max_abs_diff,
+        current_seconds=current_seconds,
+        order_stat_seconds=order_stat_seconds,
+        compiled_bank_seconds=compiled_bank_seconds,
+        speed_ratio_current_over_order_stat=(
+            current_seconds / order_stat_seconds
+            if order_stat_seconds > 0.0
+            else float("inf")
+        ),
+        speed_ratio_compiled_bank_over_order_stat=(
+            compiled_bank_seconds / order_stat_seconds
+            if order_stat_seconds > 0.0
+            else float("inf")
+        ),
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo", required=True)
+    parser.add_argument(
+        "--case",
+        choices=("constant", "leap_day_cold_spike", "reference_overlap_shift", "all"),
+        default="all",
+    )
+    parser.add_argument(
+        "--freq",
+        choices=("YS", "MS", "both"),
+        default="both",
+    )
+    args = parser.parse_args()
+
+    repo = Path(args.repo).resolve()
+    import_root = _resolve_import_root(repo)
+    sys.path.insert(0, str(import_root))
+
+    case_names = (
+        ("constant", "leap_day_cold_spike", "reference_overlap_shift")
+        if args.case == "all"
+        else (args.case,)
+    )
+    frequencies = ("YS", "MS") if args.freq == "both" else (args.freq,)
+    payload: dict[str, object] = {"repo": str(repo), "cases": {}}
+    for case_name in case_names:
+        case_payload: dict[str, object] = {}
+        for freq in frequencies:
+            case_payload[freq] = asdict(
+                compare_count_prototypes(case_name, freq, repo=repo)
+            )
+        payload["cases"][case_name] = case_payload
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/prototype_cftime_exact_order_stat_count.py
+++ b/tools/prototype_cftime_exact_order_stat_count.py
@@ -83,7 +83,7 @@ def _build_case(case_name: str) -> xr.DataArray:
 
 
 def _build_threshold():
-    from icclim.threshold.factory import build_threshold  # noqa: PLC0415
+    from icclim.threshold.factory import build_threshold
 
     return build_threshold(
         "> 90 doy_per",
@@ -94,7 +94,7 @@ def _build_threshold():
 
 @contextmanager
 def _force_compiled_cftime_count():
-    from icclim._core.generic import bootstrap as bootstrap_module  # noqa: PLC0415
+    from icclim._core.generic import bootstrap as bootstrap_module
 
     original = bootstrap_module.is_optimized_doy_percentile_count_supported
     bootstrap_module.is_optimized_doy_percentile_count_supported = lambda *_: True
@@ -124,7 +124,7 @@ def _compare(a: xr.DataArray, b: xr.DataArray) -> tuple[int, float]:
 
 
 def _compute_current(case_name: str, freq: str) -> tuple[xr.DataArray, float]:
-    from icclim._core.generic.bootstrap import (  # noqa: PLC0415
+    from icclim._core.generic.bootstrap import (
         compute_doy_percentile_bootstrap_count,
     )
 
@@ -141,7 +141,7 @@ def _compute_current(case_name: str, freq: str) -> tuple[xr.DataArray, float]:
 
 
 def _compute_compiled_bank(case_name: str, freq: str) -> tuple[xr.DataArray, float]:
-    from icclim._core.generic.bootstrap import (  # noqa: PLC0415
+    from icclim._core.generic.bootstrap import (
         compute_doy_percentile_bootstrap_count_threshold_bank_compiled_prototype,
     )
 
@@ -168,8 +168,8 @@ def _compute_order_stat(
     freq: str,
     repo: Path,
 ) -> tuple[xr.DataArray, float]:
-    from icclim._core.generic.bootstrap import _count_exceedances  # noqa: PLC0415
-    from icclim._core.generic.bootstrap_primitives import (  # noqa: PLC0415
+    from icclim._core.generic.bootstrap import _count_exceedances
+    from icclim._core.generic.bootstrap_primitives import (
         build_bootstrap_output,
         build_bootstrap_prepared_inputs,
     )

--- a/tools/prototype_cftime_exact_order_stat_quantile.py
+++ b/tools/prototype_cftime_exact_order_stat_quantile.py
@@ -68,7 +68,7 @@ def _build_case(case_name: str) -> xr.DataArray:
 
 
 def _build_threshold():
-    from icclim.threshold.factory import build_threshold  # noqa: PLC0415
+    from icclim.threshold.factory import build_threshold
 
     return build_threshold(
         "> 90 doy_per",
@@ -79,7 +79,7 @@ def _build_threshold():
 
 @contextmanager
 def _force_compiled_cftime_count():
-    from icclim._core.generic import bootstrap as bootstrap_module  # noqa: PLC0415
+    from icclim._core.generic import bootstrap as bootstrap_module
 
     original = bootstrap_module.is_optimized_doy_percentile_count_supported
     bootstrap_module.is_optimized_doy_percentile_count_supported = lambda *_: True
@@ -198,12 +198,16 @@ def _value_at_adjusted_rank(
     inserted_i = 0
     current_rank = -1
     while True:
-        base_i, removed_i = _skip_removed(base_sorted, removed_sorted, base_i, removed_i)
+        base_i, removed_i = _skip_removed(
+            base_sorted, removed_sorted, base_i, removed_i
+        )
         has_base = base_i < len(base_sorted)
         has_inserted = inserted_i < len(inserted_sorted)
         if not has_base and not has_inserted:
             raise IndexError(rank)
-        if has_inserted and (not has_base or inserted_sorted[inserted_i] <= base_sorted[base_i]):
+        if has_inserted and (
+            not has_base or inserted_sorted[inserted_i] <= base_sorted[base_i]
+        ):
             value = inserted_sorted[inserted_i]
             inserted_i += 1
         else:
@@ -229,12 +233,16 @@ def _method8_quantile_from_adjusted_sorted(
         return _value_at_adjusted_rank(base_sorted, removed_sorted, inserted_sorted, 0)
     virtual = n * quantile + (alpha + quantile * (1.0 - alpha - beta)) - 1.0
     if virtual >= n - 1:
-        return _value_at_adjusted_rank(base_sorted, removed_sorted, inserted_sorted, n - 1)
+        return _value_at_adjusted_rank(
+            base_sorted, removed_sorted, inserted_sorted, n - 1
+        )
     if virtual < 0:
         return _value_at_adjusted_rank(base_sorted, removed_sorted, inserted_sorted, 0)
     previous = int(math.floor(virtual))
     gamma = virtual - previous
-    left = _value_at_adjusted_rank(base_sorted, removed_sorted, inserted_sorted, previous)
+    left = _value_at_adjusted_rank(
+        base_sorted, removed_sorted, inserted_sorted, previous
+    )
     right = _value_at_adjusted_rank(
         base_sorted,
         removed_sorted,
@@ -265,7 +273,9 @@ def _build_order_stat_threshold_series_for_cell(
     removed_sizes = np.zeros(NON_LEAP_DAY_COUNT, dtype=np.int64)
     inserted_sizes = np.zeros(NON_LEAP_DAY_COUNT, dtype=np.int64)
     for doy_i in range(NON_LEAP_DAY_COUNT):
-        base_sorted = _nominal_sorted_sample_for_cell(flat_ref, sample_indices, doy_i, cell)
+        base_sorted = _nominal_sorted_sample_for_cell(
+            flat_ref, sample_indices, doy_i, cell
+        )
         removed_sorted = _removed_values_for_target(
             base_sorted,
             flat_ref,
@@ -308,10 +318,10 @@ def compare_order_stat_threshold_series(
     case_name: str,
     freq: str,
 ) -> ThresholdSeriesComparison:
-    from icclim._core.generic.bootstrap import (  # noqa: PLC0415
+    from icclim._core.generic.bootstrap import (
         _build_bootstrap_threshold_series_for_cell,
     )
-    from icclim._core.generic.bootstrap_primitives import (  # noqa: PLC0415
+    from icclim._core.generic.bootstrap_primitives import (
         build_bootstrap_prepared_inputs,
     )
 
@@ -336,7 +346,11 @@ def compare_order_stat_threshold_series(
     beta = float(threshold.interpolation.beta)
     build_thresholds = _build_bootstrap_threshold_series_for_cell.py_func
     n_ref_years = idx.substitute_alignment.shape[1]
-    flat_ref = arr.flat_reference_filtered if not np.isnan(min_threshold) else arr.flat_reference_raw
+    flat_ref = (
+        arr.flat_reference_filtered
+        if not np.isnan(min_threshold)
+        else arr.flat_reference_raw
+    )
     changed_doys = 0
     max_abs_diff = 0.0
     nominal_changed_doys = 0
@@ -362,25 +376,29 @@ def compare_order_stat_threshold_series(
         beta,
         min_threshold,
     )
-    nominal_prototype, removed_sizes, inserted_sizes = _build_order_stat_threshold_series_for_cell(
-        flat_ref,
-        idx.sample_indices_by_day_of_year,
-        idx.reference_index_year,
-        idx.reference_index_position,
-        idx.substitute_alignment,
-        -1,
-        -1,
-        0,
-        quantile,
-        alpha,
-        beta,
-        min_threshold,
+    nominal_prototype, removed_sizes, inserted_sizes = (
+        _build_order_stat_threshold_series_for_cell(
+            flat_ref,
+            idx.sample_indices_by_day_of_year,
+            idx.reference_index_year,
+            idx.reference_index_position,
+            idx.substitute_alignment,
+            -1,
+            -1,
+            0,
+            quantile,
+            alpha,
+            beta,
+            min_threshold,
+        )
     )
     nominal_diff = np.abs(nominal_current - nominal_prototype)
     nominal_changed = int(np.count_nonzero(nominal_diff > 1.0e-9))
     changed_doys += nominal_changed
     nominal_changed_doys += nominal_changed
-    max_abs_diff = max(max_abs_diff, float(np.nanmax(nominal_diff)) if nominal_diff.size else 0.0)
+    max_abs_diff = max(
+        max_abs_diff, float(np.nanmax(nominal_diff)) if nominal_diff.size else 0.0
+    )
     max_removed_values = max(max_removed_values, int(removed_sizes.max(initial=0)))
     max_inserted_values = max(max_inserted_values, int(inserted_sizes.max(initial=0)))
     removed_total += int(removed_sizes.sum())
@@ -406,27 +424,35 @@ def compare_order_stat_threshold_series(
                 beta,
                 min_threshold,
             )
-            prototype, removed_sizes, inserted_sizes = _build_order_stat_threshold_series_for_cell(
-                flat_ref,
-                idx.sample_indices_by_day_of_year,
-                idx.reference_index_year,
-                idx.reference_index_position,
-                idx.substitute_alignment,
-                target_ref_i,
-                substitute_i,
-                0,
-                quantile,
-                alpha,
-                beta,
-                min_threshold,
+            prototype, removed_sizes, inserted_sizes = (
+                _build_order_stat_threshold_series_for_cell(
+                    flat_ref,
+                    idx.sample_indices_by_day_of_year,
+                    idx.reference_index_year,
+                    idx.reference_index_position,
+                    idx.substitute_alignment,
+                    target_ref_i,
+                    substitute_i,
+                    0,
+                    quantile,
+                    alpha,
+                    beta,
+                    min_threshold,
+                )
             )
             diff = np.abs(current - prototype)
             overlap_changed = int(np.count_nonzero(diff > 1.0e-9))
             changed_doys += overlap_changed
             overlap_changed_doys += overlap_changed
-            max_abs_diff = max(max_abs_diff, float(np.nanmax(diff)) if diff.size else 0.0)
-            max_removed_values = max(max_removed_values, int(removed_sizes.max(initial=0)))
-            max_inserted_values = max(max_inserted_values, int(inserted_sizes.max(initial=0)))
+            max_abs_diff = max(
+                max_abs_diff, float(np.nanmax(diff)) if diff.size else 0.0
+            )
+            max_removed_values = max(
+                max_removed_values, int(removed_sizes.max(initial=0))
+            )
+            max_inserted_values = max(
+                max_inserted_values, int(inserted_sizes.max(initial=0))
+            )
             removed_total += int(removed_sizes.sum())
             inserted_total += int(inserted_sizes.sum())
             compared_series += 1
@@ -472,7 +498,9 @@ def main() -> None:
     for case_name in case_names:
         case_payload: dict[str, object] = {}
         for freq in frequencies:
-            case_payload[freq] = asdict(compare_order_stat_threshold_series(case_name, freq))
+            case_payload[freq] = asdict(
+                compare_order_stat_threshold_series(case_name, freq)
+            )
         payload["cases"][case_name] = case_payload
     print(json.dumps(payload, indent=2, sort_keys=True))
 

--- a/tools/prototype_cftime_exact_order_stat_quantile.py
+++ b/tools/prototype_cftime_exact_order_stat_quantile.py
@@ -1,3 +1,5 @@
+# ruff: noqa: ARG001, PLR2004, RUF046
+
 from __future__ import annotations
 
 import argparse

--- a/tools/prototype_cftime_exact_order_stat_quantile.py
+++ b/tools/prototype_cftime_exact_order_stat_quantile.py
@@ -1,0 +1,481 @@
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from contextlib import contextmanager
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+import cftime
+import numpy as np
+import xarray as xr
+
+NON_LEAP_DAY_COUNT = 365
+
+
+def _resolve_import_root(repo: Path) -> Path:
+    for candidate in (repo / "src", repo):
+        if (candidate / "icclim" / "__init__.py").is_file():
+            return candidate
+    msg = f"Could not locate icclim import root under {repo}"
+    raise FileNotFoundError(msg)
+
+
+def _build_time_coord() -> list[cftime.DatetimeGregorian]:
+    time = xr.date_range(
+        "2042-01-01",
+        periods=365 * 5 + 1,
+        freq="D",
+        use_cftime=True,
+    )
+    return [
+        cftime.DatetimeGregorian(int(ts.year), int(ts.month), int(ts.day))
+        for ts in time
+    ]
+
+
+def _build_case(case_name: str) -> xr.DataArray:
+    time = _build_time_coord()
+    data = np.full((len(time), 1, 1), 300.0, dtype=np.float64)
+    tas = xr.DataArray(
+        data,
+        dims=["time", "lat", "lon"],
+        coords={"time": time, "lat": [0.0], "lon": [0.0]},
+        attrs={"units": "K"},
+        name="tas",
+    )
+    if case_name == "constant":
+        return tas.chunk({"time": 365, "lat": 1, "lon": 1})
+    if case_name == "leap_day_cold_spike":
+        for timestamp in (
+            cftime.DatetimeGregorian(2044, 2, 28),
+            cftime.DatetimeGregorian(2044, 2, 29),
+            cftime.DatetimeGregorian(2044, 3, 1),
+        ):
+            tas.loc[{"time": timestamp}] = 250.0
+        return tas.chunk({"time": 365, "lat": 1, "lon": 1})
+    if case_name == "reference_overlap_shift":
+        tas.loc[{"time": cftime.DatetimeGregorian(2042, 2, 28)}] = 305.0
+        tas.loc[{"time": cftime.DatetimeGregorian(2043, 2, 28)}] = 295.0
+        tas.loc[{"time": cftime.DatetimeGregorian(2044, 2, 29)}] = 285.0
+        tas.loc[{"time": cftime.DatetimeGregorian(2045, 2, 28)}] = 310.0
+        tas.loc[{"time": cftime.DatetimeGregorian(2045, 3, 1)}] = 280.0
+        return tas.chunk({"time": 365, "lat": 1, "lon": 1})
+    msg = f"Unsupported case: {case_name}"
+    raise ValueError(msg)
+
+
+def _build_threshold():
+    from icclim.threshold.factory import build_threshold  # noqa: PLC0415
+
+    return build_threshold(
+        "> 90 doy_per",
+        doy_window_width=1,
+        reference_period=("2042-01-01", "2044-12-31"),
+    )
+
+
+@contextmanager
+def _force_compiled_cftime_count():
+    from icclim._core.generic import bootstrap as bootstrap_module  # noqa: PLC0415
+
+    original = bootstrap_module.is_optimized_doy_percentile_count_supported
+    bootstrap_module.is_optimized_doy_percentile_count_supported = lambda *_: True
+    try:
+        yield
+    finally:
+        bootstrap_module.is_optimized_doy_percentile_count_supported = original
+
+
+@dataclass(frozen=True)
+class ThresholdSeriesComparison:
+    changed_doys: int
+    max_abs_diff: float
+    nominal_changed_doys: int
+    overlap_changed_doys: int
+    max_removed_values: int
+    max_inserted_values: int
+    mean_removed_values: float
+    mean_inserted_values: float
+
+
+def _nominal_sorted_sample_for_cell(
+    flat_ref: np.ndarray,
+    sample_indices: np.ndarray,
+    doy_i: int,
+    cell: int,
+) -> np.ndarray:
+    values = []
+    for sample_i in range(sample_indices.shape[1]):
+        ref_i = sample_indices[doy_i, sample_i]
+        if ref_i < 0:
+            continue
+        value = flat_ref[ref_i, cell]
+        if not np.isnan(value):
+            values.append(float(value))
+    return np.asarray(sorted(values), dtype=np.float64)
+
+
+def _removed_values_for_target(
+    base_sorted: np.ndarray,
+    flat_ref: np.ndarray,
+    sample_indices: np.ndarray,
+    index_year: np.ndarray,
+    doy_i: int,
+    cell: int,
+    target_ref_i: int,
+) -> np.ndarray:
+    if target_ref_i < 0:
+        return np.empty(0, dtype=np.float64)
+    removed = []
+    for sample_i in range(sample_indices.shape[1]):
+        ref_i = sample_indices[doy_i, sample_i]
+        if ref_i < 0 or index_year[ref_i] != target_ref_i:
+            continue
+        value = flat_ref[ref_i, cell]
+        if not np.isnan(value):
+            removed.append(float(value))
+    if not removed:
+        return np.empty(0, dtype=np.float64)
+    return np.asarray(sorted(removed), dtype=np.float64)
+
+
+def _inserted_values_for_substitute(
+    flat_ref: np.ndarray,
+    sample_indices: np.ndarray,
+    index_year: np.ndarray,
+    index_pos: np.ndarray,
+    substitute_aligned: np.ndarray,
+    doy_i: int,
+    cell: int,
+    target_ref_i: int,
+    substitute_i: int,
+) -> np.ndarray:
+    if target_ref_i < 0 or substitute_i < 0:
+        return np.empty(0, dtype=np.float64)
+    inserted = []
+    for sample_i in range(sample_indices.shape[1]):
+        ref_i = sample_indices[doy_i, sample_i]
+        if ref_i < 0 or index_year[ref_i] != target_ref_i:
+            continue
+        mapped_i = substitute_aligned[target_ref_i, substitute_i, index_pos[ref_i]]
+        if mapped_i < 0:
+            continue
+        value = flat_ref[mapped_i, cell]
+        if not np.isnan(value):
+            inserted.append(float(value))
+    if not inserted:
+        return np.empty(0, dtype=np.float64)
+    return np.asarray(sorted(inserted), dtype=np.float64)
+
+
+def _skip_removed(
+    base_sorted: np.ndarray,
+    removed_sorted: np.ndarray,
+    base_i: int,
+    removed_i: int,
+) -> tuple[int, int]:
+    while (
+        base_i < len(base_sorted)
+        and removed_i < len(removed_sorted)
+        and base_sorted[base_i] == removed_sorted[removed_i]
+    ):
+        base_i += 1
+        removed_i += 1
+    return base_i, removed_i
+
+
+def _value_at_adjusted_rank(
+    base_sorted: np.ndarray,
+    removed_sorted: np.ndarray,
+    inserted_sorted: np.ndarray,
+    rank: int,
+) -> float:
+    base_i = 0
+    removed_i = 0
+    inserted_i = 0
+    current_rank = -1
+    while True:
+        base_i, removed_i = _skip_removed(base_sorted, removed_sorted, base_i, removed_i)
+        has_base = base_i < len(base_sorted)
+        has_inserted = inserted_i < len(inserted_sorted)
+        if not has_base and not has_inserted:
+            raise IndexError(rank)
+        if has_inserted and (not has_base or inserted_sorted[inserted_i] <= base_sorted[base_i]):
+            value = inserted_sorted[inserted_i]
+            inserted_i += 1
+        else:
+            value = base_sorted[base_i]
+            base_i += 1
+        current_rank += 1
+        if current_rank == rank:
+            return float(value)
+
+
+def _method8_quantile_from_adjusted_sorted(
+    base_sorted: np.ndarray,
+    removed_sorted: np.ndarray,
+    inserted_sorted: np.ndarray,
+    quantile: float,
+    alpha: float,
+    beta: float,
+) -> float:
+    n = len(base_sorted) - len(removed_sorted) + len(inserted_sorted)
+    if n == 0:
+        return float("nan")
+    if n == 1:
+        return _value_at_adjusted_rank(base_sorted, removed_sorted, inserted_sorted, 0)
+    virtual = n * quantile + (alpha + quantile * (1.0 - alpha - beta)) - 1.0
+    if virtual >= n - 1:
+        return _value_at_adjusted_rank(base_sorted, removed_sorted, inserted_sorted, n - 1)
+    if virtual < 0:
+        return _value_at_adjusted_rank(base_sorted, removed_sorted, inserted_sorted, 0)
+    previous = int(math.floor(virtual))
+    gamma = virtual - previous
+    left = _value_at_adjusted_rank(base_sorted, removed_sorted, inserted_sorted, previous)
+    right = _value_at_adjusted_rank(
+        base_sorted,
+        removed_sorted,
+        inserted_sorted,
+        previous + 1,
+    )
+    diff = right - left
+    if gamma >= 0.5:
+        return right - diff * (1.0 - gamma)
+    return left + diff * gamma
+
+
+def _build_order_stat_threshold_series_for_cell(
+    flat_ref: np.ndarray,
+    sample_indices: np.ndarray,
+    index_year: np.ndarray,
+    index_pos: np.ndarray,
+    substitute_aligned: np.ndarray,
+    target_ref_i: int,
+    substitute_i: int,
+    cell: int,
+    quantile: float,
+    alpha: float,
+    beta: float,
+    min_threshold: float,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    thresholds = np.empty(NON_LEAP_DAY_COUNT, dtype=np.float64)
+    removed_sizes = np.zeros(NON_LEAP_DAY_COUNT, dtype=np.int64)
+    inserted_sizes = np.zeros(NON_LEAP_DAY_COUNT, dtype=np.int64)
+    for doy_i in range(NON_LEAP_DAY_COUNT):
+        base_sorted = _nominal_sorted_sample_for_cell(flat_ref, sample_indices, doy_i, cell)
+        removed_sorted = _removed_values_for_target(
+            base_sorted,
+            flat_ref,
+            sample_indices,
+            index_year,
+            doy_i,
+            cell,
+            target_ref_i,
+        )
+        inserted_sorted = _inserted_values_for_substitute(
+            flat_ref,
+            sample_indices,
+            index_year,
+            index_pos,
+            substitute_aligned,
+            doy_i,
+            cell,
+            target_ref_i,
+            substitute_i,
+        )
+        removed_sizes[doy_i] = len(removed_sorted)
+        inserted_sizes[doy_i] = len(inserted_sorted)
+        threshold_value = _method8_quantile_from_adjusted_sorted(
+            base_sorted,
+            removed_sorted,
+            inserted_sorted,
+            quantile,
+            alpha,
+            beta,
+        )
+        if not np.isnan(min_threshold) and (
+            np.isnan(threshold_value) or threshold_value <= min_threshold
+        ):
+            threshold_value = min_threshold
+        thresholds[doy_i] = threshold_value
+    return thresholds, removed_sizes, inserted_sizes
+
+
+def compare_order_stat_threshold_series(
+    case_name: str,
+    freq: str,
+) -> ThresholdSeriesComparison:
+    from icclim._core.generic.bootstrap import (  # noqa: PLC0415
+        _build_bootstrap_threshold_series_for_cell,
+    )
+    from icclim._core.generic.bootstrap_primitives import (  # noqa: PLC0415
+        build_bootstrap_prepared_inputs,
+    )
+
+    tas = _build_case(case_name)
+    threshold = _build_threshold()
+    prepared = build_bootstrap_prepared_inputs(
+        tas,
+        threshold,
+        freq,
+        dtype=np.float64,
+    )
+    ref = prepared.reference_sample
+    idx = prepared.temporal_indexing
+    arr = prepared.array_inputs
+    min_threshold = (
+        np.nan
+        if ref.threshold_floor_in_reference_units is None
+        else float(ref.threshold_floor_in_reference_units)
+    )
+    quantile = float(threshold.percentile_coord().item()) / 100.0
+    alpha = float(threshold.interpolation.alpha)
+    beta = float(threshold.interpolation.beta)
+    build_thresholds = _build_bootstrap_threshold_series_for_cell.py_func
+    n_ref_years = idx.substitute_alignment.shape[1]
+    flat_ref = arr.flat_reference_filtered if not np.isnan(min_threshold) else arr.flat_reference_raw
+    changed_doys = 0
+    max_abs_diff = 0.0
+    nominal_changed_doys = 0
+    overlap_changed_doys = 0
+    max_removed_values = 0
+    max_inserted_values = 0
+    removed_total = 0
+    inserted_total = 0
+    compared_series = 0
+
+    nominal_current = build_thresholds(
+        flat_ref,
+        idx.sample_indices_by_day_of_year,
+        idx.reference_index_year,
+        idx.reference_index_position,
+        idx.substitute_alignment,
+        -1,
+        -1,
+        0,
+        idx.sample_indices_by_day_of_year.shape[1],
+        quantile,
+        alpha,
+        beta,
+        min_threshold,
+    )
+    nominal_prototype, removed_sizes, inserted_sizes = _build_order_stat_threshold_series_for_cell(
+        flat_ref,
+        idx.sample_indices_by_day_of_year,
+        idx.reference_index_year,
+        idx.reference_index_position,
+        idx.substitute_alignment,
+        -1,
+        -1,
+        0,
+        quantile,
+        alpha,
+        beta,
+        min_threshold,
+    )
+    nominal_diff = np.abs(nominal_current - nominal_prototype)
+    nominal_changed = int(np.count_nonzero(nominal_diff > 1.0e-9))
+    changed_doys += nominal_changed
+    nominal_changed_doys += nominal_changed
+    max_abs_diff = max(max_abs_diff, float(np.nanmax(nominal_diff)) if nominal_diff.size else 0.0)
+    max_removed_values = max(max_removed_values, int(removed_sizes.max(initial=0)))
+    max_inserted_values = max(max_inserted_values, int(inserted_sizes.max(initial=0)))
+    removed_total += int(removed_sizes.sum())
+    inserted_total += int(inserted_sizes.sum())
+    compared_series += 1
+
+    for target_ref_i in range(n_ref_years):
+        for substitute_i in range(n_ref_years):
+            if substitute_i == target_ref_i:
+                continue
+            current = build_thresholds(
+                flat_ref,
+                idx.sample_indices_by_day_of_year,
+                idx.reference_index_year,
+                idx.reference_index_position,
+                idx.substitute_alignment,
+                target_ref_i,
+                substitute_i,
+                0,
+                idx.sample_indices_by_day_of_year.shape[1],
+                quantile,
+                alpha,
+                beta,
+                min_threshold,
+            )
+            prototype, removed_sizes, inserted_sizes = _build_order_stat_threshold_series_for_cell(
+                flat_ref,
+                idx.sample_indices_by_day_of_year,
+                idx.reference_index_year,
+                idx.reference_index_position,
+                idx.substitute_alignment,
+                target_ref_i,
+                substitute_i,
+                0,
+                quantile,
+                alpha,
+                beta,
+                min_threshold,
+            )
+            diff = np.abs(current - prototype)
+            overlap_changed = int(np.count_nonzero(diff > 1.0e-9))
+            changed_doys += overlap_changed
+            overlap_changed_doys += overlap_changed
+            max_abs_diff = max(max_abs_diff, float(np.nanmax(diff)) if diff.size else 0.0)
+            max_removed_values = max(max_removed_values, int(removed_sizes.max(initial=0)))
+            max_inserted_values = max(max_inserted_values, int(inserted_sizes.max(initial=0)))
+            removed_total += int(removed_sizes.sum())
+            inserted_total += int(inserted_sizes.sum())
+            compared_series += 1
+
+    return ThresholdSeriesComparison(
+        changed_doys=changed_doys,
+        max_abs_diff=max_abs_diff,
+        nominal_changed_doys=nominal_changed_doys,
+        overlap_changed_doys=overlap_changed_doys,
+        max_removed_values=max_removed_values,
+        max_inserted_values=max_inserted_values,
+        mean_removed_values=removed_total / (NON_LEAP_DAY_COUNT * compared_series),
+        mean_inserted_values=inserted_total / (NON_LEAP_DAY_COUNT * compared_series),
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo", required=True)
+    parser.add_argument(
+        "--case",
+        choices=("constant", "leap_day_cold_spike", "reference_overlap_shift", "all"),
+        default="all",
+    )
+    parser.add_argument(
+        "--freq",
+        choices=("YS", "MS", "both"),
+        default="both",
+    )
+    args = parser.parse_args()
+
+    repo = Path(args.repo).resolve()
+    import_root = _resolve_import_root(repo)
+    sys.path.insert(0, str(import_root))
+
+    case_names = (
+        ("constant", "leap_day_cold_spike", "reference_overlap_shift")
+        if args.case == "all"
+        else (args.case,)
+    )
+    frequencies = ("YS", "MS") if args.freq == "both" else (args.freq,)
+    payload: dict[str, object] = {"repo": str(repo), "cases": {}}
+    for case_name in case_names:
+        case_payload: dict[str, object] = {}
+        for freq in frequencies:
+            case_payload[freq] = asdict(compare_order_stat_threshold_series(case_name, freq))
+        payload["cases"][case_name] = case_payload
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/run_real_data_validation.py
+++ b/tools/run_real_data_validation.py
@@ -9,6 +9,7 @@ import sys
 import time
 from pathlib import Path
 
+import cftime
 import numpy as np
 import xarray as xr
 
@@ -19,6 +20,8 @@ LAT_SLICE = slice(35.0, 70.0)
 LON_SLICE = slice(0.0, 40.0)
 DATE_EVENT_LAT_SLICE = slice(35.0, 55.0)
 DATE_EVENT_LON_SLICE = slice(0.0, 20.0)
+DRY_PR_LAT_SLICE = slice(35.0, 45.0)
+DRY_PR_LON_SLICE = slice(0.0, 30.0)
 BASE_PERIOD = ("1961-01-01", "1990-12-31")
 TIME_RANGE = ("1950-01-01", "2014-12-31")
 TASMAX_TIME_RANGE = ("1986-01-01", "1999-12-31")
@@ -93,6 +96,22 @@ def _warmup(icclim) -> None:
         ).load()
     except Exception:
         pass
+
+
+def _as_cftime_gregorian(da: xr.DataArray) -> xr.DataArray:
+    time_values = da.indexes["time"]
+    cftime_time = [
+        cftime.DatetimeGregorian(
+            int(ts.year),
+            int(ts.month),
+            int(ts.day),
+            int(getattr(ts, "hour", 0)),
+            int(getattr(ts, "minute", 0)),
+            int(getattr(ts, "second", 0)),
+        )
+        for ts in time_values
+    ]
+    return da.assign_coords(time=cftime_time)
 
 
 def _build_workload(icclim, workload: str) -> xr.Dataset:
@@ -419,6 +438,50 @@ def _build_workload(icclim, workload: str) -> xr.Dataset:
             time_range=TIME_RANGE,
             slice_mode="year",
         )
+    if workload == "generic_pr_average_bootstrap_monthly":
+        pr = _open_var(PR_GLOB, "pr")
+        return icclim.average(
+            in_files=pr,
+            var_name="pr",
+            threshold=icclim.build_threshold(
+                "> 95 doy_per",
+                threshold_min_value="1 mm/day",
+                reference_period=BASE_PERIOD,
+            ),
+            time_range=TIME_RANGE,
+            slice_mode="month",
+        )
+    if workload == "generic_pr_average_bootstrap_dry_yearly":
+        pr = _open_var(
+            PR_GLOB,
+            "pr",
+            lat_slice=DRY_PR_LAT_SLICE,
+            lon_slice=DRY_PR_LON_SLICE,
+        )
+        return icclim.average(
+            in_files=pr,
+            var_name="pr",
+            threshold=icclim.build_threshold(
+                "> 95 doy_per",
+                threshold_min_value="1 mm/day",
+                reference_period=BASE_PERIOD,
+            ),
+            time_range=TIME_RANGE,
+            slice_mode="year",
+        )
+    if workload == "generic_pr_average_bootstrap_99_yearly":
+        pr = _open_var(PR_GLOB, "pr")
+        return icclim.average(
+            in_files=pr,
+            var_name="pr",
+            threshold=icclim.build_threshold(
+                "> 99 doy_per",
+                threshold_min_value="1 mm/day",
+                reference_period=BASE_PERIOD,
+            ),
+            time_range=TIME_RANGE,
+            slice_mode="year",
+        )
     if workload == "generic_tas_fraction_bootstrap_yearly":
         tas = _open_var(TAS_GLOB, "tas")
         return icclim.fraction_of_total(
@@ -498,6 +561,26 @@ def _build_workload(icclim, workload: str) -> xr.Dataset:
             time_range=TIME_RANGE,
             slice_mode="MS",
             save_thresholds=True,
+        )
+    if workload == "tx90p_cftime_yearly":
+        tas = _as_cftime_gregorian(_open_var(TAS_GLOB, "tas"))
+        return icclim.index(
+            index_name="TX90p",
+            in_files=tas,
+            var_name="tas",
+            base_period_time_range=BASE_PERIOD,
+            time_range=TIME_RANGE,
+            slice_mode="year",
+        )
+    if workload == "tx90p_cftime_monthly":
+        tas = _as_cftime_gregorian(_open_var(TAS_GLOB, "tas"))
+        return icclim.index(
+            index_name="TX90p",
+            in_files=tas,
+            var_name="tas",
+            base_period_time_range=BASE_PERIOD,
+            time_range=TIME_RANGE,
+            slice_mode="month",
         )
     if workload == "combined_cd_yearly":
         # Compound logical-link indices currently exercise xarray boolean

--- a/tools/summarize_real_data_validation.py
+++ b/tools/summarize_real_data_validation.py
@@ -251,9 +251,7 @@ def _workload_notes(workload: str) -> str:
             "spell reducer; raw v7.1.7 differs from current and master"
         ),
         "wsdi_yearly": "standard warm-spell duration index",
-        "tx90p_cftime_yearly": (
-            "Gregorian-like cftime validation on real tas values"
-        ),
+        "tx90p_cftime_yearly": ("Gregorian-like cftime validation on real tas values"),
         "tx90p_cftime_monthly": (
             "Gregorian-like cftime monthly validation on real tas values"
         ),

--- a/tools/summarize_real_data_validation.py
+++ b/tools/summarize_real_data_validation.py
@@ -228,6 +228,16 @@ def _workload_notes(workload: str) -> str:
         "generic_pr_average_bootstrap_yearly": (
             "filtered value aggregate; wet-day style threshold_min_value"
         ),
+        "generic_pr_average_bootstrap_monthly": (
+            "filtered value aggregate monthly; wet-day style threshold_min_value"
+        ),
+        "generic_pr_average_bootstrap_dry_yearly": (
+            "filtered value aggregate on a drier regional subset; wet-day style"
+            " threshold_min_value"
+        ),
+        "generic_pr_average_bootstrap_99_yearly": (
+            "filtered value aggregate with a rarer 99th-percentile threshold"
+        ),
         "generic_tas_fraction_bootstrap_yearly": (
             "unfiltered value aggregate; optimized fraction_of_total candidate"
         ),
@@ -241,6 +251,12 @@ def _workload_notes(workload: str) -> str:
             "spell reducer; raw v7.1.7 differs from current and master"
         ),
         "wsdi_yearly": "standard warm-spell duration index",
+        "tx90p_cftime_yearly": (
+            "Gregorian-like cftime validation on real tas values"
+        ),
+        "tx90p_cftime_monthly": (
+            "Gregorian-like cftime monthly validation on real tas values"
+        ),
         "generic_tas_count_date_event_monthly": "date_event count control path",
         "combined_cd_yearly": (
             "compound tas+pr count; combines specialized leaf masks through"


### PR DESCRIPTION
## Summary
- integrate the compiled exact cftime bootstrap-count route for day-of-year percentile counts
- fix leap-year exactness for non-reference years by reusing prepared 366-day thresholds directly
- keep reusable Kraken validation runners and archive the redesign validation trail

## What changed
- route cftime percentile-count bootstrap through the compiled count path
- add the leap-year nominal-threshold branch that preserves exact public-threshold semantics
- update cftime routing and regression tests
- keep the cftime redesign notes and Kraken validation helpers used to validate the final route

## Validation
- local `.venv-icclim-705`
  - `tests/test_bootstrap_capability.py`: 18 passed
  - focused `tests/test_bootstrap_primitives.py`: 14 passed
  - focused `tests/test_main.py`: 1 passed
- Kraken focused pytest
  - 17 passed
- Kraken real-data TX90p cftime exact comparison versus safe path
  - monthly: changed_cells = 0, max_abs_diff = 7.1e-15
  - yearly: changed_cells = 0, max_abs_diff = 8.5e-14
- Kraken timing on Sunday, August 23, 2026
  - optimized monthly: 1025.19 s
  - safe monthly: 2242.53 s
  - optimized yearly: 1035.75 s
  - safe yearly: 2102.11 s

## Notes
- this PR keeps structured archive/provenance material under `doc/source/archive/` and reusable validation tooling under `tools/`
- disposable debug scripts were removed earlier and are not part of this branch
