### PR TITLE
Pin flit and flit_core to 3.12.0 in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           python-version: '3.11'
       - name: Install build tools
-        run: pip install --upgrade pip "flit<4"
+        run: pip install --upgrade pip "flit==3.12.0" "flit_core==3.12.0"
       - name: Install icclim and dev requirements (dev, test and doc)
         run: flit install --deps develop
       - name: call fun extractor
@@ -70,7 +70,7 @@ jobs:
         with:
           python-version: '3.11'
       - name: Install build tools
-        run: pip install --upgrade pip "flit<4"
+        run: pip install --upgrade pip "flit==3.12.0" "flit_core==3.12.0"
       - name: Install icclim and dev requirements (dev, test and doc)
         run: flit install --deps develop
       - name: Build coverage file
@@ -127,7 +127,7 @@ jobs:
         with:
           python-version: '3.11'
       - name: Install build tools
-        run: pip install --upgrade pip "flit<4"
+        run: pip install --upgrade pip "flit==3.12.0" "flit_core==3.12.0"
       - name: Install icclim and dev requirements (dev, test and doc)
         run: flit install --deps develop
       - name: Generate logos

--- a/.github/workflows/publish-to-pipy.yml
+++ b/.github/workflows/publish-to-pipy.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           python-version: 3.11
       - name: Install tools
-        run: python -m pip install --upgrade pip "flit<4"
+        run: python -m pip install --upgrade pip "flit==3.12.0" "flit_core==3.12.0"
       - name: Install icclim for prod
         run: python -m flit install --deps production
       - name: build package


### PR DESCRIPTION
Summary: pin workflow-installed flit and flit_core to the same 3.12.0 release. This fixes the v7.1.9 publish failure on Sunday, August 23, 2026, where loose 3.x pinning led to a flit CLI/core mismatch during python -m flit build.