### PR TITLE
Remove invalid workflows permission from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  workflows: write
 
 jobs:
   # lint is handled by pre-commit ci conf


### PR DESCRIPTION
Summary: remove the invalid `workflows: write` entry added in #464. GitHub Actions permissions do not accept a `workflows` key, and that single line is what broke the master workflow on Sunday, August 23, 2026.