### PR TITLE
Prepare 7.1.9 release

### DIFF
--- a/doc/source/references/release_notes.rst
+++ b/doc/source/references/release_notes.rst
@@ -3,6 +3,18 @@
 #################
 
 ******
+7.1.9
+******
+
+date: 2026-08-23
+
+
+-  [fix] Pin workflow-installed ``flit`` to a 3.x release so PyPI publish jobs do not emit the unsupported ``Import-Name`` metadata field.
+-  [enh] Restore the optimized exact bootstrap route for ``cftime`` day-of-year percentile count indices after integrating the compiled order-stat count path into the public routing.
+-  [fix] Preserve exact leap-year behavior for non-reference ``cftime`` study years by reusing the prepared 366-day nominal threshold field where needed.
+-  [doc] Add real-data Kraken validation and exact-count redesign archive notes for the ``cftime`` bootstrap workflow.
+
+******
 7.1.8
 ******
 

--- a/src/icclim/__init__.py
+++ b/src/icclim/__init__.py
@@ -23,7 +23,7 @@ __all__ = [
     "indices",  # noqa: F405
 ]
 
-__version__ = "7.1.8"
+__version__ = "7.1.9"
 
 
 def __getattr__(name: str) -> Callable:


### PR DESCRIPTION
Summary: bump icclim to 7.1.9 and add release notes for the cftime exact bootstrap redesign plus the flit workflow compatibility fix needed after the failed v7.1.8 publish on Sunday, August 23, 2026.