### PR TITLE
Pin flit below 4 in CI and release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           python-version: '3.11'
       - name: Install build tools
-        run: pip install --upgrade pip flit
+        run: pip install --upgrade pip "flit<4"
       - name: Install icclim and dev requirements (dev, test and doc)
         run: flit install --deps develop
       - name: call fun extractor
@@ -70,7 +70,7 @@ jobs:
         with:
           python-version: '3.11'
       - name: Install build tools
-        run: pip install --upgrade pip flit
+        run: pip install --upgrade pip "flit<4"
       - name: Install icclim and dev requirements (dev, test and doc)
         run: flit install --deps develop
       - name: Build coverage file
@@ -127,7 +127,7 @@ jobs:
         with:
           python-version: '3.11'
       - name: Install build tools
-        run: pip install --upgrade pip flit
+        run: pip install --upgrade pip "flit<4"
       - name: Install icclim and dev requirements (dev, test and doc)
         run: flit install --deps develop
       - name: Generate logos

--- a/.github/workflows/publish-to-pipy.yml
+++ b/.github/workflows/publish-to-pipy.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           python-version: 3.11
       - name: Install tools
-        run: python -m pip install --upgrade pip flit
+        run: python -m pip install --upgrade pip "flit<4"
       - name: Install icclim for prod
         run: python -m flit install --deps production
       - name: build package


### PR DESCRIPTION
## Summary
- pin workflow-installed flit to a 3.x release
- avoid emitting the unsupported Import-Name metadata in the PyPI publish job
- keep the fix limited to CI and release tooling

## Why
The v7.1.8 publish workflow failed on August 23, 2026 because the wheel metadata contained an  field that the publish path rejected.
