### PR TITLE
Prepare 7.1.8 release

### DIFF
--- a/doc/source/references/release_notes.rst
+++ b/doc/source/references/release_notes.rst
@@ -3,6 +3,17 @@
 #################
 
 ******
+7.1.8
+******
+
+date: 2026-08-23
+
+
+-  [enh] Restore the optimized exact bootstrap route for ``cftime`` day-of-year percentile count indices after integrating the compiled order-stat count path into the public routing.
+-  [fix] Preserve exact leap-year behavior for non-reference ``cftime`` study years by reusing the prepared 366-day nominal threshold field where needed.
+-  [doc] Add real-data Kraken validation and exact-count redesign archive notes for the ``cftime`` bootstrap workflow.
+
+******
 7.1.7
 ******
 

--- a/src/icclim/__init__.py
+++ b/src/icclim/__init__.py
@@ -23,7 +23,7 @@ __all__ = [
     "indices",  # noqa: F405
 ]
 
-__version__ = "7.1.7"
+__version__ = "7.1.8"
 
 
 def __getattr__(name: str) -> Callable:


### PR DESCRIPTION
## Summary
- bump icclim version to 7.1.8
- add release notes for the exact cftime bootstrap count redesign merged in #456
- keep the release delta minimal so the published package matches merged master

## Validation
- release metadata update only
- merged feature PR #456 is already green and merged on master
